### PR TITLE
fix: open graph listener as provider + root guards

### DIFF
--- a/projects/ngx-meta/src/common/src/make-for-root-guard.ts
+++ b/projects/ngx-meta/src/common/src/make-for-root-guard.ts
@@ -39,6 +39,9 @@ export const makeForRootGuard = (
   const injectionToken = new InjectionToken<void>(
     `${moduleName} forRoot() guard`,
   )
+  if (depsToGuard.length === 0) {
+    depsToGuard.push(injectionToken)
+  }
   const provider: FactoryProvider = {
     provide: injectionToken,
     useFactory: (...depsToGuard: unknown[]) => {

--- a/projects/ngx-meta/src/general-metadata/src/general-metadata.module.ts
+++ b/projects/ngx-meta/src/general-metadata/src/general-metadata.module.ts
@@ -13,10 +13,8 @@ import { LinkRelCanonicalService } from './link-rel-canonical/link-rel-canonical
 import { _MetadataRouteStrategy } from '@davidlj95/ngx-meta/routing'
 import { _makeForRootGuard } from '@davidlj95/ngx-meta/common'
 
-const [FOR_ROOT_GUARD_TOKEN, FOR_ROOT_GUARD_PROVIDER] = _makeForRootGuard(
-  'GeneralMetadata',
-  GeneralMetadataAppliersService,
-)
+const [FOR_ROOT_GUARD_TOKEN, FOR_ROOT_GUARD_PROVIDER] =
+  _makeForRootGuard('GeneralMetadata')
 
 @NgModule({
   providers: [

--- a/projects/ngx-meta/src/open-graph/src/open-graph.module.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph.module.ts
@@ -11,16 +11,15 @@ import { OPEN_GRAPH_DEFAULTS_TOKEN } from './open-graph-defaults-token'
 import { _MetadataRouteStrategy } from '@davidlj95/ngx-meta/routing'
 import { _makeForRootGuard } from '@davidlj95/ngx-meta/common'
 
-const [FOR_ROOT_GUARD_TOKEN, FOR_ROOT_GUARD_PROVIDER] = _makeForRootGuard(
-  'OpenGraphModule',
-  OpenGraphGeneralMetadataListenerService,
-)
+const [FOR_ROOT_GUARD_TOKEN, FOR_ROOT_GUARD_PROVIDER] =
+  _makeForRootGuard('OpenGraphModule')
 
 @NgModule({
   providers: [
     OpenGraphService,
     OpenGraphApplierService,
     OpenGraphAppliersService,
+    OpenGraphGeneralMetadataListenerService,
   ],
 })
 export class OpenGraphModule {
@@ -38,7 +37,6 @@ export class OpenGraphModule {
     return {
       ngModule: OpenGraphModule,
       providers: [
-        OpenGraphGeneralMetadataListenerService,
         {
           provide: OPEN_GRAPH_DEFAULTS_TOKEN,
           useValue: defaults,


### PR DESCRIPTION
Same as #41 to use Open Graph without `forRoot`
