### PR TITLE
perf: use const instead of enums to min bundle size

### DIFF
--- a/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -2,15 +2,15 @@ import { Component, OnInit } from '@angular/core'
 import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
 import { ActivatedRoute } from '@angular/router'
 import {
+  OPEN_GRAPH_TYPE_BOOK,
   OpenGraphMetadata,
-  OpenGraphType,
 } from '@davidlj95/ngx-meta/open-graph'
 import {
+  TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
   TwitterCardMetadata,
-  TwitterCardType,
 } from '@davidlj95/ngx-meta/twitter-card'
 import {
-  OpenGraphProfileGender,
+  OPEN_GRAPH_PROFILE_GENDER_FEMALE,
   OpenGraphProfileMetadata,
 } from '@davidlj95/ngx-meta/open-graph-profile'
 
@@ -24,15 +24,15 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
     OpenGraphProfileMetadata &
     TwitterCardMetadata = {
     openGraph: {
-      type: OpenGraphType.Book,
+      type: OPEN_GRAPH_TYPE_BOOK,
       profile: {
-        gender: OpenGraphProfileGender.Female,
+        gender: OPEN_GRAPH_PROFILE_GENDER_FEMALE,
       },
     },
     twitterCard: {
-      card: TwitterCardType.SummaryLargeImage,
+      card: TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
     },
-  }
+  } as const
 
   constructor(
     activatedRoute: ActivatedRoute,

--- a/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -2,15 +2,15 @@ import { Component, OnInit } from '@angular/core'
 import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
 import { ActivatedRoute } from '@angular/router'
 import {
+  OPEN_GRAPH_TYPE_BOOK,
   OpenGraphMetadata,
-  OpenGraphType,
 } from '@davidlj95/ngx-meta/open-graph'
 import {
+  TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
   TwitterCardMetadata,
-  TwitterCardType,
 } from '@davidlj95/ngx-meta/twitter-card'
 import {
-  OpenGraphProfileGender,
+  OPEN_GRAPH_PROFILE_GENDER_FEMALE,
   OpenGraphProfileMetadata,
 } from '@davidlj95/ngx-meta/open-graph-profile'
 
@@ -24,15 +24,15 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
     OpenGraphProfileMetadata &
     TwitterCardMetadata = {
     openGraph: {
-      type: OpenGraphType.Book,
+      type: OPEN_GRAPH_TYPE_BOOK,
       profile: {
-        gender: OpenGraphProfileGender.Female,
+        gender: OPEN_GRAPH_PROFILE_GENDER_FEMALE,
       },
     },
     twitterCard: {
-      card: TwitterCardType.SummaryLargeImage,
+      card: TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
     },
-  }
+  } as const
 
   constructor(
     activatedRoute: ActivatedRoute,

--- a/projects/ngx-meta/e2e/a17/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -3,15 +3,15 @@ import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
 import { JsonPipe } from '@angular/common'
 import { ActivatedRoute } from '@angular/router'
 import {
+  OPEN_GRAPH_TYPE_BOOK,
   OpenGraphMetadata,
-  OpenGraphType,
 } from '@davidlj95/ngx-meta/open-graph'
 import {
+  TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
   TwitterCardMetadata,
-  TwitterCardType,
 } from '@davidlj95/ngx-meta/twitter-card'
 import {
-  OpenGraphProfileGender,
+  OPEN_GRAPH_PROFILE_GENDER_FEMALE,
   OpenGraphProfileMetadata,
 } from '@davidlj95/ngx-meta/open-graph-profile'
 
@@ -27,15 +27,15 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
     OpenGraphProfileMetadata &
     TwitterCardMetadata = {
     openGraph: {
-      type: OpenGraphType.Book, // using enums to watch bundle size increase
+      type: OPEN_GRAPH_TYPE_BOOK,
       profile: {
-        gender: OpenGraphProfileGender.Female,
+        gender: OPEN_GRAPH_PROFILE_GENDER_FEMALE,
       },
     },
     twitterCard: {
-      card: TwitterCardType.SummaryLargeImage,
+      card: TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
     },
-  }
+  } as const
 
   constructor(
     activatedRoute: ActivatedRoute,

--- a/projects/ngx-meta/src/open-graph-profile/src/open-graph-profile-gender.ts
+++ b/projects/ngx-meta/src/open-graph-profile/src/open-graph-profile-gender.ts
@@ -1,4 +1,6 @@
-export enum OpenGraphProfileGender {
-  Male = 'male',
-  Female = 'female',
-}
+export const OPEN_GRAPH_PROFILE_GENDER_FEMALE = 'female'
+export const OPEN_GRAPH_PROFILE_GENDER_MALE = 'male'
+
+export type OpenGraphProfileGender =
+  | typeof OPEN_GRAPH_PROFILE_GENDER_FEMALE
+  | typeof OPEN_GRAPH_PROFILE_GENDER_MALE

--- a/projects/ngx-meta/src/open-graph/src/open-graph-type.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-type.ts
@@ -1,14 +1,25 @@
-export enum OpenGraphType {
-  MusicSong = 'music.song',
-  MusicAlbum = 'music.album',
-  MusicPlaylist = 'music.playlist',
-  MusicRadioStation = 'music.radio_station',
-  VideoMovie = 'video.movie',
-  VideoEpisode = 'video.episode',
-  VideoTvShow = 'video.tv_show',
-  VideoOther = 'video.other',
-  Article = 'article',
-  Book = 'book',
-  Profile = 'profile',
-  Website = 'website',
-}
+export const OPEN_GRAPH_TYPE_MUSIC_SONG = 'music.song'
+export const OPEN_GRAPH_TYPE_MUSIC_ALBUM = 'music.album'
+export const OPEN_GRAPH_TYPE_MUSIC_PLAYLIST = 'music.playlist'
+export const OPEN_GRAPH_TYPE_MUSIC_RADIO_STATION = 'music.radio_station'
+export const OPEN_GRAPH_TYPE_VIDEO_MOVIE = 'video.movie'
+export const OPEN_GRAPH_TYPE_VIDEO_EPISODE = 'video.episode'
+export const OPEN_GRAPH_TYPE_VIDEO_TV_SHOW = 'video.tv_show'
+export const OPEN_GRAPH_TYPE_VIDEO_OTHER = 'video.other'
+export const OPEN_GRAPH_TYPE_ARTICLE = 'article'
+export const OPEN_GRAPH_TYPE_BOOK = 'book'
+export const OPEN_GRAPH_TYPE_PROFILE = 'profile'
+export const OPEN_GRAPH_TYPE_WEBSITE = 'website'
+export type OpenGraphType =
+  | typeof OPEN_GRAPH_TYPE_MUSIC_SONG
+  | typeof OPEN_GRAPH_TYPE_MUSIC_ALBUM
+  | typeof OPEN_GRAPH_TYPE_MUSIC_PLAYLIST
+  | typeof OPEN_GRAPH_TYPE_MUSIC_RADIO_STATION
+  | typeof OPEN_GRAPH_TYPE_VIDEO_MOVIE
+  | typeof OPEN_GRAPH_TYPE_VIDEO_EPISODE
+  | typeof OPEN_GRAPH_TYPE_VIDEO_TV_SHOW
+  | typeof OPEN_GRAPH_TYPE_VIDEO_OTHER
+  | typeof OPEN_GRAPH_TYPE_ARTICLE
+  | typeof OPEN_GRAPH_TYPE_BOOK
+  | typeof OPEN_GRAPH_TYPE_PROFILE
+  | typeof OPEN_GRAPH_TYPE_WEBSITE

--- a/projects/ngx-meta/src/open-graph/src/open-graph.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph.ts
@@ -1,5 +1,5 @@
-import { OpenGraphType } from './open-graph-type'
 import { OpenGraphImage } from './open-graph-image'
+import { OpenGraphType } from './open-graph-type'
 
 /**
  * Open Graph metadata

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-type.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-type.ts
@@ -1,6 +1,10 @@
-export enum TwitterCardType {
-  Summary = 'summary',
-  SummaryLargeImage = 'summary_large_image',
-  App = 'app',
-  Player = 'player',
-}
+export const TWITTER_CARD_TYPE_SUMMARY = 'summary'
+export const TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE = 'summary_large_image'
+export const TWITTER_CARD_TYPE_APP = 'app'
+export const TWITTER_CARD_TYPE_PLAYER = 'player'
+
+export type TwitterCardType =
+  | typeof TWITTER_CARD_TYPE_SUMMARY
+  | typeof TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE
+  | typeof TWITTER_CARD_TYPE_APP
+  | typeof TWITTER_CARD_TYPE_PLAYER


### PR DESCRIPTION
Typescript enums are transformed into JS functions when compiling. Those create an object that can't be tree-shaken given it may be accessed dynamically. So using `const`s to ensure only the used enum props end up in the bundle

Indeed, Typescript enums may not be tree shaken even as a whole: https://github.com/microsoft/TypeScript/issues/27604
