### PR TITLE
ci: split bundle size in separate job

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
+  BUNDLE_ARTIFACT_NAME_PREFIX: main-bundle-a
 
 #👇 Needed for PR bundle size comment only
 #permissions:
@@ -53,7 +54,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Angular v${{ matrix.version }} E2E app
         working-directory: ${{ env.E2E_APP_DIR }}
-        run: pnpm build
+        run: pnpm build:source-map # with source map for bundle size job!
       - name: Start Angular v${{ matrix.version }} E2E app server
         working-directory: ${{ env.E2E_APP_DIR }}
         run: pnpm start &
@@ -63,12 +64,33 @@ jobs:
           wait-on: 'http://localhost:4200'
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
+      - name: Upload built app
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
+        with:
+          name: ${{ env.BUNDLE_ARTIFACT_NAME_PREFIX }}${{ matrix.version }}
+          path: ${{ env.E2E_APP_DIR }}/dist
+          retention-days: 5
+  bundle-size:
+    needs: e2e
+    if: github.event_name == 'pull_request'
+    name: Bundle size - Angular v${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        version: [15, 16, 17]
+    env:
+      E2E_APP_DIR: projects/ngx-meta/e2e/a${{ matrix.version }}
+    steps:
+      - name: Download built app
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4
+        with:
+          name: ${{ env.BUNDLE_ARTIFACT_NAME_PREFIX }}${{ matrix.version }}
+          path: ${{ env.E2E_APP_DIR }}/dist
       - name: Analyze main bundle size
-        if: github.event_name == 'pull_request'
         working-directory: ${{ env.E2E_APP_DIR }}
         run: pnpm run bundle-pr-comment --git-ref ${{ github.event.pull_request.head.sha }}
       - name: Find bundle size PR comment
-        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2
         id: fc
         with:
@@ -77,7 +99,6 @@ jobs:
           # Keep in sync with PR comment formatter
           body-includes: '### 📦 Bundle size (Angular v${{ matrix.version }})'
       - name: Update bundle size PR comment
-        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/projects/ngx-meta/e2e/a15/package.json
+++ b/projects/ngx-meta/e2e/a15/package.json
@@ -11,7 +11,7 @@
     "cache:clean": "ng cache clean",
     "analyze-main-bundle": "pnpm run build:source-map && pnpm run source-map-explorer",
     "source-map-explorer": "source-map-explorer dist/a15/main*.js",
-    "bundle-pr-comment": "pnpm run build:source-map && pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v15' -f bundle-size-pr-comment.md"
+    "bundle-pr-comment": "pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v15' -f bundle-size-pr-comment.md"
   },
   "private": true,
   "packageManager": "pnpm@8.14.0",

--- a/projects/ngx-meta/e2e/a16/package.json
+++ b/projects/ngx-meta/e2e/a16/package.json
@@ -11,7 +11,7 @@
     "cache:clean": "ng cache clean",
     "analyze-main-bundle": "pnpm run build:source-map && pnpm run source-map-explorer",
     "source-map-explorer": "source-map-explorer dist/a16/main*.js",
-    "bundle-pr-comment": "pnpm run build:source-map && pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v16' -f bundle-size-pr-comment.md"
+    "bundle-pr-comment": "pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v16' -f bundle-size-pr-comment.md"
   },
   "private": true,
   "packageManager": "pnpm@8.14.0",

--- a/projects/ngx-meta/e2e/a17/package.json
+++ b/projects/ngx-meta/e2e/a17/package.json
@@ -11,7 +11,7 @@
     "cache:clean": "ng cache clean",
     "analyze-main-bundle": "pnpm run build:source-map && pnpm run source-map-explorer",
     "source-map-explorer": "source-map-explorer dist/a17/browser/main*.js",
-    "bundle-pr-comment": "pnpm run build:source-map && pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v17' -f bundle-size-pr-comment.md"
+    "bundle-pr-comment": "pnpm run source-map-explorer --tsv | ../format-bundle-pr-comment.sh -h 'Angular v17' -f bundle-size-pr-comment.md"
   },
   "private": true,
   "packageManager": "pnpm@8.14.0",


### PR DESCRIPTION
In preparation to start tracking size in `main` branch and provide a comparison in every PR.
