### PR TITLE
refactor: decouple value resolve from defaults service

### DIFF
--- a/projects/ngx-meta/src/core/src/defaults.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/defaults.service.spec.ts
@@ -7,64 +7,38 @@ import { Provider } from '@angular/core'
 import { MetadataValueFromValues } from './metadata-value-from-values'
 import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
 import { MetadataValues } from './metadata-values'
-import { makeGlobalMetadataDefinition } from './__tests__/make-global-metadata-definition'
 
 describe('DefaultsService', () => {
   enableAutoSpy()
 
   describe('get', () => {
-    const dummyDefinition = makeGlobalMetadataDefinition()
-
     describe('when no defaults available', () => {
       describe('like when defaults not injected', () => {
-        it('should return undefined', () => {
+        it('should return empty object', () => {
           const sut = makeSut()
 
-          expect(sut.get(dummyDefinition)).toBeUndefined()
-        })
-      })
-
-      describe('like when empty defaults', () => {
-        const defaults = {}
-
-        it('should return undefined', () => {
-          const sut = makeSut({ defaults })
-
-          expect(sut.get(dummyDefinition)).toBeUndefined()
+          expect(sut.get()).toEqual({})
         })
       })
 
       describe('like when non defined defaults', () => {
         const defaults = undefined
 
-        it('should return undefined', () => {
+        it('should return empty object', () => {
           const sut = makeSut({ defaults })
 
-          expect(sut.get(dummyDefinition)).toBeUndefined()
+          expect(sut.get()).toEqual({})
         })
       })
     })
 
     describe('when defaults available', () => {
       const defaults = { foo: 'bar' }
-      let sut: DefaultsService
 
-      beforeEach(() => {
-        sut = makeSut({ defaults })
-      })
+      it('should return default values', () => {
+        const sut = makeSut({ defaults })
 
-      it('should return default value using collaborator', () => {
-        const value = 'value'
-        const valueFromValues = TestBed.inject(
-          MetadataValueFromValues,
-        ) as jasmine.SpyObj<MetadataValueFromValues>
-        valueFromValues.get.and.returnValue(value)
-
-        expect(sut.get(dummyDefinition)).toEqual(value)
-        expect(valueFromValues.get).toHaveBeenCalledOnceWith(
-          dummyDefinition,
-          defaults,
-        )
+        expect(sut.get()).toEqual(defaults)
       })
     })
   })

--- a/projects/ngx-meta/src/core/src/defaults.service.ts
+++ b/projects/ngx-meta/src/core/src/defaults.service.ts
@@ -1,7 +1,5 @@
 import { Inject, Injectable, Optional } from '@angular/core'
-import { MetadataValueFromValues } from './metadata-value-from-values'
 import { DEFAULTS_TOKEN } from './defaults-token'
-import { MetadataDefinition } from './metadata-definition'
 import { MetadataValues } from './metadata-values'
 
 @Injectable({ providedIn: 'root' })
@@ -10,19 +8,9 @@ export class DefaultsService {
     @Optional()
     @Inject(DEFAULTS_TOKEN)
     private readonly defaults: MetadataValues | null,
-    private readonly valueFromValues: MetadataValueFromValues,
   ) {}
 
-  get<T>(definition: MetadataDefinition): T | undefined {
-    if (!this.defaults) {
-      return
-    }
-    const globalDefaultValue = definition.global
-      ? this.defaults[definition.global]
-      : undefined
-    const defaultValue = this.valueFromValues.get(definition, this.defaults)
-    const effectiveValue =
-      defaultValue !== undefined ? defaultValue : globalDefaultValue
-    return effectiveValue !== undefined ? (effectiveValue as T) : undefined
+  get(): MetadataValues {
+    return this.defaults ?? {}
   }
 }

--- a/projects/ngx-meta/src/core/src/metadata-setter.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-setter.spec.ts
@@ -40,7 +40,7 @@ describe('MetadataSetter', () => {
       value: 'value',
       prop: 'value',
     }
-    const defaultValue = 'defaultValue'
+    const defaultValues = { default: 'values' }
     const routeValues = { route: 'values' }
 
     describe('when value exists for the metadata', () => {
@@ -84,31 +84,28 @@ describe('MetadataSetter', () => {
       })
     })
 
-    describe('when default exists', () => {
+    describe('when defaults exist', () => {
       beforeEach(() => {
-        defaultsService.get.and.returnValue(value)
-      })
-
-      it('should call setter with default value', () => {
-        sut.set(dummyMetadata, dummyValues)
-
-        expect(dummyMetadata.set).toHaveBeenCalledOnceWith(value)
-        expect(defaultsService.get).toHaveBeenCalledOnceWith(
-          dummyMetadata.definition,
+        defaultsService.get.and.returnValue(defaultValues)
+        valueFromValues.get.and.callFake(
+          <T>(def: MetadataDefinition, values: MetadataValues) => {
+            if (values !== defaultValues) {
+              return undefined
+            }
+            return value as T
+          },
         )
       })
-    })
 
-    describe('when value and default value exist', () => {
-      beforeEach(() => {
-        defaultsService.get.and.returnValue(defaultValue)
-        valueFromValues.get.and.returnValue(value)
-      })
-
-      it('should call setter with value', () => {
+      it('should call setter with value obtained from there', () => {
         sut.set(dummyMetadata, dummyValues)
 
         expect(dummyMetadata.set).toHaveBeenCalledOnceWith(value)
+        expect(defaultsService.get).toHaveBeenCalledOnceWith()
+        expect(valueFromValues.get).toHaveBeenCalledWith(
+          dummyMetadata.definition,
+          defaultValues,
+        )
       })
     })
 
@@ -172,20 +169,7 @@ describe('MetadataSetter', () => {
       })
     })
 
-    describe('when value is null and default exists', () => {
-      beforeEach(() => {
-        valueFromValues.get.and.returnValue(null)
-        defaultsService.get.and.returnValue(defaultValue)
-      })
-
-      it('should call setter with null', () => {
-        sut.set(dummyMetadata, dummyValues)
-
-        expect(dummyMetadata.set).toHaveBeenCalledOnceWith(null)
-      })
-    })
-
-    describe('when neither value or default value exists', () => {
+    describe('when neither value, route value or default value exists', () => {
       it('should call setter with undefined', () => {
         sut.set(dummyMetadata, dummyValues)
 

--- a/projects/ngx-meta/src/core/src/metadata-setter.ts
+++ b/projects/ngx-meta/src/core/src/metadata-setter.ts
@@ -20,7 +20,10 @@ export class MetadataSetter {
       metadata.definition,
       this.routeMetadataValues.get(),
     )
-    const defaultValue = this.defaultsService.get(metadata.definition)
+    const defaultValue = this.valueFromValues.get(
+      metadata.definition,
+      this.defaultsService.get(),
+    )
     const effectiveValue =
       isObject(value) && (isObject(routeValue) || isObject(defaultValue))
         ? { ...(defaultValue as object), ...(routeValue as object), ...value }


### PR DESCRIPTION
To enforce the SRP on defaults service. Same way that route metadata values operates.
