### PR TITLE
docs: update ngx-meta desc

### DIFF
--- a/projects/ngx-meta/docs/content/index.md
+++ b/projects/ngx-meta/docs/content/index.md
@@ -1,4 +1,4 @@
-# Hello World! 👋
+# Hello World!
 
 Angular SSR
 

--- a/projects/ngx-meta/docs/mkdocs.yml
+++ b/projects/ngx-meta/docs/mkdocs.yml
@@ -3,9 +3,9 @@ site_url: https://ngx-meta.pages.dev
 repo_url: https://github.com/davidlj95/ngx
 site_description: >
   Set your Angular site's metadata: standard meta tags, Open Graph,
-  Twitter cards, JSON-LD structured data & more.
+  Twitter cards, JSON-LD structured data and more.
   Supports SSR (and Angular Universal).
-  Use a service and/or route's data.
+  Use a service. Use routes' data.
   Set it up in a flash! 🚀
 site_author: davidlj95
 copyright: MIT License

--- a/projects/ngx-meta/src/README.md
+++ b/projects/ngx-meta/src/README.md
@@ -20,9 +20,9 @@
 [![Package manager: pnpm](https://img.shields.io/badge/Package_manager-pnpm-f69220?logo=pnpm&link=https%3A%2F%2Fpnpm.io%2F)](https://pnpm.io/)
 
 Set your Angular site's metadata: [standard meta tags], [Open Graph],
-[Twitter cards], JSON-LD [structured data] & more.
-Supports [SSR][angular-ssr] (and Angular Universal).
-Use a service and/or route's data.
+[Twitter cards], JSON-LD [structured data] and more.
+Supports SSR (and Angular Universal).
+Use a service. Use routes' data.
 Set it up in a flash! 🚀
 
 [title-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title

--- a/projects/ngx-meta/src/package.json
+++ b/projects/ngx-meta/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@davidlj95/ngx-meta",
   "version": "0.0.0-PLACEHOLDER",
-  "description": "Set your Angular site's metadata: standard meta tags, Open Graph, Twitter cards, JSON-LD structured data & more. Supports SSR (and Angular Universal). Use a service and/or route's data. Set it up in a flash! 🚀",
+  "description": "Set your Angular site's metadata: standard meta tags, Open Graph, Twitter cards, JSON-LD structured data and more. Supports SSR (and Angular Universal). Use a service. Use routes' data. Set it up in a flash! 🚀",
   "keywords": [
     "angular",
     "angular2",


### PR DESCRIPTION
Social card eventuall was ending with `(and `. Now it's great!

![index](https://github.com/davidlj95/ngx/assets/8050648/68740294-3626-4d6b-92ca-173c0d972929)

Color can't be set to theme's color until insider feature gets released
