### PR TITLE
docs: mark internal APIs as internal

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -21,29 +21,29 @@ export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER: FactoryProvider;
 
 // Warning: (ae-forgotten-export) The symbol "JSON_LD_KEY" needs to be exported by the entry point all-entry-points.d.ts
 //
-// @public (undocumented)
+// @internal (undocumented)
 export const __JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<JsonLdMetadata[typeof JSON_LD_KEY]>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY: (metaService: NgxMetaMetaService) => (value: OpenGraph[typeof GLOBAL_IMAGE]) => void;
 
 // Warning: (ae-forgotten-export) The symbol "KEY_2" needs to be exported by the entry point all-entry-points.d.ts
 //
-// @public (undocumented)
+// @internal (undocumented)
 export const __STANDARD_GENERATOR_METADATA_SETTER_FACTORY: MetadataSetterFactory<Standard[typeof KEY_2]>;
 
 // Warning: (ae-forgotten-export) The symbol "KEY" needs to be exported by the entry point all-entry-points.d.ts
 //
-// @public (undocumented)
+// @internal (undocumented)
 export const __STANDARD_KEYWORDS_METADATA_SETTER_FACTORY: MetadataSetterFactory<Standard[typeof KEY]>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const __STANDARD_LOCALE_METADATA_SETTER_FACTORY: MetadataSetterFactory<Standard[typeof GLOBAL_LOCALE]>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const __STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<Standard[typeof GLOBAL_TITLE]>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _COMPOSED_KEY_VAL_META_DEFINITION_DEFAULT_SEPARATOR = ":";
 
 // Warning: (ae-forgotten-export) The symbol "CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts
