### PR TITLE
build(deps-dev): update pnpm/action-setup to v3.0.0 (major)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
+      uses: pnpm/action-setup@v3.0.0
     - name: Setup Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
       with:

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -55,7 +55,7 @@ jobs:
           cache: 'poetry'
           cache-dependency-path: '${{ env.DOCS_DIR }}/poetry.lock'
       - name: Setup pnpm
-        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
+        uses: pnpm/action-setup@v3.0.0
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -47,7 +47,7 @@ jobs:
           name: ${{ inputs.dist-artifact-name }}
           path: 'projects/ngx-meta/dist'
       - name: Setup pnpm
-        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2
+        uses: pnpm/action-setup@v3.0.0
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:


### PR DESCRIPTION
Manually, as seems Renovate is having issues with this action and Cypress setup one

```
Dependency Lookup Warnings
Renovate failed to look up the following dependencies:

Could not determine new digest for update (github-tags package pnpm/action-setup), Could not determine new digest for update (github-tags package cypress-io/github-action)

Files affected:

.github/actions/setup/action.yml, .github/workflows/reusable-docs.yml, .github/workflows/reusable-e2e.yml
```
