### PR TITLE
build(deps-dev): pin pnpm, cache, cypress actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
     - name: Setup Node.js
       uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
       with:

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -55,7 +55,7 @@ jobs:
           cache: 'poetry'
           cache-dependency-path: '${{ env.DOCS_DIR }}/poetry.lock'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
@@ -67,7 +67,7 @@ jobs:
       - name: Generate cache id for Mkdocs build
         run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - name: Cache Mkdocs build
-        uses: actions/cache@v4
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: '${{ env.DOCS_DIR }}/.cache'

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -47,7 +47,7 @@ jobs:
           name: ${{ inputs.dist-artifact-name }}
           path: 'projects/ngx-meta/dist'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Start Angular v${{ matrix.version }} E2E app server
         run: pnpm start &
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a # v6
         with:
           wait-on: 'http://localhost:4200'
           working-directory: ${{ env.E2E_DIR }}


### PR DESCRIPTION
Renovate is having an issue with:
 - `pnpm`, `cypress` pinning given no exact version is given (`v2`/`v6` don't exist per se)
 - `cache`: seems due to Python `.python-version` not being able to pin?
