### PR TITLE
ci: store bundle size info as GitHub check run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       build-artifact-name: ngx-meta
+    permissions:
+      checks: write
   release:
     name: Release
     needs: [e2e]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,9 +9,10 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       artifact-name: ngx-meta
-  test:
-    name: Test
-    uses: ./.github/workflows/reusable-test.yml
+  # Temporary for testing
+  #test:
+  #  name: Test
+  #  uses: ./.github/workflows/reusable-test.yml
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml
@@ -19,7 +20,7 @@ jobs:
     name: Style
     uses: ./.github/workflows/reusable-style.yml
   e2e:
-    needs: [build, test, lint]
+    needs: [build, lint]
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,9 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       artifact-name: ngx-meta
-  # Temporary for testing
-  #test:
-  #  name: Test
-  #  uses: ./.github/workflows/reusable-test.yml
+  test:
+    name: Test
+    uses: ./.github/workflows/reusable-test.yml
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml
@@ -20,12 +19,10 @@ jobs:
     name: Style
     uses: ./.github/workflows/reusable-style.yml
   e2e:
-    needs: [build, lint]
+    needs: [build, test, lint]
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       build-artifact-name: ngx-meta
     permissions:
       pull-requests: write
-      # Temporary! Just to check now
-      checks: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,3 +26,5 @@ jobs:
       build-artifact-name: ngx-meta
     permissions:
       pull-requests: write
+      # Temporary! Just to check now
+      checks: write

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -29,7 +29,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [15, 16, 17]
+        # Temporary for testing
+        version: [17]
     env:
       E2E_APP_DIR: projects/ngx-meta/e2e/a${{ matrix.version }}
     defaults:
@@ -59,14 +60,15 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Angular v${{ matrix.version }} E2E app
         run: pnpm build:source-map # with source map for bundle size job!
-      - name: Start Angular v${{ matrix.version }} E2E app server
-        run: pnpm start &
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
-        with:
-          wait-on: 'http://localhost:4200'
-          working-directory: ${{ env.E2E_DIR }}
-          browser: chrome
+      # Temporary for testing
+      # - name: Start Angular v${{ matrix.version }} E2E app server
+      #   run: pnpm start &
+      # - name: Cypress run
+      #   uses: cypress-io/github-action@v6
+      #   with:
+      #     wait-on: 'http://localhost:4200'
+      #     working-directory: ${{ env.E2E_DIR }}
+      #     browser: chrome
       - name: Analyze main bundle with source map explorer
         run: |
           pnpm run source-map-explorer-json &&
@@ -90,7 +92,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [15, 16, 17]
+        # Temporary for testing
+        version: [17]
     steps:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4
@@ -140,7 +143,7 @@ jobs:
               head_sha: context.sha,
               conclusion: 'neutral',
               output: {
-                title: 'Bundle size - Angular v${{ matrix.version }}'
+                title: 'Bundle size - Angular v${{ matrix.version }}',
                 summary: 'Sizes of the library modules when packed inside a main bundle of an Angular v${{ matrix.version }} app. In bytes. Thanks to source-map-explorer :)',
                 text: smeJsonString,
               }

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -141,13 +141,17 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: '${{ env.CHECK_RUN_NAME }}',
-              // Temporary until we don't test in a PR
               // head_sha: context.sha,
+              // In case you're testing this in a PR, you'll want the head SHA
+              // otherwise, `context.sha` refers to the GitHub PR merge branch
+              // which is a detail hidden away from users. Uncomment 👇
               head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               output: {
                 title: 'Bundle size - Angular v${{ matrix.version }}',
-                summary: 'Sizes of the library modules when packed inside a main bundle of an Angular v${{ matrix.version }} app. In bytes. Thanks to source-map-explorer :)',
+                summary: 'Sizes of the library modules when packed inside a ' +
+                         'main bundle of an Angular v${{ matrix.version }} ' +
+                         'app. In bytes. Thanks to `source-map-explorer` :)',
                 text: smeJsonString,
               }
             })

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -135,14 +135,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const smeJson = fs.readFileSync('source-map-explorer.json', 'utf8');
-            const smeJsonString = JSON.parse(smeJson).toString();
+            const smeJson = require('./source-map-explorer.json');
+            const smeJsonString = smeJson.toString();
             return github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: '${{ env.CHECK_RUN_NAME }}',
