### PR TITLE
chore: avoid importing EventType to compile with v17.1

### DIFF
--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
@@ -10,6 +10,11 @@ import {
   NgxMetaService,
 } from '@davidlj95/ngx-meta/core'
 
+// WTF is this? Well, compatibility reasons 🙃
+// See https://github.com/davidlj95/ngx/pull/246 for the details
+// https://github.com/angular/angular/blob/17.1.1/packages/router/src/events.ts#L32
+export const NAVIGATION_END_EVENT_TYPE: EventType = 1
+
 @Injectable({ providedIn: 'root' })
 export class NgxMetaRouterListenerService implements OnDestroy {
   // Replace by `takeUntilDestroyed` when stable
@@ -38,7 +43,7 @@ export class NgxMetaRouterListenerService implements OnDestroy {
     }
 
     this.sub = this.router.events
-      .pipe(filter(({ type }) => type === EventType.NavigationEnd))
+      .pipe(filter(({ type }) => type === NAVIGATION_END_EVENT_TYPE))
       .subscribe({
         next: () => {
           if (!this.strategy) {

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, OnDestroy, Optional } from '@angular/core'
-import { ActivatedRoute, EventType, Router } from '@angular/router'
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router'
 import { filter, Subscription } from 'rxjs'
 import {
   NGX_META_ROUTE_STRATEGY,
@@ -10,10 +10,9 @@ import {
   NgxMetaService,
 } from '@davidlj95/ngx-meta/core'
 
-// WTF is this? Well, compatibility reasons 🙃
+// WTF is this? Why not just import `EventType`? Well, compatibility reasons 🙃
 // See https://github.com/davidlj95/ngx/pull/246 for the details
-// https://github.com/angular/angular/blob/17.1.1/packages/router/src/events.ts#L32
-export const NAVIGATION_END_EVENT_TYPE: EventType = 1
+export const NAVIGATION_END_EVENT_TYPE = new NavigationEnd(0, '', '').type
 
 @Injectable({ providedIn: 'root' })
 export class NgxMetaRouterListenerService implements OnDestroy {


### PR DESCRIPTION
E2E tests of the PR to upgrade the Angular version to compile the library to v17.1 (from v17.0.8) failed. Specifically, v16 tests:

https://github.com/davidlj95/ngx/actions/runs/7676450436/job/20924021745

Error:

`./node_modules/@davidlj95/ngx-meta/fesm2022/davidlj95-ngx-meta-routing.mjs:27:[21](https://github.com/davidlj95/ngx/actions/runs/7676450436/job/20924021745#step:7:22)-44 - Error: export 'EventType' (imported as 'EventType') was not found in '@angular/router' (possible exports: {long list where you can't find EventType in there})`

After some digging, seems that actually `EventType` isn't there in Angular v16.2.12
https://www.npmjs.com/package/@angular/router/v/16.2.12?activeTab=code

Check the `esm2022/src/index.mjs` file for instance:

`export { ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, GuardsCheckEnd, GuardsCheckStart, ... } from './events';`

What happened? Seems it's never been there 🤔 However, it appeared in v17.1.0:
https://www.npmjs.com/package/@angular/router/v/17.1.0?activeTab=code

Now it's there!

`export { ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, **EventType**, GuardsCheckEnd, GuardsCheckStart, ... } from './events';`

So then if we compile with Angular v17.1.x we'll import the `EventType`. But that will produce a file that isn't compatible with Angular v16 or v15 given that isn't exported there.

Specifically, before Angular v17.1.x the compiled file was:

```typescript
import * as i1 from '@angular/router'; (only)
// ...

this.sub = this.router.events
  .pipe(filter(({ type }) => type === 1 /* EventType.NavigationEnd */))
```

And after the update:

```typescript
import * as i1 from '@angular/router';
import { EventType } from '@angular/router'; // NEW! But doesn't exist before v17.1

this.sub = this.router.events
  .pipe(filter(({ type }) => type === EventType.NavigationEnd))
```

This seems related to https://github.com/angular/angular/pull/51670 . Though seems it may be reverted at some point: https://github.com/angular/angular/pull/53753

~Anyway, to avoid this missing import in older versions, hardcoding the value of the `NavigationEnd` event type. Which has always been 1. This will hardly ever change.~ That was dangerous

Workaround proposed is to create a `NavigationEnd` object, that contains the type. So we can access it without importing it directly. `NavigationEnd` has been exported in older versions.