### PR TITLE
feat: add Angular router as peer dep

### DIFF
--- a/projects/ngx-meta/src/package.json
+++ b/projects/ngx-meta/src/package.json
@@ -8,7 +8,13 @@
   },
   "peerDependencies": {
     "@angular/common": "^17 || ^16 || ^15",
-    "@angular/core": "^17 || ^16 || ^15"
+    "@angular/core": "^17 || ^16 || ^15",
+    "@angular/router": "^17 || ^16 || ^15"
+  },
+  "peerDependenciesMeta": {
+    "@angular/router": {
+      "optional": true
+    }
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
And mark it as optional thanks to `peerDependenciesMeta`. Didn't know that existed. That's why it was omitted til now. It's optional cause if you don't use the routing pkg it's not needed.
