### PR TITLE
fix: move general md appliers to providers

### DIFF
--- a/projects/ngx-meta/e2e/a17/src/app/app.config.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/app.config.ts
@@ -1,13 +1,8 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core'
+import { ApplicationConfig } from '@angular/core'
 import { provideRouter } from '@angular/router'
 
 import { routes } from './app.routes'
-import { NgxMetaCommonModule } from '@davidlj95/ngx-meta/common'
-import { NgxMetaGeneralModule } from '@davidlj95/ngx-meta/general-metadata'
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes),
-    importProvidersFrom(NgxMetaCommonModule, NgxMetaGeneralModule.forRoot()),
-  ],
+  providers: [provideRouter(routes)],
 }

--- a/projects/ngx-meta/e2e/a17/src/app/meta-set-by-services/meta-set-by-services.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-set-by-services/meta-set-by-services.component.ts
@@ -1,16 +1,22 @@
 import { Component, OnInit } from '@angular/core'
-import { GeneralMetadataService } from '@davidlj95/ngx-meta/general-metadata'
+import {
+  GeneralMetadataService,
+  NgxMetaGeneralModule,
+} from '@davidlj95/ngx-meta/general-metadata'
 import generalMetaSetByService from '../../../../cypress/fixtures/general-meta-set-by-service.json'
 import { JsonPipe } from '@angular/common'
+import { NgxMetaCommonModule } from '@davidlj95/ngx-meta/common'
 
 @Component({
   selector: 'app-meta-set-by-services',
   standalone: true,
   templateUrl: './meta-set-by-services.component.html',
   styleUrl: './meta-set-by-services.component.css',
-  imports: [JsonPipe],
+  imports: [JsonPipe, NgxMetaCommonModule, NgxMetaGeneralModule],
 })
 export class MetaSetByServicesComponent implements OnInit {
+  protected readonly generalMetaSetByService = generalMetaSetByService
+
   constructor(
     private readonly generalMetadataService: GeneralMetadataService,
   ) {}
@@ -18,6 +24,4 @@ export class MetaSetByServicesComponent implements OnInit {
   ngOnInit(): void {
     this.generalMetadataService.apply(generalMetaSetByService)
   }
-
-  protected readonly generalMetaSetByService = generalMetaSetByService
 }

--- a/projects/ngx-meta/src/general-metadata/src/general-metadata.module.ts
+++ b/projects/ngx-meta/src/general-metadata/src/general-metadata.module.ts
@@ -22,6 +22,7 @@ const [FOR_ROOT_GUARD_TOKEN, FOR_ROOT_GUARD_PROVIDER] = _makeForRootGuard(
   providers: [
     GeneralMetadataService,
     GeneralMetadataApplierService,
+    GeneralMetadataAppliersService,
     GeneralMetadataRouteDataService,
     LinkRelCanonicalService,
     HtmlLangAttributeService,
@@ -38,7 +39,6 @@ export class GeneralMetadataModule {
       ngModule: GeneralMetadataModule,
       providers: [
         FOR_ROOT_GUARD_PROVIDER,
-        GeneralMetadataAppliersService,
         {
           provide: GENERAL_METADATA_DEFAULTS_TOKEN,
           useValue: defaults,


### PR DESCRIPTION
Otherwise, you can't import the module in a standalone Angular component and set metadata

The trade-off is that if included multiple times, multiple change emissions will be done. But that isn't kind of a problem given each change application is idempotent.

To ensure it works, changes the E2E app to import the module in standalone component
