### PR TITLE
build(ide): remove semantic release run config

### DIFF
--- a/.idea/runConfigurations/Semantic_Release.xml
+++ b/.idea/runConfigurations/Semantic_Release.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Semantic Release" type="NodeJSConfigurationType" node-parameters="--env-file .env" path-to-js-file="node_modules/.pnpm/semantic-release@22.0.8_typescript@5.2.2/node_modules/semantic-release/bin/semantic-release.js" working-dir="$PROJECT_DIR$">
-    <method v="2" />
-  </configuration>
-</component>


### PR DESCRIPTION
It's tied to the version of it given it's pointing to the `node_modules` dir. And given it's not used often, let's remove it to avoid it from breaking everytime we update.
