### PR TITLE
perf: add global consts to reduce dup strings

### DIFF
--- a/projects/ngx-meta/src/core/src/global-metadata.ts
+++ b/projects/ngx-meta/src/core/src/global-metadata.ts
@@ -1,4 +1,5 @@
 import { GlobalMetadataImage } from './global-metadata-image'
+import { GlobalMetadataKey } from './global-metadata-key'
 
 export interface GlobalMetadata {
   /**
@@ -69,11 +70,13 @@ export interface GlobalMetadata {
    * image if you want to customize those too.
    */
   readonly image?: GlobalMetadataImage | null
-
-  /**
-   * JSON-LD object to set in the page
-   *
-   * Needs JSON-LD module to be imported
-   */
-  readonly jsonLd?: object | null
 }
+
+export const GLOBAL_TITLE = 'title' satisfies GlobalMetadataKey
+export const GLOBAL_DESCRIPTION = 'description' satisfies GlobalMetadataKey
+export const GLOBAL_APPLICATION_NAME =
+  'applicationName' satisfies GlobalMetadataKey
+
+export const GLOBAL_CANONICAL_URL = 'canonicalUrl' satisfies GlobalMetadataKey
+export const GLOBAL_LOCALE = 'locale' satisfies GlobalMetadataKey
+export const GLOBAL_IMAGE = 'image' satisfies GlobalMetadataKey

--- a/projects/ngx-meta/src/json-ld/src/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/json-ld-metadata-provider.ts
@@ -1,18 +1,18 @@
 import { DOCUMENT } from '@angular/common'
 import {
-  GlobalMetadata,
   HEAD_ELEMENT_UPSERT_OR_REMOVE,
   HeadElementUpsertOrRemove,
-  makeGlobalMetadata,
+  makeMetadata,
   MetadataSetterFactory,
   provideMetadataFactory,
 } from '@davidlj95/ngx-meta/core'
+import { JsonLdMetadata } from './json-ld-metadata'
 
-const KEY: keyof GlobalMetadata = 'jsonLd'
+const KEY: keyof JsonLdMetadata = 'jsonLd'
 const SCRIPT_TYPE = 'application/ld+json'
 
 export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  GlobalMetadata[typeof KEY]
+  JsonLdMetadata[typeof KEY]
 > =
   (headElementUpsertOrRemove: HeadElementUpsertOrRemove, doc: Document) =>
   (jsonLd) => {
@@ -26,7 +26,7 @@ export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   }
 
 export const JSON_LD_METADATA_PROVIDER = provideMetadataFactory(
-  makeGlobalMetadata('jsonLd'),
+  makeMetadata([KEY]),
   JSON_LD_METADATA_SETTER_FACTORY,
   [HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT],
 )

--- a/projects/ngx-meta/src/json-ld/src/json-ld-metadata.ts
+++ b/projects/ngx-meta/src/json-ld/src/json-ld-metadata.ts
@@ -1,0 +1,6 @@
+export interface JsonLdMetadata {
+  /**
+   * JSON-LD object to set in the page
+   */
+  readonly jsonLd?: object | null
+}

