### PR TITLE
ci: refer to proper build artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
-      dist-artifact-name: ngx-meta
+      dist-artifact-name: ngx-meta-dist
     permissions:
       checks: write
   release:


### PR DESCRIPTION
After changing artifact names, workflow in `main` failed due to that:
https://github.com/davidlj95/ngx/actions/runs/7787845219/job/21235937811

Tried to use `env` constants to refer to those but that can't be using `env` 
https://github.com/orgs/community/discussions/26671

so just fixing it to move on
