### PR TITLE
refactor: generate dist in project dir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
     with:
-      artifact-name: build
+      artifact-name: ngx-meta
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [build, test, lint]
     uses: ./.github/workflows/reusable-release.yml
     with:
-      build-artifact-name: build
+      build-artifact-name: ngx-meta
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
       github-token-pr: ${{ secrets.PR_GH_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
     with:
-      artifact-name: build
+      artifact-name: ngx-meta
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -23,4 +23,4 @@ jobs:
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
-      build-artifact-name: build
+      build-artifact-name: ngx-meta

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ''
       artifact-name:
-        description: Artifact name containing `dist/` files
+        description: Artifact name containing built lib
         type: string
         required: false
 
@@ -40,5 +40,5 @@ jobs:
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: ${{ inputs.artifact-name }}
-          path: 'dist'
+          path: 'projects/ngx-meta/dist'
           retention-days: 5

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: ${{ inputs.build-artifact-name }}
-          path: 'dist'
+          path: 'projects/ngx-meta/dist'
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
       - name: Setup Node.js

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: ${{ inputs.build-artifact-name }}
-          path: 'dist'
+          path: 'projects/ngx-meta/dist'
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -14,9 +14,13 @@ module.exports = {
     [
       '@semantic-release/npm',
       //👇 Publish built version
-      { pkgRoot: './dist/ngx-meta', tarballDir: 'dist', npmPublish: false },
+      {
+        pkgRoot: './projects/ngx-meta/dist',
+        tarballDir: './projects/ngx-meta/dist',
+        npmPublish: false,
+      },
     ],
-    ['@semantic-release/github', { assets: 'dist/*.tgz' }],
+    ['@semantic-release/github', { assets: './projects/ngx-meta/dist/*.tgz' }],
     [
       '@semantic-release/changelog',
       {

--- a/projects/ngx-meta/e2e/a17/package.json
+++ b/projects/ngx-meta/e2e/a17/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "17.0.4",
     "@angular/platform-browser-dynamic": "17.0.4",
     "@angular/router": "17.0.4",
-    "@davidlj95/ngx-meta": "link:../../../../dist/ngx-meta",
+    "@davidlj95/ngx-meta": "link:../../dist",
     "rxjs": "7.8.1",
     "tslib": "2.6.2",
     "zone.js": "0.14.2"

--- a/projects/ngx-meta/e2e/a17/pnpm-lock.yaml
+++ b/projects/ngx-meta/e2e/a17/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: 17.0.4
     version: 17.0.4(@angular/common@17.0.4)(@angular/core@17.0.4)(@angular/platform-browser@17.0.4)(rxjs@7.8.1)
   '@davidlj95/ngx-meta':
-    specifier: link:../../../../dist/ngx-meta
-    version: link:../../../../dist/ngx-meta
+    specifier: link:../../dist
+    version: link:../../dist
   rxjs:
     specifier: 7.8.1
     version: 7.8.1

--- a/projects/ngx-meta/src/README.md
+++ b/projects/ngx-meta/src/README.md
@@ -14,7 +14,7 @@ Run `ng build ngx-meta` to build the project. The build artifacts will be stored
 
 ## Publishing
 
-After building your library with `ng build ngx-meta`, go to the dist folder `cd dist/ngx-meta` and run `npm publish`.
+After building your library with `ng build ngx-meta`, go to the dist folder `cd ../dist/ngx-meta` and run `npm publish`.
 
 ## Running unit tests
 

--- a/projects/ngx-meta/src/ng-package.json
+++ b/projects/ngx-meta/src/ng-package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../../dist/ngx-meta",
+  "dest": "../dist",
   "lib": {
     "entryFile": "public-api.ts"
   }


### PR DESCRIPTION
So that `ngx-meta` project is more isolated. Otherwise the global `dist/` directory may conflict with other packages when added.
