### PR TITLE
feat: add clear API to metadata service

### DIFF
--- a/projects/ngx-meta/e2e/a15/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a15/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -18,6 +18,6 @@ export class MetaSetByServiceComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     //👇 Clear metadata when changing page
     //   If you have enabled the routing module, this is not needed
-    this.metadataService.set()
+    this.metadataService.clear()
   }
 }

--- a/projects/ngx-meta/e2e/a16/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a16/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -18,6 +18,6 @@ export class MetaSetByServiceComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     //👇 Clear metadata when changing page
     //   If you have enabled the routing module, this is not needed
-    this.metadataService.set()
+    this.metadataService.clear()
   }
 }

--- a/projects/ngx-meta/e2e/a17/src/app/meta-set-by-service/meta-set-by-service.component.ts
+++ b/projects/ngx-meta/e2e/a17/src/app/meta-set-by-service/meta-set-by-service.component.ts
@@ -21,6 +21,6 @@ export class MetaSetByServiceComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     //👇 Clear metadata when changing page
     //   If you have enabled the routing module, this is not needed
-    this.metadataService.set()
+    this.metadataService.clear()
   }
 }

--- a/projects/ngx-meta/src/core/src/metadata.service.ts
+++ b/projects/ngx-meta/src/core/src/metadata.service.ts
@@ -16,4 +16,7 @@ export class MetadataService {
       metadata.set(this.resolver(metadata.metadata, values))
     }
   }
+  public clear(): void {
+    this.set()
+  }
 }


### PR DESCRIPTION
To avoid `this.metadataService.set()` calls. It's not 100% clear the intention of it
