### PR TITLE
perf: use ngDevMode instead of isDevMode

### DIFF
--- a/projects/ngx-meta/src/routing/src/router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/router-listener.service.ts
@@ -1,10 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  isDevMode,
-  OnDestroy,
-  Optional,
-} from '@angular/core'
+import { Inject, Injectable, OnDestroy, Optional } from '@angular/core'
 import { ActivatedRoute, EventType, Router } from '@angular/router'
 import { filter, Subscription } from 'rxjs'
 import { MetadataRouteStrategy } from './metadata-route-strategy'
@@ -26,11 +20,11 @@ export class RouterListenerService implements OnDestroy {
   ) {}
 
   public listen() {
-    if (this.subscription) {
-      if (isDevMode()) {
+    if (this.isListening) {
+      if (ngDevMode) {
         console.warn(
-          'NgxMeta router listener was listened twice. ' +
-            'Ensure the NgxMetaRoutingModule is not imported twice',
+          'NgxMetaRoutingModule was set to listen for route changes ' +
+            'twice. Ensure the NgxMetaRoutingModule is not imported twice',
         )
       }
       return
@@ -41,12 +35,12 @@ export class RouterListenerService implements OnDestroy {
       .subscribe({
         next: () => {
           if (!this.metadataRouteStrategies) {
-            if (isDevMode()) {
+            if (ngDevMode) {
               console.warn(
-                'NgxMeta router tried to set metadata for this route, ' +
-                  'but no metadata route strategies were found. ' +
-                  'Provide one MetadataRouteStrategy to resolves metadata ' +
-                  'from a route to fix this.',
+                '`NgxMetaRoutingModule` tried to set metadata for this ' +
+                  'route but no metadata route strategies were found. ' +
+                  'Provide at least one `MetadataRouteStrategy` to resolve ' +
+                  'and apply metadata from a route to fix this.',
               )
             }
             return
@@ -60,6 +54,10 @@ export class RouterListenerService implements OnDestroy {
           }
         },
       })
+  }
+
+  public get isListening(): boolean {
+    return !!this.subscription
   }
 
   ngOnDestroy(): void {

--- a/projects/ngx-meta/src/tsconfig.lib.json
+++ b/projects/ngx-meta/src/tsconfig.lib.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "typeRoots": ["./types"],
+    "types": ["angular"]
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.spec.ts", "**/__tests__/*.ts"]

--- a/projects/ngx-meta/src/types/angular.d.ts
+++ b/projects/ngx-meta/src/types/angular.d.ts
@@ -1,0 +1,19 @@
+// https://stackoverflow.com/a/59499895/3263250
+export {}
+
+// https://github.com/angular/angular/blob/17.0.7/packages/core/src/util/ng_dev_mode.ts#L26
+declare global {
+  /**
+   * Used to know if we're in dev mode, in the same fashion Angular does
+   *
+   * Public API `isDevMode` (https://angular.io/api/core/isDevMode) is more
+   * stable. However, given it's a function call, code under `if(isDevMode())`
+   * can not tree-shaken. So to allow tree-shaking, using a `const` in the
+   * same fashion Angular does for their packages. Simplifying the type to be
+   * just an object, to avoid
+   *
+   * For instance:
+   * https://github.com/angular/angular/blob/17.0.7/packages/router/src/router_module.ts#L38-L39
+   */
+  const ngDevMode: null | undefined | object
+}


### PR DESCRIPTION
After inspecting the generated bundle code when using the library in an app, seems that the helper messages intended only for dev mode were getting in the production bundle. 

In order to save some bytes, using `ngDevMode` const instead of `isDevMode` so that helper messages are kept only in development bundle, not in production bundle. 

This comes at the cost of maintaining the `ngDevMode` private Angular API in sync with `@angular/core`. 

The worst that can happen is that at some point it's no longer used, but that would mean that no helpful messages appear on development. So it's worth the risk. From time to time we should check that const is there.

## Other changes
- Introduce `isListening` in `RouterListenerService` for a feature was baking at same time (#74 )
- Remove `listen` describe in tests. Better review hiding whitespaces, lots of whitespaces changed.
