### PR TITLE
ci: add ref back + update comment by id

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -14,6 +14,7 @@ on:
 env:
   E2E_DIR: projects/ngx-meta/e2e
   SOURCE_MAP_EXPLORER_ARTIFACT_NAME_PREFIX: ngx-meta-source-map-explorer-a
+  BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-a
 
 #👇 Needed for PR bundle size comment only
 #permissions:
@@ -65,7 +66,11 @@ jobs:
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
       - name: Analyze main bundle with source map explorer
-        run: pnpm run source-map-explorer-json && pnpm run bundle-pr-comment
+        run: |
+          pnpm run source-map-explorer-json &&
+          pnpm run bundle-pr-comment \
+            --git-ref '${{ github.event.pull_request.head.sha }}' \
+            --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.version }}'
       - name: Upload main bundle analysis results
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
         with:
@@ -95,8 +100,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          # Keep in sync with PR comment formatter
-          body-includes: '### 📦 Bundle size (Angular v${{ matrix.version }})'
+          body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.version }}
       - name: Update bundle size PR comment
         uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:

--- a/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
+++ b/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
@@ -8,12 +8,14 @@ input_file=""
 header=""
 output_file=""
 git_ref=""
+hidden_info=""
 
 # Function to display usage information
 display_usage() {
   cat <<BLOCK
 Usage: $0 -h|--header HEADER -i|--input-file SME_JSON_FILE
        -o|--output-file OUTPUT_FILE [-r|--git-ref GIT_REF]
+       [--hidden-info INFO]
 
        SME stands for Source Map Explorer
 BLOCK
@@ -39,6 +41,10 @@ while [ "$#" -gt 0 ]; do
     shift
     git_ref="$1"
     ;;
+  --hidden-info)
+    shift
+    hidden_info="$1"
+    ;;
   *)
     display_usage
     ;;
@@ -58,7 +64,7 @@ if ! [ -r "$input_file" ]; then
 fi
 
 # Ensure jq is available
-if ! command -v jq > /dev/null 2>&1; then
+if ! command -v jq >/dev/null 2>&1; then
   echo "❌ jq is not installed"
   exit 1
 fi
@@ -66,6 +72,9 @@ fi
 # 👇 Keep in sync with CI comment finder
 echo "### 📦 Bundle size ($header)" >"$output_file"
 {
+  if [ -n "$hidden_info" ]; then
+    echo "<!-- $hidden_info -->"
+  fi
   if [ -n "$git_ref" ]; then
     echo "Git ref: $git_ref"
   fi


### PR DESCRIPTION
Git ref in bundle size PR comments was lost in #143
Uses an HTML comment (that won't be rendered) to update comments instead of visible text. Also, makes that text configurable so markdown script doesn't need to be in sync with CI step

