### PR TITLE
docs: add API Reference docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,10 @@ jobs:
       id-token: write
   docs:
     name: Docs
-    needs: [e2e]
+    needs: [release, api-extractor]
     uses: ./.github/workflows/reusable-docs.yml
+    with:
+      api-docs-artifact-name: ngx-meta-api-docs
     secrets:
       cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,8 +35,11 @@ jobs:
     permissions:
       pull-requests: write
   docs:
+    needs: [api-extractor]
     name: Docs
     uses: ./.github/workflows/reusable-docs.yml
+    with:
+      api-docs-artifact-name: ngx-meta-api-docs
     secrets:
       cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -7,6 +7,10 @@ on:
         type: string
         required: false
         default: ''
+    api-docs-artifact-name:
+      description: Artifact name containing API reference markdown docs
+      type: string
+      required: false
     secrets:
       cloudflare-account-id:
         required: true
@@ -37,6 +41,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Download API reference docs
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4
+        with:
+          name: ${{ inputs.api-docs-artifact-name }}
+          path: 'projects/ngx-meta/docs/content/api'
       - name: Install poetry # pipx comes built-in in GitHub runner
         run: pipx install poetry
       - name: Setup Python

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -7,10 +7,10 @@ on:
         type: string
         required: false
         default: ''
-    api-docs-artifact-name:
-      description: Artifact name containing API reference markdown docs
-      type: string
-      required: false
+      api-docs-artifact-name:
+        description: Artifact name containing API reference markdown docs
+        type: string
+        required: false
     secrets:
       cloudflare-account-id:
         required: true

--- a/projects/ngx-meta/docs/mkdocs.yml
+++ b/projects/ngx-meta/docs/mkdocs.yml
@@ -22,7 +22,9 @@ nav:
       - built-in-modules/open-graph.md
       - built-in-modules/twitter-cards.md
       - built-in-modules/json-ld.md
+  - API Reference: api/ngx-meta.md
   - changelog.md
+not_in_nav: api/*.md
 # From here below, all for Material for mkdocs
 repo_name: davidlj95/ngx
 theme:


### PR DESCRIPTION
Uses #271 API Reference markdown docs output to include it in docs