@@ -96,10 +96,10 @@ export interface GlobalMetadataImage {
     readonly url: string | URL;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _HEAD_ELEMENT_UPSERT_OR_REMOVE: InjectionToken<_HeadElementUpsertOrRemove>;
 
-// @public (undocumented)
+// @internal (undocumented)
 export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
 
 // @public (undocumented)
@@ -119,10 +119,10 @@ const KEY: keyof Standard;
 // @public (undocumented)
 const KEY_2: keyof Standard;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _KEY_ATTRIBUTE_NAME = "name";
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _KEY_ATTRIBUTE_PROPERTY = "property";
 
 // Warning: (ae-forgotten-export) The symbol "MakeComposedKeyValMetaDefinitionOpts" needs to be exported by the entry point all-entry-points.d.ts
@@ -147,7 +147,7 @@ export const makeKeyValMetaDefinition: (opts: {
 // @public (undocumented)
 type MakeKeyValMetaDefinitionOpts = Parameters<typeof makeKeyValMetaDefinition>[0];
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _makeMetadata: <T>(id: string, resolverOptions: MetadataResolverOptions, set: MetadataSetter<T>) => NgxMetaMetadata<T>;
 
 // @public (undocumented)
@@ -158,7 +158,7 @@ export const makeMetadataProviderFromSetterFactory: <T>(setterFactory: MetadataS
     g?: string;
 }) => FactoryProvider;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global']) => MetadataResolverOptions;
 
 // @public (undocumented)
@@ -248,7 +248,7 @@ export interface NgxMetaRouteData<M = MetadataValues> {
     meta: M;
 }
 
-// @public (undocumented)
+// @internal (undocumented)
 export class _NgxMetaRouteValuesService {
     constructor(router: Router);
     // (undocumented)
@@ -498,7 +498,7 @@ export const TWITTER_CARD_TYPE_SUMMARY = "summary";
 export const TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE = "summary_large_image";
 
 // @public
-export class TwitterCard {
+export interface TwitterCard {
     readonly card?: TwitterCardType | null;
     readonly creator?: TwitterCardCreator;
     readonly description?: string | null;
@@ -552,7 +552,7 @@ export interface TwitterCardSiteUsername {
 // @public (undocumented)
 export type TwitterCardType = typeof TWITTER_CARD_TYPE_SUMMARY | typeof TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE | typeof TWITTER_CARD_TYPE_APP | typeof TWITTER_CARD_TYPE_PLAYER;
 
-// @public (undocumented)
+// @internal (undocumented)
 export const _VAL_ATTRIBUTE_CONTENT = "content";
 
 // @public (undocumented)

--- a/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.ts
+++ b/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.ts
@@ -18,11 +18,17 @@ export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_FACTORY =
     doc.head.appendChild(element)
   }
 
+/**
+ * @internal
+ */
 export type _HeadElementUpsertOrRemove = (
   selector: string,
   element: HTMLElement | null | undefined,
 ) => void
 
+/**
+ * @internal
+ */
 export const _HEAD_ELEMENT_UPSERT_OR_REMOVE =
   new InjectionToken<_HeadElementUpsertOrRemove>(
     ngDevMode ? 'NgxMeta head element upsert or remove util' : 'NgxMetaHEUOR',

--- a/projects/ngx-meta/src/core/src/make-composed-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/make-composed-key-val-meta-definition.ts
@@ -21,4 +21,8 @@ export const makeComposedKeyValMetaDefinition = (
       opts.separator ?? _COMPOSED_KEY_VAL_META_DEFINITION_DEFAULT_SEPARATOR,
     ),
   })
+
+/**
+ * @internal
+ */
 export const _COMPOSED_KEY_VAL_META_DEFINITION_DEFAULT_SEPARATOR = ':'

--- a/projects/ngx-meta/src/core/src/make-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/make-key-val-meta-definition.ts
@@ -12,6 +12,15 @@ export const makeKeyValMetaDefinition = (opts: {
     selector: `${keyAttr}='${opts.keyName}'`,
   }
 }
+/**
+ * @internal
+ */
 export const _KEY_ATTRIBUTE_NAME = 'name'
+/**
+ * @internal
+ */
 export const _KEY_ATTRIBUTE_PROPERTY = 'property'
+/**
+ * @internal
+ */
 export const _VAL_ATTRIBUTE_CONTENT = 'content'

--- a/projects/ngx-meta/src/core/src/ngx-meta-metadata.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-metadata.ts
@@ -11,6 +11,9 @@ export interface MetadataResolverOptions {
 
 export type MetadataSetter<T> = (value: T) => void
 
+/**
+ * @internal
+ */
 export const _makeMetadata = <T>(
   id: NgxMetaMetadata<T>['id'],
   resolverOptions: NgxMetaMetadata<T>['resolverOptions'],
@@ -21,6 +24,9 @@ export const _makeMetadata = <T>(
   set,
 })
 
+/**
+ * @internal
+ */
 export const _makeMetadataResolverOptions = (
   jsonPath: MetadataResolverOptions['jsonPath'],
   global?: MetadataResolverOptions['global'],

--- a/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 import { Router } from '@angular/router'
 
+/**
+ * @internal
+ */
 @Injectable()
 export class _NgxMetaRouteValuesService {
   private url?: string

--- a/projects/ngx-meta/src/json-ld/src/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/json-ld-metadata-provider.ts
@@ -10,6 +10,9 @@ import { JsonLdMetadata } from './json-ld-metadata'
 const JSON_LD_KEY: keyof JsonLdMetadata = 'jsonLd'
 const SCRIPT_TYPE = 'application/ld+json'
 
+/**
+ * @internal
+ */
 export const __JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   JsonLdMetadata[typeof JSON_LD_KEY]
 > =

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -12,6 +12,9 @@ const NO_KEY_VALUE: OpenGraph[typeof GLOBAL_IMAGE] = {
   height: null,
 }
 
+/**
+ * @internal
+ */
 export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
   (metaService: NgxMetaMetaService) =>
   (value: OpenGraph[typeof GLOBAL_IMAGE]) => {

--- a/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.ts
@@ -9,6 +9,9 @@ import { makeStandardMetaDefinition } from './make-standard-meta-definition'
 
 const KEY: keyof Standard = 'generator'
 
+/**
+ * @internal
+ */
 export const __STANDARD_GENERATOR_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   Standard[typeof KEY]
 > = (metaService: NgxMetaMetaService) => (value) =>

--- a/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.ts
@@ -8,6 +8,9 @@ import { makeStandardMetaDefinition } from './make-standard-meta-definition'
 
 const KEY: keyof Standard = 'keywords'
 
+/**
+ * @internal
+ */
 export const __STANDARD_KEYWORDS_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   Standard[typeof KEY]
 > = (metaService: NgxMetaMetaService) => (value) =>

--- a/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.ts
@@ -4,6 +4,10 @@ import { DOCUMENT } from '@angular/common'
 import { Standard } from './standard'
 
 const ATTRIBUTE_NAME = 'lang'
+
+/**
+ * @internal
+ */
 export const __STANDARD_LOCALE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   Standard[typeof GLOBAL_LOCALE]
 > = (doc: Document) => (locale) => {

--- a/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.ts
@@ -3,6 +3,9 @@ import { Standard } from './standard'
 import { Title } from '@angular/platform-browser'
 import { GLOBAL_TITLE, MetadataSetterFactory } from '@davidlj95/ngx-meta/core'
 
+/**
+ * @internal
+ */
 export const __STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   Standard[typeof GLOBAL_TITLE]
 > = (titleService: Title) => (value) => {

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card.ts
@@ -10,7 +10,7 @@ import { TwitterCardCreator } from './twitter-card-creator'
  * @see https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
  * @see https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
  */
-export class TwitterCard {
+export interface TwitterCard {
   /**
    * The card type
    *


### PR DESCRIPTION
So they don't appear in API Reference docs

\+ they don't miss the release tag
