### PR TITLE
feat: improve metadata value types

### DIFF
--- a/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core'
-import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
+import { MetadataService } from '@davidlj95/ngx-meta/core'
 import { ActivatedRoute } from '@angular/router'
 import {
   OPEN_GRAPH_TYPE_BOOK,
@@ -42,8 +42,6 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.metadataService.set(
-      this.overriddenMetadata as unknown as MetadataValues,
-    )
+    this.metadataService.set(this.overriddenMetadata)
   }
 }

--- a/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core'
-import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
+import { MetadataService } from '@davidlj95/ngx-meta/core'
 import { ActivatedRoute } from '@angular/router'
 import {
   OPEN_GRAPH_TYPE_BOOK,
@@ -42,8 +42,6 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.metadataService.set(
-      this.overriddenMetadata as unknown as MetadataValues,
-    )
+    this.metadataService.set(this.overriddenMetadata)
   }
 }

--- a/projects/ngx-meta/e2e/a17/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core'
-import { MetadataService, MetadataValues } from '@davidlj95/ngx-meta/core'
+import { MetadataService } from '@davidlj95/ngx-meta/core'
 import { JsonPipe } from '@angular/common'
 import { ActivatedRoute } from '@angular/router'
 import {
@@ -45,8 +45,6 @@ export class MetaSetByRouteAndServiceComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.metadataService.set(
-      this.overriddenMetadata as unknown as MetadataValues,
-    )
+    this.metadataService.set(this.overriddenMetadata)
   }
 }

--- a/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
@@ -6,21 +6,23 @@ import { Injectable } from '@angular/core'
 
 @Injectable({ providedIn: 'root' })
 export class MetadataJsonResolver {
-  get<T>(definition: Metadata, values?: MetadataValues): T | undefined {
+  get<T>(metadata: Metadata, values?: MetadataValues): T | undefined {
     if (values === undefined) {
       return
     }
 
-    const keys = [...definition.jsonPath]
+    const keys = [...metadata.jsonPath]
     let value: unknown = values
     for (const key of keys) {
       if (value === undefined || value === null) {
         break
       }
-      value = (value as MetadataValues)[key]
+      value = (value as IndexedObject)[key]
     }
     const globalValue =
-      definition.global !== undefined ? values[definition.global] : undefined
+      metadata.global !== undefined
+        ? (values as IndexedObject)[metadata.global]
+        : undefined
     if (value !== undefined && !globalValue) {
       return value as MaybeUndefined<T>
     }
@@ -33,3 +35,5 @@ export class MetadataJsonResolver {
     return globalValue as MaybeUndefined<T>
   }
 }
+
+type IndexedObject = Record<string, unknown>

--- a/projects/ngx-meta/src/core/src/metadata-values.ts
+++ b/projects/ngx-meta/src/core/src/metadata-values.ts
@@ -1,3 +1,1 @@
-export interface MetadataValues {
-  [key: string]: unknown
-}
+export type MetadataValues = object

--- a/projects/ngx-meta/src/core/src/route-metadata-values.spec.ts
+++ b/projects/ngx-meta/src/core/src/route-metadata-values.spec.ts
@@ -4,13 +4,12 @@ import { RouteMetadataValues } from './route-metadata-values'
 import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
 import { MockProviders } from 'ng-mocks'
 import { Router } from '@angular/router'
-import { MetadataValues } from './metadata-values'
 
 describe('RouteMetadataValues', () => {
   enableAutoSpy()
   let sut: RouteMetadataValues
   let router: jasmine.SpyObj<Router>
-  const dummyValues: MetadataValues = { foo: 'bar' }
+  const dummyValues = { foo: 'bar' }
   const url = '/set-url'
 
   beforeEach(() => {

--- a/projects/ngx-meta/src/routing/src/metadata-route-data.ts
+++ b/projects/ngx-meta/src/routing/src/metadata-route-data.ts
@@ -1,5 +1,5 @@
-import { GlobalMetadata, MetadataValues } from '@davidlj95/ngx-meta/core'
+import { MetadataValues } from '@davidlj95/ngx-meta/core'
 
-export interface MetadataRouteData {
-  meta: GlobalMetadata & MetadataValues
+export interface MetadataRouteData<M = MetadataValues> {
+  meta: M
 }

--- a/projects/ngx-meta/src/routing/src/metadata-route-strategy.ts
+++ b/projects/ngx-meta/src/routing/src/metadata-route-strategy.ts
@@ -1,10 +1,12 @@
 import { InjectionToken } from '@angular/core'
 import { ActivatedRouteSnapshot } from '@angular/router'
+import { MetadataValues } from '@davidlj95/ngx-meta/core'
 
-export type MetadataRouteStrategy = <T>(
+export type MetadataRouteStrategy = (
   activatedRouteSnapshot: ActivatedRouteSnapshot,
-) => T | undefined
+) => MetadataValues | undefined
 
-export const METADATA_ROUTE_STRATEGY = new InjectionToken(
-  ngDevMode ? 'NgxMeta Metadata Route Strategy' : 'NgxMetaMRS',
-)
+export const METADATA_ROUTE_STRATEGY =
+  new InjectionToken<MetadataRouteStrategy>(
+    ngDevMode ? 'NgxMeta Metadata Route Strategy' : 'NgxMetaMRS',
+  )


### PR DESCRIPTION
In the metadata set by route + service E2E test, the code to use the `MetadataService` was a bit awkward in the types sense. We had to cast to `unknown` and then to `MetadataValues`. Not a great DX

Rethinking the types referring to metadata values and their usages to provide as good DX as we can

Changes:
 - Make `MetadataValues` be just `object`. Which is anything other than a primitive:
   - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type
   - https://www.typescripttutorial.net/typescript-tutorial/typescript-object-type/
   This allows metadata values to be whatever JSON object unless you specifically opt-in for some types. [There's no specific JSON type in Typescript](https://github.com/microsoft/TypeScript/issues/1897) So that's the best option AFAIK. Not using `unknown` as that includes primitives and we're sure we want an object. Indeed `unknown` allows `undefined` too. Not using `any` as it's a bad practice + same issues as `unknown`
 - ~In `MetadataService`, make the `set` method generic to allow to opt-in to type-safe values argument~. Consumers can declare data to put as argument in a separate variable or use `satisfies`
 - Make `MetadataRouteStrategy` type return `MetadataValues` too
 - Make `MetadataRouteData` generic to allow specifying type of route data. Defaulting to broad `MetadataValues` aka `object` in case you don't want to opt-in for safe types.

This allows to:
 - Use module `XMetadata` & `X` types to declare type safe metadata values. Like `OpenGraphMetadata` & `OpenGraph`. 
 - Add `MetadataRouteData<OpenGraphMetadata & TwitterCardMetadata>` to ensure route data is properly typed. Either when declaring a var type or using `satisfies`.
 - All interfaces accept broad `MetadataValues` / `object`, so it's open for extension but closed for modification. Consumers can specify a stricter type if they want to ensure types are ok or the IDE to help them write them. 

This doesn't allow to:
 - Ensure loaded metadata from JSON matches the proper types. Given union types (like `OpenGraph.type` or `TwitterCard.card`) don't match. Because the JSON types those fields as `string`. You can't use `as const` in there. Yet. https://github.com/microsoft/TypeScript/issues/32063