### PR TITLE
ci: move tsc to build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ jobs:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
     with:
-      artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta-dist
+      tsc-artifact-name: ngx-meta-tsc
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -27,7 +28,7 @@ jobs:
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
-      build-artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta
     permissions:
       checks: write
   release:
@@ -35,7 +36,7 @@ jobs:
     needs: [e2e]
     uses: ./.github/workflows/reusable-release.yml
     with:
-      build-artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta-dist
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
       github-token-pr: ${{ secrets.PR_GH_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,8 @@ jobs:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
     with:
-      artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta-dist
+      tsc-artifact-name: ngx-meta-tsc
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -23,7 +24,7 @@ jobs:
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
-      build-artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta-dist
     permissions:
       pull-requests: write
   docs:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -42,3 +42,23 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: 'projects/ngx-meta/dist'
           retention-days: 5
+  tsc:
+    name: TypeScript compilation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Run tsc
+        run: cd .ci && make tsc
+      - name: Upload compiled JS files
+        if: ${{ inputs.artifact-name != '' }}
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: 'projects/ngx-meta/out'
+          retention-days: 5

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -7,7 +7,11 @@ on:
         type: string
         required: false
         default: ''
-      artifact-name:
+      dist-artifact-name:
+        description: Artifact name containing built lib
+        type: string
+        required: false
+      tsc-artifact-name:
         description: Artifact name containing built lib
         type: string
         required: false
@@ -36,10 +40,10 @@ jobs:
       - name: Build libraries
         run: cd .ci && make build
       - name: Upload distribution files
-        if: ${{ inputs.artifact-name != '' }}
+        if: ${{ inputs.dist-artifact-name != '' }}
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.dist-artifact-name }}
           path: 'projects/ngx-meta/dist'
           retention-days: 5
   tsc:
@@ -56,9 +60,9 @@ jobs:
       - name: Run tsc
         run: cd .ci && make tsc
       - name: Upload compiled JS files
-        if: ${{ inputs.artifact-name != '' }}
+        if: ${{ inputs.tsc-artifact-name != '' }}
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.tsc-artifact-name }}
           path: 'projects/ngx-meta/out'
           retention-days: 5

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -2,7 +2,7 @@ name: E2E
 on:
   workflow_call:
     inputs:
-      build-artifact-name:
+      dist-artifact-name:
         required: true
         type: string
       ref:
@@ -44,7 +44,7 @@ jobs:
       - name: Download distribution files
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4
         with:
-          name: ${{ inputs.build-artifact-name }}
+          name: ${{ inputs.dist-artifact-name }}
           path: 'projects/ngx-meta/dist'
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -23,20 +23,6 @@ jobs:
       - name: Run linter
         run: cd .ci && make lint
 
-  tsc:
-    name: TypeScript compilation
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Run tsc
-        run: cd .ci && make tsc
-
   commit-messages:
     name: Commit messages
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   workflow_call:
     inputs:
-      build-artifact-name:
+      dist-artifact-name:
         required: true
         type: string
     secrets:
@@ -46,7 +46,7 @@ jobs:
       - name: Download distribution files
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4
         with:
-          name: ${{ inputs.build-artifact-name }}
+          name: ${{ inputs.dist-artifact-name }}
           path: 'projects/ngx-meta/dist'
       - name: Release
         env:


### PR DESCRIPTION
Belongs more there. Also, adding an upload step that will later be used by API Extractor to generate an API report + docs

Updates GitHub `main` branch protection rules to require build / tsc step (and don't require the not anymore existing lint / tsc)