-              head_sha: context.sha,
+              // Temporary until we don't test in a PR
+              // head_sha: context.sha,
+              head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               output: {
                 title: 'Bundle size - Angular v${{ matrix.version }}',

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           script: |
             const smeJson = require('./source-map-explorer.json');
-            const smeJsonString = smeJson.toString();
+            const smeJsonString = JSON.stringify(smeJson);
             return github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -29,8 +29,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        # Temporary for testing
-        version: [17]
+        version: [15, 16, 17]
     env:
       E2E_APP_DIR: projects/ngx-meta/e2e/a${{ matrix.version }}
     defaults:
@@ -60,15 +59,14 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Angular v${{ matrix.version }} E2E app
         run: pnpm build:source-map # with source map for bundle size job!
-      # Temporary for testing
-      # - name: Start Angular v${{ matrix.version }} E2E app server
-      #   run: pnpm start &
-      # - name: Cypress run
-      #   uses: cypress-io/github-action@v6
-      #   with:
-      #     wait-on: 'http://localhost:4200'
-      #     working-directory: ${{ env.E2E_DIR }}
-      #     browser: chrome
+      - name: Start Angular v${{ matrix.version }} E2E app server
+        run: pnpm start &
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        with:
+          wait-on: 'http://localhost:4200'
+          working-directory: ${{ env.E2E_DIR }}
+          browser: chrome
       - name: Analyze main bundle with source map explorer
         run: |
           pnpm run source-map-explorer-json &&
@@ -92,8 +90,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        # Temporary for testing
-        version: [17]
+        version: [15, 16, 17]
     steps:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4
@@ -115,15 +112,13 @@ jobs:
           edit-mode: replace
   bundle-size-check:
     needs: e2e
-    # Temporary for testing
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     name: Bundle size store - Angular v${{ matrix.version }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        # Temporary for testing
-        version: [17]
+        version: [15, 16, 17]
     env:
       CHECK_RUN_NAME: ngx-meta-bundle-size-a${{ matrix.version }}
     steps:
@@ -141,11 +136,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: '${{ env.CHECK_RUN_NAME }}',
-              // head_sha: context.sha,
+              head_sha: context.sha,
               // In case you're testing this in a PR, you'll want the head SHA
               // otherwise, `context.sha` refers to the GitHub PR merge branch
               // which is a detail hidden away from users. Uncomment 👇
-              head_sha: '${{ github.event.pull_request.head.sha }}',
+              // head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               output: {
                 title: 'Bundle size - Angular v${{ matrix.version }}',

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -112,7 +112,8 @@ jobs:
           edit-mode: replace
   bundle-size-check:
     needs: e2e
-    if: github.event_name == 'push'
+    # Temporary for testing
+    # if: github.event_name == 'push'
     name: Bundle size store - Angular v${{ matrix.version }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -16,9 +16,11 @@ env:
   SOURCE_MAP_EXPLORER_ARTIFACT_NAME_PREFIX: ngx-meta-source-map-explorer-a
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-a
 
-#👇 Needed for PR bundle size comment only
 #permissions:
+#  👇 Needed for PR bundle size comment only
 #  pull_requests: write
+#  👇 Needed for main bundle size check store only
+#  checks: write
 
 jobs:
   e2e:
@@ -108,3 +110,37 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: bundle-size-pr-comment.md
           edit-mode: replace
+  bundle-size-check:
+    needs: e2e
+    if: github.event_name == 'push'
+    name: Bundle size store - Angular v${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        version: [15, 16, 17]
+    env:
+      CHECK_RUN_NAME: ngx-meta-bundle-size-a${{ matrix.version }}
+    steps:
+      - name: Download main bundle analysis results
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4
+        with:
+          name: ${{ env.SOURCE_MAP_EXPLORER_ARTIFACT_NAME_PREFIX }}${{ matrix.version }}
+      - name: Create check run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const smeJson = require('source-map-explorer.json');
+            const smeJsonString = smeJson.toString();
+            return github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: '${{ env.CHECK_RUN_NAME }}',
+              head_sha: context.sha,
+              conclusion: 'neutral',
+              output: {
+                title: 'Bundle size - Angular v${{ matrix.version }}'
+                summary: 'Sizes of the library modules when packed inside a main bundle of an Angular v${{ matrix.version }} app. In bytes. Thanks to source-map-explorer :)',
+                text: smeJsonString,
+              }
+            })

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -122,7 +122,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [15, 16, 17]
+        # Temporary for testing
+        version: [17]
     env:
       CHECK_RUN_NAME: ngx-meta-bundle-size-a${{ matrix.version }}
     steps:
@@ -134,8 +135,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const smeJson = require('source-map-explorer.json');
-            const smeJsonString = smeJson.toString();
+            const fs = require('fs');
+            const smeJson = fs.readFileSync('source-map-explorer.json', 'utf8');
+            const smeJsonString = JSON.parse(smeJson).toString();
             return github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
So we can later use that info to compare in each PR
