### PR TITLE
ci(setup): let pnpm use pkg.json version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,8 +5,6 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
-      with:
-        version: 8
     - name: Setup Node.js
       uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
       with:


### PR DESCRIPTION
Tried to set cache the `setup-pnpm` action way in README.md but that's outdated. You can let the `setup-node` action do it for you. Docs should note that. Just took note to contribute if have some time.

Eventually, just letting `pnpm` use version from `packageManager` of `package.json`. This way, the version is only there and managed by dependencies update bot