### PR TITLE
refactor: setter into resolver

### DIFF
--- a/projects/ngx-meta/src/core/src/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.ts
@@ -1,33 +1,38 @@
 import { Injectable } from '@angular/core'
-import { Metadata } from './metadata'
 import { DefaultsService } from './defaults.service'
 import { MetadataValueFromValues } from './metadata-value-from-values'
 import { MetadataValues } from './metadata-values'
 import { RouteMetadataValues } from './route-metadata-values'
 import { isObject } from './is-object'
+import { MetadataDefinition } from './metadata-definition'
+import { MaybeUndefined } from './maybe-undefined'
 
 @Injectable({ providedIn: 'root' })
-export class MetadataSetter {
+export class MetadataResolver {
   constructor(
     private readonly valueFromValues: MetadataValueFromValues,
     private readonly routeMetadataValues: RouteMetadataValues,
     private readonly defaultsService: DefaultsService,
   ) {}
 
-  set(metadata: Metadata<unknown>, values: MetadataValues): void {
-    const value = this.valueFromValues.get(metadata.definition, values)
+  get<T>(
+    metadataDefinition: MetadataDefinition,
+    values: MetadataValues,
+  ): T | undefined {
+    const value = this.valueFromValues.get(metadataDefinition, values)
     const routeValue = this.valueFromValues.get(
-      metadata.definition,
+      metadataDefinition,
       this.routeMetadataValues.get(),
     )
     const defaultValue = this.valueFromValues.get(
-      metadata.definition,
+      metadataDefinition,
       this.defaultsService.get(),
     )
     const effectiveValue =
       isObject(value) && (isObject(routeValue) || isObject(defaultValue))
         ? { ...(defaultValue as object), ...(routeValue as object), ...value }
         : [value, routeValue, defaultValue].find((v) => v !== undefined)
-    metadata.set(effectiveValue)
+
+    return effectiveValue as MaybeUndefined<T>
   }
 }

--- a/projects/ngx-meta/src/core/src/metadata.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata.service.spec.ts
@@ -3,9 +3,11 @@ import { MetadataService } from './metadata.service'
 import { MockProviders } from 'ng-mocks'
 import { makeMetadata } from './__tests__/make-metadata'
 import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
-import { MetadataSetter } from './metadata-setter'
+import { MetadataResolver } from './metadata-resolver'
 import { RouteMetadataValues } from './route-metadata-values'
 import { MetadataRegistry } from './metadata-registry'
+import { MaybeUndefined } from './maybe-undefined'
+import { MetadataDefinition } from './metadata-definition'
 
 describe('MetadataService', () => {
   enableAutoSpy()
@@ -28,25 +30,39 @@ describe('MetadataService', () => {
       metadataRegistry.getAll.and.returnValue([firstMetadata, secondMetadata])
     })
 
-    it('should set each metadata using the setter', () => {
-      const metadataSetter = TestBed.inject(
-        MetadataSetter,
-      ) as unknown as jasmine.SpyObj<MetadataSetter>
+    it('should set each metadata using resolved values', () => {
+      const resolver = TestBed.inject(
+        MetadataResolver,
+      ) as unknown as jasmine.SpyObj<MetadataResolver>
+      const dummyFirstMetadataValue = 'firstMetadataValue'
+      const dummySecondMetadataValue = 'secondMetadataValue'
+      resolver.get.and.callFake(<T>(definition: MetadataDefinition) => {
+        switch (definition) {
+          case firstMetadata.definition:
+            return dummyFirstMetadataValue as MaybeUndefined<T>
+          case secondMetadata.definition:
+            return dummySecondMetadataValue as MaybeUndefined<T>
+          default:
+            throw new Error('Unexpected metadata definition')
+        }
+      })
       sut.set(dummyValues)
 
-      expect(metadataSetter.set).toHaveBeenCalledTimes(2)
-      expect(metadataSetter.set).toHaveBeenCalledWith(
-        firstMetadata,
-        dummyValues,
-      )
-      expect(metadataSetter.set).toHaveBeenCalledWith(
-        secondMetadata,
-        dummyValues,
-      )
       expect(metadataRegistry.getAll).toHaveBeenCalledOnceWith()
+      expect(resolver.get).toHaveBeenCalledTimes(2)
+      expect(resolver.get).toHaveBeenCalledWith(
+        firstMetadata.definition,
+        dummyValues,
+      )
+      expect(firstMetadata.set).toHaveBeenCalledWith(dummyFirstMetadataValue)
+      expect(resolver.get).toHaveBeenCalledWith(
+        secondMetadata.definition,
+        dummyValues,
+      )
+      expect(secondMetadata.set).toHaveBeenCalledWith(dummySecondMetadataValue)
     })
 
-    it('should set values for current url when finished', () => {
+    it('should set values for route when finished', () => {
       const routeMetadataValues = TestBed.inject(
         RouteMetadataValues,
       ) as jasmine.SpyObj<RouteMetadataValues>
@@ -62,7 +78,7 @@ function makeSut() {
   TestBed.configureTestingModule({
     providers: [
       MetadataService,
-      MockProviders(MetadataRegistry, MetadataSetter, RouteMetadataValues),
+      MockProviders(MetadataRegistry, MetadataResolver, RouteMetadataValues),
     ],
   })
   return TestBed.inject(MetadataService)

--- a/projects/ngx-meta/src/core/src/metadata.service.ts
+++ b/projects/ngx-meta/src/core/src/metadata.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { MetadataSetter } from './metadata-setter'
+import { MetadataResolver } from './metadata-resolver'
 import { MetadataValues } from './metadata-values'
 import { RouteMetadataValues } from './route-metadata-values'
 import { MetadataRegistry } from './metadata-registry'
@@ -8,15 +8,15 @@ import { MetadataRegistry } from './metadata-registry'
 export class MetadataService {
   constructor(
     private readonly registry: MetadataRegistry,
-    private readonly setter: MetadataSetter,
-    private readonly routeMetadataValues: RouteMetadataValues,
+    private readonly resolver: MetadataResolver,
+    private readonly routeValues: RouteMetadataValues,
   ) {}
 
   public set(values: MetadataValues = {}): void {
     const allMetadata = this.registry.getAll()
     for (const metadata of allMetadata) {
-      this.setter.set(metadata, values)
+      metadata.set(this.resolver.get(metadata.definition, values))
     }
-    this.routeMetadataValues.set(values)
+    this.routeValues.set(values)
   }
 }


### PR DESCRIPTION
Given it's the most important function. Set can be called by the service with resolved value. Improves SRP on the (now) resolver class
