### PR TITLE
build: improve a17 e2e app dx

### DIFF
--- a/.idea/runConfigurations/ngx_meta_e2e__A17_build.xml
+++ b/.idea/runConfigurations/ngx_meta_e2e__A17_build.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ngx-meta/e2e: A17 build" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/projects/ngx-meta/e2e/a17/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="build" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/projects/ngx-meta/e2e/a17/tsconfig.json
+++ b/projects/ngx-meta/e2e/a17/tsconfig.json
@@ -18,7 +18,15 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"]
+    "lib": ["ES2022", "dom"],
+    "paths": {
+      // 👇 Only needed to avoid IDE getting confused given lib is installed
+      //    from local path and not from NPM.
+      //    Seems it doesn't follow symlinks 🤷
+      //    You don't need this in a regular app where lib is installed from
+      //    NPM registry
+      "@davidlj95/ngx-meta/*": ["../../dist/*"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/projects/ngx-meta/e2e/a17/tsconfig.json
+++ b/projects/ngx-meta/e2e/a17/tsconfig.json
@@ -18,15 +18,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"],
-    "paths": {
-      // 👇 Only needed to avoid IDE getting confused given lib is installed
-      //    from local path and not from NPM.
-      //    Seems it doesn't follow symlinks 🤷
-      //    You don't need this in a regular app where lib is installed from
-      //    NPM registry
-      "@davidlj95/ngx-meta/*": ["../../dist/*"]
-    }
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
~Seems IDE got confused following symlinks, adding `paths` so it can follow Typescript imports.~

Seems doesn't work in GitHub Actions then: https://github.com/davidlj95/ngx/actions/runs/7026484520/job/19119311950?pr=42

Reverting back. Restarting WebStorm IDE helps when gets lost. Closing / opening the project.

So just adding run config to build A17 E2E app
