### PR TITLE
feat: allow to late load metadata providers

### DIFF
--- a/projects/ngx-meta/e2e/a15/src/app/app-routing.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/app-routing.module.ts
@@ -4,10 +4,16 @@ import { ROUTES } from '../../../cypress/fixtures/routes'
 import { MetaSetByServiceComponent } from './meta-set-by-service/meta-set-by-service.component'
 import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.component'
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
-import * as METADATA from '../../../cypress/fixtures/metadata.json'
+import * as METADATA_JSON from '../../../cypress/fixtures/metadata.json'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
+import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from '../late-loaded-metadata'
+import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
 
-const metadataRouteData: MetadataRouteData = { meta: METADATA }
+const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
 const routes: Routes = [
   {
@@ -23,6 +29,12 @@ const routes: Routes = [
     path: ROUTES.metaSetByRouteAndService.path,
     component: MetaSetByRouteAndServiceComponent,
     data: metadataRouteData,
+  },
+  {
+    path: ROUTES.metaLateLoaded.path,
+    component: MetaLateLoadedComponent,
+    data: { meta: LATE_LOADED_METADATA_JSON },
+    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
   },
 ]
 

--- a/projects/ngx-meta/e2e/a15/src/app/app-routing.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/app-routing.module.ts
@@ -6,12 +6,7 @@ import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.c
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
 import * as METADATA_JSON from '../../../cypress/fixtures/metadata.json'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
-import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
-import {
-  LATE_LOADED_METADATA_JSON,
-  provideLateLoadedMetadata,
-} from '../late-loaded-metadata'
-import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
+import { MetaLateLoadedModule } from './meta-late-loaded/meta-late-loaded.module'
 
 const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
@@ -32,9 +27,7 @@ const routes: Routes = [
   },
   {
     path: ROUTES.metaLateLoaded.path,
-    component: MetaLateLoadedComponent,
-    data: { meta: LATE_LOADED_METADATA_JSON },
-    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
+    loadChildren: () => MetaLateLoadedModule,
   },
 ]
 

--- a/projects/ngx-meta/e2e/a15/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/app.module.ts
@@ -18,6 +18,7 @@ import {
 } from '@davidlj95/ngx-meta/open-graph'
 import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
 import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
+import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
     MetaSetByServiceComponent,
     MetaSetByRouteComponent,
     MetaSetByRouteAndServiceComponent,
