### PR TITLE
ci: handle base bundle size not available case

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -112,7 +112,12 @@ jobs:
               check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.version }}',
               per_page: 1,
             })
-            const checkRun = checkRunResponse.data.check_runs[0]
+            const checkRuns = checkRunResponse.data.check_runs
+            if (checkRuns.length < 1) {
+              console.info('No check runs found')
+              return
+            }
+            const checkRun = checkRuns[0]
             const smeJsonString = checkRun.output.text
             const fs = require('fs')
             fs.writeFileSync('./source-map-explorer.json', smeJsonString)

--- a/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
+++ b/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
@@ -156,6 +156,7 @@ for file in $files; do
 done >>"$output_file"
 
 if base_file_provided && ! base_file_exists; then
+    echo ""
     printf "Base size data is not available yet. "
     echo "Try again when the CI/CD has finished running on main branch"
 fi >> "$output_file"

--- a/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
+++ b/projects/ngx-meta/e2e/generate-bundle-pr-comment.sh
@@ -74,7 +74,11 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-base_file() {
+base_file_provided() {
+  test -n "$base_file"
+}
+
+base_file_exists() {
   test -r "$base_file"
 }
 
@@ -89,13 +93,13 @@ echo "### 📦 Bundle size ($header)" >"$output_file"
   fi
   echo ""
   printf "| Module file | Size |"
-  if base_file; then
+  if base_file_provided; then
     echo " Base size | Difference"
   else
     echo ""
   fi
   printf "| --- | --- |"
-  if base_file; then
+  if base_file_provided; then
     echo " --- | --- |"
   else
     echo ""
@@ -129,20 +133,29 @@ for file in $files; do
   )"
   input_bytes_size=$(echo "$lib_files" | jq -r ".[\"$file\"].size")
   printf "| \`%s\` | %s |" "$beautified_file" "$(format_size_column "$input_bytes_size")"
-  if base_file; then
-    base_bytes_size="$(jq -r ".results[0].files[\"$file\"].size" "$base_file")"
-    base_size="$(format_size_column "$base_bytes_size")"
-    diff_bytes_size="$((input_bytes_size - base_bytes_size))"
-    diff_size="$(format_size_column "$diff_bytes_size")"
-    # Operate with precision, but output 2 decimals only
-    # https://askubuntu.com/a/217575/605666#comment1744264_217575
-    diff_percent="$(echo "res=$diff_bytes_size/$base_bytes_size*100; scale=2; res/1" | bc -l)"
-    diff=""
-    if [ "$diff_percent" != "0" ]; then
-      diff="$diff_percent%: $diff_size"
+  if base_file_provided; then
+    if base_file_exists; then
+      base_bytes_size="$(jq -r ".results[0].files[\"$file\"].size" "$base_file")"
+      base_size="$(format_size_column "$base_bytes_size")"
+      diff_bytes_size="$((input_bytes_size - base_bytes_size))"
+      diff_size="$(format_size_column "$diff_bytes_size")"
+      # Operate with precision, but output 2 decimals only
+      # https://askubuntu.com/a/217575/605666#comment1744264_217575
+      diff_percent="$(echo "res=$diff_bytes_size/$base_bytes_size*100; scale=2; res/1" | bc -l)"
+      diff="No change"
+      if [ "$diff_percent" != "0" ]; then
+        diff="$diff_percent%: $diff_size"
+      fi
+      echo " $base_size | $diff |"
+    else
+      echo " Not available | Not available |"
     fi
-    echo " $base_size | $diff |"
   else
     echo ""
   fi
 done >>"$output_file"
+
+if base_file_provided && ! base_file_exists; then
+    printf "Base size data is not available yet. "
+    echo "Try again when the CI/CD has finished running on main branch"
+fi >> "$output_file"


### PR DESCRIPTION
The job creating the PR comment assumed that there would always be a check run in main branch  containing the bundle size info. However that may not be true. For instance:
 - A fresh repo
 - Error running the CI pipeline on that commit
 - Skipped job as not needed for files changed
 - CI is still running. Then, even if there was a check run that was created for that commit before, API will return no check runs exists for that ref

So here we handle that case by stating base size is not available in those scenarios. And add a comment about trying again later. As right now with current setup, the most likely scenario is CI hasn't finished running yet or has failed. Either of which should be temporary.

Also changes the "Difference" column value in case there's no difference to "No change" to be more explicit.

It worked at first run: https://github.com/davidlj95/ngx/actions/runs/7512297770/job/20452872822?pr=153

Re-running again later as we need a space between table and comment (in local worked fine, but not when rendering in GitHub)