--- a/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
@@ -1,7 +1,5 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
-import { OpenGraph } from './open-graph'
-
-const KEY: keyof OpenGraph = 'description'
+import { GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
 
 export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
-  makeOpenGraphMetadataProvider(KEY, { g: KEY })
+  makeOpenGraphMetadataProvider(GLOBAL_DESCRIPTION, { g: GLOBAL_DESCRIPTION })

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -1,10 +1,9 @@
 import { OpenGraph } from './open-graph'
-import { MetaService } from '@davidlj95/ngx-meta/core'
+import { GLOBAL_IMAGE, MetaService } from '@davidlj95/ngx-meta/core'
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
 import { makeOpenGraphMetaProperty } from './make-open-graph-meta-property'
 
-const KEY: keyof OpenGraph = 'image'
-const NO_KEY_VALUE: OpenGraph[typeof KEY] = {
+const NO_KEY_VALUE: OpenGraph[typeof GLOBAL_IMAGE] = {
   url: undefined,
   alt: undefined,
   secureUrl: null,
@@ -14,30 +13,33 @@ const NO_KEY_VALUE: OpenGraph[typeof KEY] = {
 }
 
 export const OPEN_GRAPH_IMAGE_SETTER_FACTORY =
-  (metaService: MetaService) => (value: OpenGraph[typeof KEY]) => {
+  (metaService: MetaService) => (value: OpenGraph[typeof GLOBAL_IMAGE]) => {
     const imageUrl = value?.url?.toString()
-    const effectiveValue: OpenGraph[typeof KEY] =
+    const effectiveValue: OpenGraph[typeof GLOBAL_IMAGE] =
       imageUrl !== undefined && imageUrl !== null ? value : NO_KEY_VALUE
-    metaService.set(makeOpenGraphMetaProperty(KEY), imageUrl)
-    metaService.set(makeOpenGraphMetaProperty(KEY, 'alt'), effectiveValue?.alt)
+    metaService.set(makeOpenGraphMetaProperty(GLOBAL_IMAGE), imageUrl)
     metaService.set(
-      makeOpenGraphMetaProperty(KEY, 'secure_url'),
+      makeOpenGraphMetaProperty(GLOBAL_IMAGE, 'alt'),
+      effectiveValue?.alt,
+    )
+    metaService.set(
+      makeOpenGraphMetaProperty(GLOBAL_IMAGE, 'secure_url'),
       effectiveValue?.secureUrl?.toString(),
     )
     metaService.set(
-      makeOpenGraphMetaProperty(KEY, 'type'),
+      makeOpenGraphMetaProperty(GLOBAL_IMAGE, 'type'),
       effectiveValue?.type,
     )
     metaService.set(
-      makeOpenGraphMetaProperty(KEY, 'width'),
+      makeOpenGraphMetaProperty(GLOBAL_IMAGE, 'width'),
       effectiveValue?.width?.toString(),
     )
     metaService.set(
-      makeOpenGraphMetaProperty(KEY, 'height'),
+      makeOpenGraphMetaProperty(GLOBAL_IMAGE, 'height'),
       effectiveValue?.height?.toString(),
     )
   }
 export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
-  KEY,
-  { s: OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: KEY },
+  GLOBAL_IMAGE,
+  { s: OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: GLOBAL_IMAGE },
 )

--- a/projects/ngx-meta/src/open-graph/src/open-graph-locale-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-locale-metadata-provider.ts
@@ -1,6 +1,5 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
-import { OpenGraph } from './open-graph'
+import { GLOBAL_LOCALE } from '@davidlj95/ngx-meta/core'
 
-const key: keyof OpenGraph = 'locale'
 export const OPEN_GRAPH_LOCALE_METADATA_PROVIDER =
-  makeOpenGraphMetadataProvider(key, { g: key })
+  makeOpenGraphMetadataProvider(GLOBAL_LOCALE, { g: GLOBAL_LOCALE })

--- a/projects/ngx-meta/src/open-graph/src/open-graph-site-name-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-site-name-metadata-provider.ts
@@ -1,7 +1,8 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
+import { GLOBAL_APPLICATION_NAME } from '@davidlj95/ngx-meta/core'
 
 export const OPEN_GRAPH_SITE_NAME_METADATA_PROVIDER =
   makeOpenGraphMetadataProvider('siteName', {
-    g: 'applicationName',
+    g: GLOBAL_APPLICATION_NAME,
     p: 'site_name',
   })

--- a/projects/ngx-meta/src/open-graph/src/open-graph-title-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-title-metadata-provider.ts
@@ -1,9 +1,7 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
-import { OpenGraph } from './open-graph'
-
-const KEY: keyof OpenGraph = 'title'
+import { GLOBAL_TITLE } from '@davidlj95/ngx-meta/core'
 
 export const OPEN_GRAPH_TITLE_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
-  KEY,
-  { g: KEY },
+  GLOBAL_TITLE,
+  { g: GLOBAL_TITLE },
 )

--- a/projects/ngx-meta/src/open-graph/src/open-graph-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-url-metadata-provider.ts
@@ -1,6 +1,7 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
+import { GLOBAL_CANONICAL_URL } from '@davidlj95/ngx-meta/core'
 
 export const OPEN_GRAPH_URL_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
   'url',
-  { g: 'canonicalUrl' },
+  { g: GLOBAL_CANONICAL_URL },
 )

--- a/projects/ngx-meta/src/standard/src/standard-canonical-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-canonical-url-metadata-provider.ts
@@ -1,20 +1,19 @@
 import { makeStandardMetadataProvider } from './make-standard-metadata-provider'
-import { Standard } from './standard'
 import {
+  GLOBAL_CANONICAL_URL,
   HEAD_ELEMENT_UPSERT_OR_REMOVE,
   HeadElementUpsertOrRemove,
 } from '@davidlj95/ngx-meta/core'
 import { DOCUMENT } from '@angular/common'
 
-const KEY: keyof Standard = 'canonicalUrl'
 const LINK_TAG = 'link'
 const REL_ATTR = 'rel'
 const CANONICAL_VAL = 'canonical'
 const SELECTOR = `${LINK_TAG}[${REL_ATTR}='${CANONICAL_VAL}']`
 
 export const STANDARD_CANONICAL_URL_METADATA_PROVIDER =
-  makeStandardMetadataProvider(KEY, {
-    g: KEY,
+  makeStandardMetadataProvider(GLOBAL_CANONICAL_URL, {
+    g: GLOBAL_CANONICAL_URL,
     s:
       (headElementUpsertOrRemove: HeadElementUpsertOrRemove, doc: Document) =>
       (value) => {

--- a/projects/ngx-meta/src/standard/src/standard-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-description-metadata-provider.ts
@@ -1,7 +1,8 @@
 import { makeStandardMetadataProvider } from './make-standard-metadata-provider'
 import { Standard } from './standard'
+import { GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
 
-const KEY: keyof Standard = 'description'
+const KEY: keyof Standard = GLOBAL_DESCRIPTION
 
 export const STANDARD_DESCRIPTION_METADATA_PROVIDER =
   makeStandardMetadataProvider(KEY, { g: KEY })

--- a/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.ts
@@ -1,13 +1,11 @@
 import { makeStandardMetadataProvider } from './make-standard-metadata-provider'
-import { Standard } from './standard'
 import { HtmlLangAttributeService } from './html-lang-attribute/html-lang-attribute.service'
-
-const KEY: keyof Standard = 'locale'
+import { GLOBAL_LOCALE } from '@davidlj95/ngx-meta/core'
 
 export const STANDARD_LOCALE_METADATA_PROVIDER = makeStandardMetadataProvider(
-  KEY,
+  GLOBAL_LOCALE,
   {
-    g: KEY,
+    g: GLOBAL_LOCALE,
     s: (htmlLangAttributeService: HtmlLangAttributeService) => (value) =>
       htmlLangAttributeService.set(value),
     d: [HtmlLangAttributeService],

--- a/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.ts
@@ -1,12 +1,10 @@
 import { makeStandardMetadataProvider } from './make-standard-metadata-provider'
 import { Standard } from './standard'
 import { Title } from '@angular/platform-browser'
-import { MetadataSetterFactory } from '@davidlj95/ngx-meta/core'
-
-const KEY: keyof Standard = 'title'
+import { GLOBAL_TITLE, MetadataSetterFactory } from '@davidlj95/ngx-meta/core'
 
 export const STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof KEY]
+  Standard[typeof GLOBAL_TITLE]
 > = (titleService: Title) => (value) => {
   if (value === undefined || value === null) {
     return
@@ -15,6 +13,6 @@ export const STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
 }
 
 export const STANDARD_TITLE_METADATA_PROVIDER = makeStandardMetadataProvider(
-  KEY,
-  { g: KEY, s: STANDARD_TITLE_METADATA_SETTER_FACTORY, d: [Title] },
+  GLOBAL_TITLE,
+  { g: GLOBAL_TITLE, s: STANDARD_TITLE_METADATA_SETTER_FACTORY, d: [Title] },
 )

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
@@ -1,7 +1,5 @@
 import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
-import { TwitterCard } from './twitter-card'
-
-const KEY: keyof TwitterCard = 'description'
+import { GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
 
 export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER =
-  makeTwitterCardMetadataProvider(KEY, { g: KEY })
+  makeTwitterCardMetadataProvider(GLOBAL_DESCRIPTION, { g: GLOBAL_DESCRIPTION })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
@@ -1,14 +1,18 @@
 import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
-import { TwitterCard } from './twitter-card'
 import { makeTwitterCardMetaProperty } from './make-twitter-card-meta-property'
-
-const KEY: keyof TwitterCard = 'image'
+import { GLOBAL_IMAGE } from '@davidlj95/ngx-meta/core'
 
 export const TWITTER_CARD_IMAGE_METADATA_PROVIDER =
-  makeTwitterCardMetadataProvider(KEY, {
-    g: KEY,
+  makeTwitterCardMetadataProvider(GLOBAL_IMAGE, {
+    g: GLOBAL_IMAGE,
     s: (metaService) => (value) => {
-      metaService.set(makeTwitterCardMetaProperty(KEY), value?.url?.toString())
-      metaService.set(makeTwitterCardMetaProperty(KEY, 'alt'), value?.alt)
+      metaService.set(
+        makeTwitterCardMetaProperty(GLOBAL_IMAGE),
+        value?.url?.toString(),
+      )
+      metaService.set(
+        makeTwitterCardMetaProperty(GLOBAL_IMAGE, 'alt'),
+        value?.alt,
+      )
     },
   })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-title-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-title-metadata-provider.ts
@@ -1,7 +1,5 @@
 import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
-import { TwitterCard } from './twitter-card'
-
-const KEY: keyof TwitterCard = 'title'
+import { GLOBAL_TITLE } from '@davidlj95/ngx-meta/core'
 
 export const TWITTER_CARD_TITLE_METADATA_PROVIDER =
-  makeTwitterCardMetadataProvider(KEY, { g: KEY })
+  makeTwitterCardMetadataProvider(GLOBAL_TITLE, { g: GLOBAL_TITLE })


### PR DESCRIPTION
In order to remove duplicate strings refering to same globals around, adding consts

Also move out JSON LD from globals to make the module less tight to `core` module