+    MetaLateLoadedComponent,
   ],
   imports: [
     BrowserModule,

--- a/projects/ngx-meta/e2e/a15/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/app.module.ts
@@ -18,7 +18,6 @@ import {
 } from '@davidlj95/ngx-meta/open-graph'
 import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
 import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
-import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
 
 @NgModule({
   declarations: [
@@ -26,13 +25,13 @@ import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.com
     MetaSetByServiceComponent,
     MetaSetByRouteComponent,
     MetaSetByRouteAndServiceComponent,
-    MetaLateLoadedComponent,
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     NgForOf,
     RouterOutlet,
+    JsonPipe,
     NgxMetaCoreModule.forRoot({ defaults: DEFAULTS }),
     NgxMetaRoutingModule.forRoot(),
     NgxMetaStandardModule,
@@ -40,8 +39,6 @@ import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.com
     NgxMetaOpenGraphProfileModule,
     NgxMetaTwitterCardModule,
     NgxMetaJsonLdModule,
-    JsonPipe,
-    JsonPipe,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/projects/ngx-meta/e2e/a15/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-servi
 import { JsonPipe, NgForOf } from '@angular/common'
 import { RouterOutlet } from '@angular/router'
 import { NgxMetaCoreModule } from '@davidlj95/ngx-meta/core'
-import * as DEFAULTS from '../../../cypress/fixtures/defaults.json'
+import * as DEFAULTS_JSON from '../../../cypress/fixtures/defaults.json'
 import { NgxMetaRoutingModule } from '@davidlj95/ngx-meta/routing'
 import { NgxMetaStandardModule } from '@davidlj95/ngx-meta/standard'
 import {
@@ -32,7 +32,7 @@ import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
     NgForOf,
     RouterOutlet,
     JsonPipe,
-    NgxMetaCoreModule.forRoot({ defaults: DEFAULTS }),
+    NgxMetaCoreModule.forRoot({ defaults: DEFAULTS_JSON }),
     NgxMetaRoutingModule.forRoot(),
     NgxMetaStandardModule,
     NgxMetaOpenGraphModule,

--- a/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/late-loaded-metadata.ts
@@ -4,7 +4,7 @@ import {
   MetaService,
   provideMetadataFactory,
 } from '@davidlj95/ngx-meta/core'
-import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+import LATE_LOADED_METADATA_JSON from '../../../../cypress/fixtures/late-loaded-metadata.json'
 
 type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
 

--- a/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.html
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.html
@@ -1,0 +1,9 @@
+Metadata of this page has been set by a late loaded metadata provider. Source:
+
+<pre>{{ providerSource }}</pre>
+
+Then, metadata values were set using the following route data:
+
+<pre>{{ routeData | json }}</pre>
+
+Check the <code>&lt;head&gt;</code> HTML element of this page to see the results

--- a/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core'
+import { ActivatedRoute } from '@angular/router'
+import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
+
+@Component({
+  selector: 'app-meta-late-loaded',
+  templateUrl: './meta-late-loaded.component.html',
+})
+export class MetaLateLoadedComponent {
+  protected readonly routeData: unknown
+  protected readonly providerSource: string
+
+  constructor(activatedRoute: ActivatedRoute) {
+    this.routeData = activatedRoute.snapshot.data
+    this.providerSource = provideLateLoadedMetadata.toString()
+  }
+}

--- a/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
-import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
+import { provideLateLoadedMetadata } from './late-loaded-metadata'
 
 @Component({
   selector: 'app-meta-late-loaded',

--- a/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.module.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-late-loaded/meta-late-loaded.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core'
+import { RouterModule } from '@angular/router'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from './late-loaded-metadata'
+import { NgxMetaMetadataLoaderModule } from '@davidlj95/ngx-meta/core'
+import { MetaLateLoadedComponent } from './meta-late-loaded.component'
+import { JsonPipe } from '@angular/common'
+
+@NgModule({
+  declarations: [MetaLateLoadedComponent],
+  imports: [
+    JsonPipe,
+    NgxMetaMetadataLoaderModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: MetaLateLoadedComponent,
+        data: { meta: LATE_LOADED_METADATA_JSON },
+      },
+    ]),
+  ],
+  providers: [provideLateLoadedMetadata()],
+})
+export class MetaLateLoadedModule {}

--- a/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route/meta-set-by-route.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-set-by-route/meta-set-by-route.component.ts
@@ -8,7 +8,7 @@ import { ActivatedRoute } from '@angular/router'
 export class MetaSetByRouteComponent {
   protected readonly routeData: unknown
 
-  constructor(readonly activatedRoute: ActivatedRoute) {
+  constructor(activatedRoute: ActivatedRoute) {
     this.routeData = activatedRoute.snapshot.data
   }
 }

--- a/projects/ngx-meta/e2e/a15/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import * as METADATA from '../../../../cypress/fixtures/metadata.json'
+import * as METADATA_JSON from '../../../../cypress/fixtures/metadata.json'
 import { MetadataService } from '@davidlj95/ngx-meta/core'
 
 @Component({
@@ -7,7 +7,7 @@ import { MetadataService } from '@davidlj95/ngx-meta/core'
   templateUrl: './meta-set-by-service.component.html',
 })
 export class MetaSetByServiceComponent implements OnInit, OnDestroy {
-  protected readonly metadata = METADATA
+  protected readonly metadata = METADATA_JSON
 
   constructor(private readonly metadataService: MetadataService) {}
 

--- a/projects/ngx-meta/e2e/a15/src/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a15/src/late-loaded-metadata.ts
@@ -1,0 +1,28 @@
+import {
+  makeMetadata,
+  MetaProperty,
+  MetaService,
+  provideMetadataFactory,
+} from '@davidlj95/ngx-meta/core'
+import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+
+type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
+
+export const provideLateLoadedMetadata = () =>
+  provideMetadataFactory<string | undefined>(
+    makeMetadata([
+      'lateLoadedMetadata' satisfies keyof LateLoadedMetadata,
+      'content' satisfies keyof LateLoadedMetadata['lateLoadedMetadata'],
+    ]),
+    (metaService: MetaService) => (value) => {
+      metaService.set(
+        new MetaProperty({
+          keyName: LATE_LOADED_METADATA_JSON.lateLoadedMetadata.name,
+        }),
+        value,
+      )
+    },
+    [MetaService],
+  )
+
+export { LATE_LOADED_METADATA_JSON }

--- a/projects/ngx-meta/e2e/a15/tsconfig.app.json
+++ b/projects/ngx-meta/e2e/a15/tsconfig.app.json
@@ -5,7 +5,8 @@
     "outDir": "./out-tsc/app",
     "types": [],
     // To load JSON fixture data
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"]

--- a/projects/ngx-meta/e2e/a16/src/app/app-routing.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/app-routing.module.ts
@@ -6,12 +6,7 @@ import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.c
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
 import * as METADATA_JSON from '../../../cypress/fixtures/metadata.json'
-import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
-import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
-import {
-  LATE_LOADED_METADATA_JSON,
-  provideLateLoadedMetadata,
-} from '../late-loaded-metadata'
+import { MetaLateLoadedModule } from './meta-late-loaded/meta-late-loaded.module'
 
 const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
@@ -32,9 +27,7 @@ const routes: Routes = [
   },
   {
     path: ROUTES.metaLateLoaded.path,
-    component: MetaLateLoadedComponent,
-    data: { meta: LATE_LOADED_METADATA_JSON },
-    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
+    loadChildren: () => MetaLateLoadedModule,
   },
 ]
 

--- a/projects/ngx-meta/e2e/a16/src/app/app-routing.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/app-routing.module.ts
@@ -5,9 +5,15 @@ import { MetaSetByServiceComponent } from './meta-set-by-service/meta-set-by-ser
 import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.component'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
-import * as METADATA from '../../../cypress/fixtures/metadata.json'
+import * as METADATA_JSON from '../../../cypress/fixtures/metadata.json'
+import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
+import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from '../late-loaded-metadata'
 
-const metadataRouteData: MetadataRouteData = { meta: METADATA }
+const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
 const routes: Routes = [
   {
@@ -23,6 +29,12 @@ const routes: Routes = [
     path: ROUTES.metaSetByRouteAndService.path,
     component: MetaSetByRouteAndServiceComponent,
     data: metadataRouteData,
+  },
+  {
+    path: ROUTES.metaLateLoaded.path,
+    component: MetaLateLoadedComponent,
+    data: { meta: LATE_LOADED_METADATA_JSON },
+    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
   },
 ]
 

--- a/projects/ngx-meta/e2e/a16/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/app.module.ts
@@ -18,6 +18,7 @@ import {
 } from '@davidlj95/ngx-meta/open-graph'
 import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
 import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
+import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
     MetaSetByServiceComponent,
     MetaSetByRouteComponent,
     MetaSetByRouteAndServiceComponent,
+    MetaLateLoadedComponent,
   ],
   imports: [
     BrowserModule,

--- a/projects/ngx-meta/e2e/a16/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { MetaSetByServiceComponent } from './meta-set-by-service/meta-set-by-ser
 import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.component'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
 import { NgxMetaCoreModule } from '@davidlj95/ngx-meta/core'
-import * as DEFAULTS from '../../../cypress/fixtures/defaults.json'
+import * as DEFAULTS_JSON from '../../../cypress/fixtures/defaults.json'
 import { NgxMetaRoutingModule } from '@davidlj95/ngx-meta/routing'
 import { NgxMetaStandardModule } from '@davidlj95/ngx-meta/standard'
 import {
@@ -32,7 +32,7 @@ import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
     NgForOf,
     RouterOutlet,
     JsonPipe,
-    NgxMetaCoreModule.forRoot({ defaults: DEFAULTS }),
+    NgxMetaCoreModule.forRoot({ defaults: DEFAULTS_JSON }),
     NgxMetaRoutingModule.forRoot(),
     NgxMetaStandardModule,
     NgxMetaOpenGraphModule,

--- a/projects/ngx-meta/e2e/a16/src/app/app.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/app.module.ts
@@ -18,7 +18,6 @@ import {
 } from '@davidlj95/ngx-meta/open-graph'
 import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
 import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
-import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.component'
 
 @NgModule({
   declarations: [
@@ -26,7 +25,6 @@ import { MetaLateLoadedComponent } from './meta-late-loaded/meta-late-loaded.com
     MetaSetByServiceComponent,
     MetaSetByRouteComponent,
     MetaSetByRouteAndServiceComponent,
-    MetaLateLoadedComponent,
   ],
   imports: [
     BrowserModule,

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/late-loaded-metadata.ts
@@ -4,7 +4,7 @@ import {
   MetaService,
   provideMetadataFactory,
 } from '@davidlj95/ngx-meta/core'
-import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+import LATE_LOADED_METADATA_JSON from '../../../../cypress/fixtures/late-loaded-metadata.json'
 
 type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
 

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.html
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.html
@@ -1,0 +1,9 @@
+Metadata of this page has been set by a late loaded metadata manager. Source:
+
+<pre>{{ providerSource }}</pre>
+
+Then, metadata values were set using the following route data:
+
+<pre>{{ routeData | json }}</pre>
+
+Check the <code>&lt;head&gt;</code> HTML element of this page to see the results

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.html
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.html
@@ -1,4 +1,4 @@
-Metadata of this page has been set by a late loaded metadata manager. Source:
+Metadata of this page has been set by a late loaded metadata provider. Source:
 
 <pre>{{ providerSource }}</pre>
 

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core'
+import { ActivatedRoute } from '@angular/router'
+import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
+
+@Component({
+  selector: 'app-meta-late-loaded',
+  templateUrl: './meta-late-loaded.component.html',
+})
+export class MetaLateLoadedComponent {
+  protected readonly routeData: unknown
+  protected readonly providerSource: string
+
+  constructor(activatedRoute: ActivatedRoute) {
+    this.routeData = activatedRoute.snapshot.data
+    this.providerSource = provideLateLoadedMetadata.toString()
+  }
+}

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
-import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
+import { provideLateLoadedMetadata } from './late-loaded-metadata'
 
 @Component({
   selector: 'app-meta-late-loaded',

--- a/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.module.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-late-loaded/meta-late-loaded.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core'
+import { RouterModule } from '@angular/router'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from './late-loaded-metadata'
+import { NgxMetaMetadataLoaderModule } from '@davidlj95/ngx-meta/core'
+import { MetaLateLoadedComponent } from './meta-late-loaded.component'
+import { JsonPipe } from '@angular/common'
+
+@NgModule({
+  declarations: [MetaLateLoadedComponent],
+  imports: [
+    JsonPipe,
+    NgxMetaMetadataLoaderModule,
+    RouterModule.forChild([
+      {
+        path: '',
+        component: MetaLateLoadedComponent,
+        data: { meta: LATE_LOADED_METADATA_JSON },
+      },
+    ]),
+  ],
+  providers: [provideLateLoadedMetadata()],
+})
+export class MetaLateLoadedModule {}

--- a/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route/meta-set-by-route.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-set-by-route/meta-set-by-route.component.ts
@@ -8,7 +8,7 @@ import { ActivatedRoute } from '@angular/router'
 export class MetaSetByRouteComponent {
   protected readonly routeData: unknown
 
-  constructor(readonly activatedRoute: ActivatedRoute) {
+  constructor(activatedRoute: ActivatedRoute) {
     this.routeData = activatedRoute.snapshot.data
   }
 }

--- a/projects/ngx-meta/e2e/a16/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import * as METADATA from '../../../../cypress/fixtures/metadata.json'
+import * as METADATA_JSON from '../../../../cypress/fixtures/metadata.json'
 import { MetadataService } from '@davidlj95/ngx-meta/core'
 
 @Component({
@@ -7,7 +7,7 @@ import { MetadataService } from '@davidlj95/ngx-meta/core'
   templateUrl: './meta-set-by-service.component.html',
 })
 export class MetaSetByServiceComponent implements OnInit, OnDestroy {
-  protected readonly metadata = METADATA
+  protected readonly metadata = METADATA_JSON
 
   constructor(private readonly metadataService: MetadataService) {}
 

--- a/projects/ngx-meta/e2e/a16/src/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a16/src/late-loaded-metadata.ts
@@ -1,0 +1,28 @@
+import {
+  makeMetadata,
+  MetaProperty,
+  MetaService,
+  provideMetadataFactory,
+} from '@davidlj95/ngx-meta/core'
+import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+
+type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
+
+export const provideLateLoadedMetadata = () =>
+  provideMetadataFactory<string | undefined>(
+    makeMetadata([
+      'lateLoadedMetadata' satisfies keyof LateLoadedMetadata,
+      'content' satisfies keyof LateLoadedMetadata['lateLoadedMetadata'],
+    ]),
+    (metaService: MetaService) => (value) => {
+      metaService.set(
+        new MetaProperty({
+          keyName: LATE_LOADED_METADATA_JSON.lateLoadedMetadata.name,
+        }),
+        value,
+      )
+    },
+    [MetaService],
+  )
+
+export { LATE_LOADED_METADATA_JSON }

--- a/projects/ngx-meta/e2e/a16/tsconfig.app.json
+++ b/projects/ngx-meta/e2e/a16/tsconfig.app.json
@@ -5,7 +5,8 @@
     "outDir": "./out-tsc/app",
     "types": [],
     // To load JSON fixture data
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"]

--- a/projects/ngx-meta/e2e/a17/src/app/app.config.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/app.config.ts
@@ -6,7 +6,7 @@ import {
   provideNgxMetaCore,
   withNgxMetaDefaults,
 } from '@davidlj95/ngx-meta/core'
-import DEFAULTS from '../../../cypress/fixtures/defaults.json'
+import DEFAULTS_JSON from '../../../cypress/fixtures/defaults.json'
 import { provideNgxMetaRouting } from '@davidlj95/ngx-meta/routing'
 import { provideNgxMetaStandardMetadata } from '@davidlj95/ngx-meta/standard'
 import {
@@ -19,7 +19,7 @@ import { provideNgxMetaJsonLdMetadata } from '@davidlj95/ngx-meta/json-ld'
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    provideNgxMetaCore(withNgxMetaDefaults(DEFAULTS)),
+    provideNgxMetaCore(withNgxMetaDefaults(DEFAULTS_JSON)),
     provideNgxMetaRouting(),
     provideNgxMetaStandardMetadata(),
     provideNgxMetaOpenGraphMetadata(),

--- a/projects/ngx-meta/e2e/a17/src/app/app.routes.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/app.routes.ts
@@ -5,12 +5,7 @@ import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.c
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
 import METADATA_JSON from '../../../cypress/fixtures/metadata.json'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
-import { MetaLateLoaded } from './meta-late-loaded/meta-late-loaded.component'
-import {
-  LATE_LOADED_METADATA_JSON,
-  provideLateLoadedMetadata,
-} from '../late-loaded-metadata'
-import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
+import { META_LATE_LOADED_ROUTES } from './meta-late-loaded/meta-late-loaded.routes'
 
 const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
@@ -31,8 +26,6 @@ export const routes: Routes = [
   },
   {
     path: ROUTES.metaLateLoaded.path,
-    component: MetaLateLoaded,
-    data: { meta: LATE_LOADED_METADATA_JSON },
-    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
+    loadChildren: () => META_LATE_LOADED_ROUTES,
   },
 ]

--- a/projects/ngx-meta/e2e/a17/src/app/app.routes.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/app.routes.ts
@@ -3,10 +3,16 @@ import { MetaSetByServiceComponent } from './meta-set-by-service/meta-set-by-ser
 import { ROUTES } from '../../../cypress/fixtures/routes'
 import { MetaSetByRouteComponent } from './meta-set-by-route/meta-set-by-route.component'
 import { MetadataRouteData } from '@davidlj95/ngx-meta/routing'
-import METADATA from '../../../cypress/fixtures/metadata.json'
+import METADATA_JSON from '../../../cypress/fixtures/metadata.json'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
+import { MetaLateLoaded } from './meta-late-loaded/meta-late-loaded.component'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from '../late-loaded-metadata'
+import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
 
-const metadataRouteData: MetadataRouteData = { meta: METADATA }
+const metadataRouteData: MetadataRouteData = { meta: METADATA_JSON }
 
 export const routes: Routes = [
   {
@@ -22,5 +28,11 @@ export const routes: Routes = [
     path: ROUTES.metaSetByRouteAndService.path,
     component: MetaSetByRouteAndServiceComponent,
     data: metadataRouteData,
+  },
+  {
+    path: ROUTES.metaLateLoaded.path,
+    component: MetaLateLoaded,
+    data: { meta: LATE_LOADED_METADATA_JSON },
+    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
   },
 ]

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/late-loaded-metadata.ts
@@ -4,7 +4,7 @@ import {
   MetaService,
   provideMetadataFactory,
 } from '@davidlj95/ngx-meta/core'
-import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+import LATE_LOADED_METADATA_JSON from '../../../../cypress/fixtures/late-loaded-metadata.json'
 
 type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
 

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.html
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.html
@@ -1,0 +1,9 @@
+Metadata of this page has been set by a late loaded metadata manager. Source:
+
+<pre>{{ providerSource }}</pre>
+
+Then, metadata values were set using the following route data:
+
+<pre>{{ routeData | json }}</pre>
+
+Check the <code>&lt;head&gt;</code> HTML element of this page to see the results

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.html
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.html
@@ -1,4 +1,4 @@
-Metadata of this page has been set by a late loaded metadata manager. Source:
+Metadata of this page has been set by a late loaded metadata provider. Source:
 
 <pre>{{ providerSource }}</pre>
 

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,17 +1,20 @@
 import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
 import { JsonPipe } from '@angular/common'
+import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
 
 @Component({
-  selector: 'app-meta-set-by-route',
+  selector: 'app-meta-late-loaded',
   standalone: true,
   imports: [JsonPipe],
-  templateUrl: './meta-set-by-route.component.html',
+  templateUrl: './meta-late-loaded.component.html',
 })
-export class MetaSetByRouteComponent {
+export class MetaLateLoaded {
   protected readonly routeData: unknown
+  protected readonly providerSource: string
 
   constructor(activatedRoute: ActivatedRoute) {
     this.routeData = activatedRoute.snapshot.data
+    this.providerSource = provideLateLoadedMetadata.toString()
   }
 }

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
 import { JsonPipe } from '@angular/common'
-import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
+import { provideLateLoadedMetadata } from './late-loaded-metadata'
 
 @Component({
   selector: 'app-meta-late-loaded',
@@ -9,7 +9,7 @@ import { provideLateLoadedMetadata } from '../../late-loaded-metadata'
   imports: [JsonPipe],
   templateUrl: './meta-late-loaded.component.html',
 })
-export class MetaLateLoaded {
+export class MetaLateLoadedComponent {
   protected readonly routeData: unknown
   protected readonly providerSource: string
 

--- a/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.routes.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-late-loaded/meta-late-loaded.routes.ts
@@ -1,0 +1,16 @@
+import { Routes } from '@angular/router'
+import { MetaLateLoadedComponent } from './meta-late-loaded.component'
+import {
+  LATE_LOADED_METADATA_JSON,
+  provideLateLoadedMetadata,
+} from './late-loaded-metadata'
+import { provideNgxMetaMetadataLoader } from '@davidlj95/ngx-meta/core'
+
+export const META_LATE_LOADED_ROUTES: Routes = [
+  {
+    path: '',
+    component: MetaLateLoadedComponent,
+    data: { meta: LATE_LOADED_METADATA_JSON },
+    providers: [provideLateLoadedMetadata(), provideNgxMetaMetadataLoader()],
+  },
+]

--- a/projects/ngx-meta/e2e/a17/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import METADATA from '../../../../cypress/fixtures/metadata.json'
+import METADATA_JSON from '../../../../cypress/fixtures/metadata.json'
 import { MetadataService } from '@davidlj95/ngx-meta/core'
 import { JsonPipe } from '@angular/common'
 
@@ -10,7 +10,7 @@ import { JsonPipe } from '@angular/common'
   imports: [JsonPipe],
 })
 export class MetaSetByServiceComponent implements OnInit, OnDestroy {
-  protected readonly metadata = METADATA
+  protected readonly metadata = METADATA_JSON
 
   constructor(private readonly metadataService: MetadataService) {}
 

--- a/projects/ngx-meta/e2e/a17/src/late-loaded-metadata.ts
+++ b/projects/ngx-meta/e2e/a17/src/late-loaded-metadata.ts
@@ -1,0 +1,28 @@
+import {
+  makeMetadata,
+  MetaProperty,
+  MetaService,
+  provideMetadataFactory,
+} from '@davidlj95/ngx-meta/core'
+import LATE_LOADED_METADATA_JSON from '../../cypress/fixtures/late-loaded-metadata.json'
+
+type LateLoadedMetadata = typeof LATE_LOADED_METADATA_JSON
+
+export const provideLateLoadedMetadata = () =>
+  provideMetadataFactory<string | undefined>(
+    makeMetadata([
+      'lateLoadedMetadata' satisfies keyof LateLoadedMetadata,
+      'content' satisfies keyof LateLoadedMetadata['lateLoadedMetadata'],
+    ]),
+    (metaService: MetaService) => (value) => {
+      metaService.set(
+        new MetaProperty({
+          keyName: LATE_LOADED_METADATA_JSON.lateLoadedMetadata.name,
+        }),
+        value,
+      )
+    },
+    [MetaService],
+  )
+
+export { LATE_LOADED_METADATA_JSON }

--- a/projects/ngx-meta/e2e/cypress/e2e/defaults.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/defaults.spec.cy.ts
@@ -3,7 +3,7 @@ import {
   spyOnConsole,
   testNoConsoleLogsAreEmitted,
 } from '../support/no-console-logs-are-emitted'
-import DEFAULTS from '../fixtures/defaults.json'
+import DEFAULTS_JSON from '../fixtures/defaults.json'
 
 describe('Defaults', () => {
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('Defaults', () => {
   })
 
   it('should set default author', () => {
-    cy.fixture('defaults.json').then((defaults: typeof DEFAULTS) => {
+    cy.fixture('defaults.json').then((defaults: typeof DEFAULTS_JSON) => {
       cy.getMeta('author')
         .shouldHaveContent()
         .and('eq', defaults.standard.author)

--- a/projects/ngx-meta/e2e/cypress/e2e/meta-late-loaded.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-late-loaded.spec.cy.ts
@@ -1,0 +1,42 @@
+import { ROUTES } from '../fixtures/routes'
+import {
+  spyOnConsole,
+  testNoConsoleLogsAreEmitted,
+} from '../support/no-console-logs-are-emitted'
+import LATE_LOADED_METADATA_JSON from '../fixtures/late-loaded-metadata.json'
+
+describe('Meta late loaded', () => {
+  beforeEach(() => {
+    cy.visit(ROUTES.metaLateLoaded.path, {
+      onBeforeLoad(win: Cypress.AUTWindow) {
+        spyOnConsole(win)
+      },
+    })
+  })
+
+  testNoConsoleLogsAreEmitted()
+  it('should set late loaded metadata', () => {
+    cy.fixture('late-loaded-metadata.json').then(
+      (lateLoadedMetadata: typeof LATE_LOADED_METADATA_JSON) => {
+        cy.getMeta(lateLoadedMetadata.lateLoadedMetadata.name)
+          .shouldHaveContent()
+          .and('eq', lateLoadedMetadata.lateLoadedMetadata.content)
+      },
+    )
+  })
+
+  describe('when going to another route', () => {
+    beforeEach(() => {
+      cy.goToRootPage()
+    })
+
+    testNoConsoleLogsAreEmitted()
+    it('should unset late loaded metadata', () => {
+      cy.fixture('late-loaded-metadata.json').then(
+        (metadata: typeof LATE_LOADED_METADATA_JSON) => {
+          cy.getMeta(metadata.lateLoadedMetadata.name).should('not.exist')
+        },
+      )
+    })
+  })
+})

--- a/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
@@ -30,12 +30,9 @@ describe('Meta set by route and service', () => {
   testSetsAllTwitterCardMetadata({ card: 'summary_large_image' })
   testSetsJsonLd()
 
-  // noinspection DuplicatedCode
   describe('when going to another route', () => {
     beforeEach(() => {
-      const selector = `#${ROUTES.root.linkId}`
-      cy.get(selector).click()
-      cy.location('pathname').should('eq', ROUTES.root.path)
+      cy.goToRootPage()
     })
 
     testUnsetsAllStandardMetadata()

--- a/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route.spec.cy.ts
@@ -32,9 +32,7 @@ describe('Meta set by route', () => {
 
   describe('when going to another route', () => {
     beforeEach(() => {
-      const selector = `#${ROUTES.root.linkId}`
-      cy.get(selector).click()
-      cy.location('pathname').should('eq', ROUTES.root.path)
+      cy.goToRootPage()
     })
 
     testUnsetsAllStandardMetadata()

--- a/projects/ngx-meta/e2e/cypress/fixtures/late-loaded-metadata.json
+++ b/projects/ngx-meta/e2e/cypress/fixtures/late-loaded-metadata.json
@@ -1,0 +1,6 @@
+{
+  "lateLoadedMetadata": {
+    "name": "late-loaded",
+    "content": "dummy meta"
+  }
+}

--- a/projects/ngx-meta/e2e/cypress/fixtures/routes.ts
+++ b/projects/ngx-meta/e2e/cypress/fixtures/routes.ts
@@ -19,4 +19,9 @@ export const ROUTES = {
     displayName: 'Meta set by route and service',
     linkId: undefined,
   },
+  metaLateLoaded: {
+    path: 'meta-late-loaded',
+    displayName: 'Meta late loaded',
+    linkId: undefined,
+  },
 }

--- a/projects/ngx-meta/e2e/cypress/support/commands.ts
+++ b/projects/ngx-meta/e2e/cypress/support/commands.ts
@@ -37,6 +37,7 @@
 // }
 
 import Chainable = Cypress.Chainable
+import { ROUTES } from '../fixtures/routes'
 
 Cypress.Commands.add<'getMeta'>('getMeta', (name) => {
   cy.get(`meta[name="${name}"]`)
@@ -57,6 +58,12 @@ Cypress.Commands.add<'shouldHaveContent', Chainable<HTMLMetaElement>>(
   },
 )
 
+Cypress.Commands.add<'goToRootPage'>('goToRootPage', () => {
+  const selector = `#${ROUTES.root.linkId}`
+  cy.get(selector).click()
+  cy.location('pathname').should('eq', ROUTES.root.path)
+})
+
 // 👇 Make TypeScript happy (not in Cypress docs though)
 // https://stackoverflow.com/a/59499895/3263250
 export {}
@@ -64,6 +71,7 @@ export {}
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      goToRootPage(): Chainable<void>
       getMeta(name: string): Chainable<HTMLMetaElement>
       getMetaWithProperty(property: string): Chainable<HTMLMetaElement>
       shouldHaveContent(): Chainable<Subject>

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-metadata.ts
@@ -1,8 +1,8 @@
-import METADATA from '../fixtures/metadata.json'
+import METADATA_JSON from '../fixtures/metadata.json'
 
 export function testSetsAllOpenGraphMetadata(openGraphOverrides: object = {}) {
   it('should set all Open Graph metadata', () => {
-    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA) => {
+    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA_JSON) => {
       const metadata = {
         ...jsonMetadata,
         openGraph: {

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-profile-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-profile-metadata.ts
@@ -1,10 +1,10 @@
-import METADATA from '../fixtures/metadata.json'
+import METADATA_JSON from '../fixtures/metadata.json'
 
 export function testSetsAllOpenGraphProfileMetadata(
   openGraphProfileOverrides: object = {},
 ) {
   it('should set all Open Graph profile metadata', () => {
-    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA) => {
+    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA_JSON) => {
       const metadata = {
         ...jsonMetadata,
         openGraph: {

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-standard-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-standard-metadata.ts
@@ -1,8 +1,8 @@
-import METADATA from '../fixtures/metadata.json'
+import METADATA_JSON from '../fixtures/metadata.json'
 
 export function testSetsAllStandardMetadata() {
   it('should set all standard metadata', () => {
-    cy.fixture('metadata.json').then((metadata: typeof METADATA) => {
+    cy.fixture('metadata.json').then((metadata: typeof METADATA_JSON) => {
       cy.title().should('eq', metadata.title)
       cy.getMeta('description')
         .shouldHaveContent()

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-twitter-card-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-twitter-card-metadata.ts
@@ -1,10 +1,10 @@
-import METADATA from '../fixtures/metadata.json'
+import METADATA_JSON from '../fixtures/metadata.json'
 
 export function testSetsAllTwitterCardMetadata(
   twitterCardOverrides: object = {},
 ) {
   it('should set all Twitter card metadata', () => {
-    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA) => {
+    cy.fixture('metadata.json').then((jsonMetadata: typeof METADATA_JSON) => {
       const metadata = {
         ...jsonMetadata,
         twitterCard: {

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-json-ld.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-json-ld.ts
@@ -1,8 +1,8 @@
-import METADATA from '../fixtures/metadata.json'
+import METADATA_JSON from '../fixtures/metadata.json'
 
 export function testSetsJsonLd() {
   it('should set JSON LD metadata', () => {
-    cy.fixture('metadata.json').then((metadata: typeof METADATA) => {
+    cy.fixture('metadata.json').then((metadata: typeof METADATA_JSON) => {
       cy.get('script[type="application/ld+json"]').should(
         'have.text',
         JSON.stringify(metadata.jsonLd),

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-json-ld.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-json-ld.ts
@@ -1,9 +1,5 @@
-import METADATA from '../fixtures/metadata.json'
-
 export function testUnsetsJsonLd() {
   it('should unset JSON LD metadata', () => {
-    cy.fixture('metadata.json').then((metadata: typeof METADATA) => {
-      cy.get('script[type="application/ld+json"]').should('not.exist')
-    })
+    cy.get('script[type="application/ld+json"]').should('not.exist')
   })
 }

--- a/projects/ngx-meta/src/core/public-api.ts
+++ b/projects/ngx-meta/src/core/public-api.ts
@@ -6,6 +6,8 @@ export {
   provideCore as provideNgxMetaCore,
   withDefaults as withNgxMetaDefaults,
 } from './src/provide-core'
+export { provideMetadataLoader as provideNgxMetaMetadataLoader } from './src/provide-metadata-loader'
+export { MetadataLoaderModule as NgxMetaMetadataLoaderModule } from './src/metadata-loader.module'
 export * from './src/global-metadata'
 export * from './src/global-metadata-image'
 export * from './src/head-element-upsert-or-remove'

--- a/projects/ngx-meta/src/core/src/defaults-token.ts
+++ b/projects/ngx-meta/src/core/src/defaults-token.ts
@@ -2,5 +2,5 @@ import { InjectionToken } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 
 export const DEFAULTS_TOKEN = new InjectionToken<MetadataValues>(
-  ngDevMode ? 'Metadata defaults' : 'NgxMetaDefs',
+  ngDevMode ? 'NgxMeta Metadata defaults' : 'NgxMetaDefs',
 )

--- a/projects/ngx-meta/src/core/src/metadata-loader.module.ts
+++ b/projects/ngx-meta/src/core/src/metadata-loader.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core'
+import { METADATA_LOADER_PROVIDERS } from './provide-metadata-loader'
+
+@NgModule({
+  providers: [...METADATA_LOADER_PROVIDERS],
+})
+export class MetadataLoaderModule {}

--- a/projects/ngx-meta/src/core/src/metadata-loader.ts
+++ b/projects/ngx-meta/src/core/src/metadata-loader.ts
@@ -1,0 +1,22 @@
+import { FactoryProvider, InjectionToken, SkipSelf } from '@angular/core'
+import { MetadataRegistry } from './metadata-registry'
+
+export type MetadataLoader = () => void
+
+export const METADATA_LOADER = new InjectionToken(
+  ngDevMode ? 'NgxMeta loader provider' : 'NgxMetaLP',
+)
+export const METADATA_LOADER_FACTORY: (
+  ...deps: Exclude<FactoryProvider['deps'], undefined>
+) => MetadataLoader =
+  (globalRegistry: MetadataRegistry, localRegistry: MetadataRegistry) => () => {
+    const localMetadata = localRegistry.getAll()
+    for (const metadata of localMetadata) {
+      globalRegistry.register(metadata)
+    }
+  }
+export const METADATA_LOADER_PROVIDER: FactoryProvider = {
+  provide: METADATA_LOADER,
+  useFactory: METADATA_LOADER_FACTORY,
+  deps: [[MetadataRegistry, new SkipSelf()], [MetadataRegistry]],
+}

--- a/projects/ngx-meta/src/core/src/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/metadata-registry.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Optional } from '@angular/core'
 import { MetadataProvider } from './metadata-provider'
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class MetadataRegistry {
   private readonly byId = new Map<string, MetadataProvider<unknown>>()
 

--- a/projects/ngx-meta/src/core/src/provide-core.ts
+++ b/projects/ngx-meta/src/core/src/provide-core.ts
@@ -7,10 +7,12 @@ import { MetadataValues } from './metadata-values'
 import { DEFAULTS_TOKEN } from './defaults-token'
 import { HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER } from './head-element-upsert-or-remove'
 import { METADATA_RESOLVER_PROVIDER } from './metadata-resolver'
+import { MetadataRegistry } from './metadata-registry'
 
 export const CORE_PROVIDERS = [
   HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER,
   METADATA_RESOLVER_PROVIDER,
+  MetadataRegistry,
 ]
 
 export function provideCore(

--- a/projects/ngx-meta/src/core/src/provide-metadata-loader.ts
+++ b/projects/ngx-meta/src/core/src/provide-metadata-loader.ts
@@ -1,0 +1,20 @@
+import { ENVIRONMENT_INITIALIZER, Provider } from '@angular/core'
+import {
+  METADATA_LOADER,
+  METADATA_LOADER_PROVIDER,
+  MetadataLoader,
+} from './metadata-loader'
+import { MetadataRegistry } from './metadata-registry'
+
+export const METADATA_LOADER_PROVIDERS: Provider[] = [
+  MetadataRegistry,
+  METADATA_LOADER_PROVIDER,
+  {
+    provide: ENVIRONMENT_INITIALIZER,
+    multi: true,
+    useFactory: (loader: MetadataLoader) => () => loader(),
+    deps: [METADATA_LOADER],
+  },
+]
+
+export const provideMetadataLoader = (): Provider[] => METADATA_LOADER_PROVIDERS


### PR DESCRIPTION
You may want to set some metadata but just for some part of the site. To allow improving _First Contentful Paint_, you may then want to load metadata providers handling that metadata just when the user visits that part of the site. To do so, introducing a module that will allow this. Otherwise, you may provide some `MetadataProvider` to the injection system, but the `MetadataService` and the `RouterListenerService` are global. So they are already injected and won't reach those new providers.

To allow the use case, the global `MetadataRegistry` is called when the metadata loader is provided, to ensure new providers can be read by globally-injected services.

Other changes:
 - Remove `readonly` from e2e app component constructors `activatedRoute` arg if no need to store it as instance property
 - Add `_JSON` suffix to loaded JSONs in E2E apps
 - Add `NgxMeta` to injection tokens to be able to identify them quicker
 - Allow default synth exports in v15/v16 e2e apps. Otherwise, a weird error appeared despite importing with `x as * from`
 - Add Cypress `goToRoot` to reduce duplication when navigating away current route.

TODO: ~Use module in Angular v15 & v16~