### PR TITLE
docs: link module types to API Reference

### DIFF
--- a/.idea/runConfigurations/ngx_meta__API_Documenter.xml
+++ b/.idea/runConfigurations/ngx_meta__API_Documenter.xml
@@ -7,6 +7,8 @@
     </scripts>
     <node-interpreter value="project" />
     <envs />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="ngx-meta: API Extractor (local)" run_configuration_type="js.build_tools.npm" />
+    </method>
   </configuration>
 </component>

--- a/projects/ngx-meta/docs/content/built-in-modules/index.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/index.md
@@ -1,1 +1,3 @@
-Library provides a series of modules to help you set common metadata. Check out each module for more info about what metadata it can set.
+Library provides a series of built-in modules to help you set common metadata.
+
+Check out each module in the sidenav on the left 👈 (or in the hamburger menu if using mobile version) for more info about how to add the module and what metadata it can set.

--- a/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
@@ -11,16 +11,16 @@ The module allows you to embed a JSON-LD object inside a `#!html <script>` tag (
 ## Setup
 
 === "For non-standalone, module-based apps"
-Add `NgxMetaJsonLdModule` to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
+Add [`NgxMetaJsonLdModule`](../api/ngx-meta.ngxmetajsonldmodule.md) to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
 
 === "For standalone, module-free apps"
-Add `provideNgxMetaJsonLd()` to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
+Add [`provideNgxMetaJsonLd()`](../api/ngx-meta.providengxmetajsonld.md) to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
 
 ## Types
 
 Following Typescript types provide you with all implemented metadata:
 
-- `JsonLdMetadata`
+- [`JsonLdMetadata`](../api/ngx-meta.jsonldmetadata.md)
 
 ## Resources
 

--- a/projects/ngx-meta/docs/content/built-in-modules/open-graph.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/open-graph.md
@@ -17,26 +17,26 @@ Contains the essential to set up Open Graph metadata. They will allow you to set
 Specifically, manages [basic](https://ogp.me/#metadata) and [optional](https://ogp.me/#optional) metadata
 
 === "For non-standalone, module-based apps"
-Add `NgxMetaOpenGraphModule` to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
+Add [`NgxMetaOpenGraphModule`](../api/ngx-meta.ngxmetaopengraphmodule.md) to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
 
 === "For standalone, module-free apps"
-Add `provideNgxMetaOpenGraph()` to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
+Add [`provideNgxMetaOpenGraph()`](../api/ngx-meta.providengxmetaopengraph.md) to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
 
 ### Profile
 
 Manages [profile](https://ogp.me/#type_profile) non-vertical metadata
 
 === "For non-standalone, module-based apps"
-Add `NgxMetaOpenGraphProfileModule` to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
+Add [`NgxMetaOpenGraphProfileModule`](../api/ngx-meta.ngxmetaopengraphprofilemodule.md) to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
 
 === "For standalone, module-free apps"
-Add `provideNgxMetaOpenGraphProfile()` to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
+Add [`provideNgxMetaOpenGraphProfile()`](../api/ngx-meta.providengxmetaopengraphprofile.md) to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
 
 ## Types
 
 Following Typescript types provide you with all implemented metadata:
 
-- `OpenGraphMetadata`
+- [`OpenGraphMetadata`](../api/ngx-meta.opengraphmetadata.md)
 
 ## Platforms reading Open Graph metadata
 

--- a/projects/ngx-meta/docs/content/built-in-modules/standard.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/standard.md
@@ -9,16 +9,16 @@ Depending on what metadata you need to set, add one of more of the following mod
 ### Main
 
 === "For non-standalone, module-based apps"
-Add `NgxMetaStandardModule` to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
+Add [`NgxMetaStandardModule`](../api/ngx-meta.ngxmetastandardmodule.md) to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
 
 === "For standalone, module-free apps"
-Add `provideNgxMetaStandard()` to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
+Add [`provideNgxMetaStandard()`](../api/ngx-meta.providengxmetastandard.md) to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
 
 ## Types
 
 Following Typescript types provide you with all implemented metadata:
 
-- `StandardMetadata`
+- [`StandardMetadata`](../api/ngx-meta.standardmetadata.md)
 
 ## Resources
 

--- a/projects/ngx-meta/docs/content/built-in-modules/twitter-cards.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/twitter-cards.md
@@ -15,16 +15,16 @@ Depending on what metadata you need to set, add one of more of the Twitter Card 
 To set the Twitter Card type or the basic _summary_ or _summary large_ cards, you can use the main Twitter Cards module
 
 === "For non-standalone, module-based apps"
-Add `NgxMetaTwitterCardModule` to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
+Add [`NgxMetaTwitterCardModule`](../api/ngx-meta.ngxmetatwittercardmodule.md) to your module-based app's `app.module.ts` file. Checkout [get started setup] for more details.
 
 === "For standalone, module-free apps"
-Add `provideNgxMetaTwitterCard()` to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
+Add [`provideNgxMetaTwitterCard()`](../api/ngx-meta.providengxmetatwittercard.md) to your standalone app's `app.config.ts` file providers. Checkout [get started setup] for more details.
 
 ## Types
 
 Following Typescript types provide you with all implemented metadata:
 
-- `TwitterCardMetadata`
+- [`TwitterCardMetadata`](../api/ngx-meta.twittercard.md)
 
 ## Resources
 

--- a/projects/ngx-meta/docs/content/get-started.md
+++ b/projects/ngx-meta/docs/content/get-started.md
@@ -84,13 +84,13 @@ export class CoolPageComponent implements OnInit {
 
 That's it, you should see the `#!html <title>` and `#!html <meta name="description">` set in that page with the values you provided ✨
 
-[Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set. Later we'll get into what's that `GlobalMetadata` type
+[Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set. Later we'll get into what's that [`GlobalMetadata`](./api/ngx-meta.globalmetadata.md) type
 
 Check out the [Angular v17 example app]'s [`meta-set-by-service.component.ts` file](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/e2e/a17/src/app/meta-set-by-service/meta-set-by-service.component.ts) for a full component file example
 
 !!! info "Metadata set by service won't be cleared by default"
 
-    Metadata set (in the example, `#!html <title>` and `#!html <meta name="description">`) will stay when the route changes if the routing module / provider hasn't been added. If you want those metadata values to get removed when changing route without adding the routing module / provider, you can add a call to the service on the `ngOnDestroy` hook:
+    Metadata set (in the example, `#!html <title>` and `#!html <meta name="description">`) will stay when the route changes if the routing module / provider hasn't been added. If you want those metadata values to get removed when changing route without adding the routing module / provider, you can add a call to the service on the [`ngOnDestroy`](https://angular.dev/guide/components/lifecycle#ngondestroy) hook:
 
     ```typescript
     @Component({
@@ -134,7 +134,7 @@ export const routes: Routes = [
 
 That's it, you should see the `#!html <title>` and `#!html <meta name='description'>` set in the `cool-page` page with the values you provided ✨
 
-As with the service case, [Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set. Later it will be explained what's that `GlobalMetadata` type
+As with the service case, [Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set. Later it will be explained what's that [`GlobalMetadata`](./api/ngx-meta.globalmetadata.md) type
 
 Check out the [Angular v17 example app] [`app.routes.ts` file](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/e2e/a17/src/app/app.routes.ts) for a full routes file example
 
@@ -144,17 +144,17 @@ A forth step? You lied to me 😢 Well you had some metadata in your site at end
 
 Now, do you wonder what metadata can you set? Typescript types can help you.
 
-Following the example, inspect `GlobalMetadata` and `StandardMetadata` types to see all values you can set.
+Following the example, inspect [`GlobalMetadata`](./api/ngx-meta.globalmetadata.md) and [`StandardMetadata`](./api/ngx-meta.standardmetadata.md) types to see all values you can set.
 
 ### Global metadata
 
-`GlobalMetadata` defines metadata values that will be used by several modules. For instance, the `title` will be used by standard module to set the page's `#!html <title>`. But it will also be used by [Open Graph] module (if added) to set the `#!html <meta property='og:title'>` element.
+[`GlobalMetadata`](./api/ngx-meta.globalmetadata.md) defines metadata values that will be used by several modules. For instance, the `title` will be used by standard module to set the page's `#!html <title>`. But it will also be used by [Open Graph] module (if added) to set the `#!html <meta property='og:title'>` element.
 
 ### Module metadata
 
-`StandardMetadata` defines metadata values that will be used only by the standard module. That's why all values should be placed under the `standard` key.
+[`StandardMetadata`](./api/ngx-meta.standardmetadata.md) defines metadata values that will be used only by the standard module. That's why all values should be placed under the `standard` key.
 
-You can inspect what metadata can be set using that module. And which of those can be set as global ones so they're also shared with other modules. If you specify a module value and a global value, specific will take preference.
+You can inspect what metadata can be set using that module. And which of those can be set as global ones, so they're also shared with other modules. If you specify a module value and a global value, specific will take preference.
 
 For instance if setting those values (either using service or route data):
 

--- a/projects/ngx-meta/src/core/src/global-metadata.ts
+++ b/projects/ngx-meta/src/core/src/global-metadata.ts
@@ -1,77 +1,76 @@
 import { GlobalMetadataImage } from './global-metadata-image'
 
 /**
- * Diggity daggity doo
+ * Specifies metadata that will be used by more than one module
  *
  * @public
  */
 export interface GlobalMetadata {
   /**
-   * Sets
-   *  - Standard `<title>` HTML element
-   *  - Open Graph title (if Open Graph module present)
-   *  - Twitter Card title (if Twitter card module present)
+   * Sets title for:
+   *
+   *  - {@link Standard.title} (needs standard module)
+   *
+   *  - {@link OpenGraph.title} (needs Open Graph module)
+   *
+   *  - {@link TwitterCard.title} (needs Twitter Cards module)
    */
   readonly title?: string
 
   /**
-   * Sets
-   *  - Standard `<meta name='description'>` HTML element
-   *  - Open Graph description (if Open Graph module present)
-   *  - Twitter Card description (if Twitter card module present)
+   * Sets description for:
    *
-   * Recommendations:
-   *  - Open Graph: 1 or 2 sentences for Open Graph
-   *  - Twitter Card: 200 characters for Twitter card
+   *  - {@link Standard.description} (needs standard module)
    *
-   * See specific details in each module
+   *  - {@link OpenGraph.description} (needs Open Graph module)
+   *
+   *  - {@link TwitterCard.description} (needs Twitter Cards module)
    */
   readonly description?: string | null
 
   /**
-   * Sets
-   *  - Standard `<meta name='application-name'>` HTML element
-   *  - Open Graph site name (if Open Graph module present)
+   * Sets application name for:
    *
-   * Recommendations:
-   *  - Standard: must not be used if the page is not a web application
+   *  - {@link Standard.applicationName} (needs standard module)
+   *
+   *  - {@link OpenGraph.siteName} (needs Open Graph module)
    */
   readonly applicationName?: string | null
 
   /**
-   * Sets
-   *  - Standard `<link rel='canonical'>` HTML element
-   *  - Open Graph URL (if Open Graph module present)
+   * Sets canonical URL for:
    *
-   * Recommendations:
-   *  - Standard: check standard doc links
+   *  - {@link Standard.canonicalUrl} (needs standard module)
+   *
+   *  - {@link OpenGraph.url} (needs Open Graph module)
    */
   readonly canonicalUrl?: URL | string | null
 
   /**
-   * Language & localization of this page
+   * Sets localization of this page
    *
    * Value must be a valid language tag complying with BCP 47
-   * For instance: "es" or "es-ES"
+   * For instance: "`es`" or "`es-ES`"
    *
-   * Sets the
-   *  - Standard `lang` attribute to the `<html>` element
-   *  - Open Graph locale (if Open Graph module present)
+   * For:
    *
-   * @see https://datatracker.ietf.org/doc/html/rfc5646 (BCP 47)
+   *  - {@link Standard.locale} (needs standard module)
+   *
+   *  - {@link OpenGraph.locale} (needs Open Graph module)
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc5646 | RFC 5646/BCP 47}
    */
   readonly locale?: string | null
 
   /**
-   * Image metadata for this page
+   * Sets image (will be used for link previews / social cards) for
    *
-   * If present, will use it as image for Open Graph and/or Twitter Cards, even
-   * if the `image` property for those is not set
+   * - {@link OpenGraph.image} (needs standard module)
    *
-   * Does nothing if neither Open Graph nor Twitter Cards modules are present
+   * - {@link TwitterCard.image} (needs Twitter Cards module)
    *
-   * Open Graph allows for more attributes for the image. Specify Open Graph
-   * image if you want to customize those too.
+   * Open Graph allows for more attributes for the image.
+   * Specify {@link OpenGraph.image} if you want to customize those too.
    */
   readonly image?: GlobalMetadataImage | null
 }

--- a/projects/ngx-meta/src/open-graph/src/open-graph.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph.ts
@@ -85,6 +85,8 @@ export interface OpenGraph {
   /**
    * Open Graph profile metadata for this page
    *
+   * <b>Requires Open Graph Profile module / provider to work</b>
+   *
    * @see https://ogp.me/#type_profile
    */
   readonly profile?: OpenGraphProfile


### PR DESCRIPTION
Also, improve `GlobalMetadata` interface docs, linking which specific metadata each property sets.

Makes IDE config `API Documenter` depend on `API Extractor` for quicker feedback loop when improving docs