### PR TITLE
docs: do not report bundle size diff

### DIFF
--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -70,5 +70,5 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.result }}
-          body-path: bundle-size-report.md
+          body-path: bundle-size-pr-comment.md
           edit-mode: replace

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -56,6 +56,7 @@ jobs:
         run: pnpm run source-map-explorer-json
       - name: Fetch bundle size analysis results from 'main' branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        if: github.event_name == 'pull_request'
         with:
           script: |
             const checkRunResponse = await github.rest.checks.listForRef({
@@ -74,18 +75,25 @@ jobs:
             const smeJsonString = checkRun.output.text
             const fs = require('fs')
             fs.writeFileSync('${{ env.E2E_APP_DIR }}/source-map-explorer-main.json', smeJsonString)
-      - name: Generate bundle size report
+      - name: Generate bundle size PR comment
+        if: github.event_name == 'pull_request'
         run: |
           pnpm run bundle-size-report \
           --git-ref '${{ github.event.pull_request.head.sha }}' \
           --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.version }}' \
-          --base-file 'source-map-explorer-main.json'
+          --base-file 'source-map-explorer-main.json' \
+          --output-file 'bundle-size-pr-comment.md'
+      - name: Generate bundle size report
+        run: |
+          pnpm run bundle-size-report \
+          --git-ref '${{ github.event.pull_request.head.sha }}'
       - name: Upload bundle size analysis results
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
           name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.version }}
           path: |
             ${{ env.E2E_APP_DIR }}/source-map-explorer*.json
+            ${{ env.E2E_APP_DIR }}/bundle-size-pr-comment.md
             ${{ env.E2E_APP_DIR }}/bundle-size-report.md
           retention-days: 5
 

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -84,9 +84,7 @@ jobs:
           --base-file 'source-map-explorer-main.json' \
           --output-file 'bundle-size-pr-comment.md'
       - name: Generate bundle size report
-        run: |
-          pnpm run bundle-size-report \
-          --git-ref '${{ github.event.pull_request.head.sha }}'
+        run: pnpm run bundle-size-report --git-ref '${{ github.sha }}'
       - name: Upload bundle size analysis results
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ pnpm-lock.yaml
 # Ignored given local .gitignore files
 Pipfile.lock
 projects/ngx-meta/e2e/a*/bundle-size-report.md
+projects/ngx-meta/e2e/a*/bundle-size-pr-comment.md
 projects/ngx-meta/docs/site
 projects/ngx-meta/docs/.venv
 projects/ngx-meta/docs/content/fonts/**

--- a/projects/ngx-meta/e2e/.gitignore
+++ b/projects/ngx-meta/e2e/.gitignore
@@ -12,6 +12,7 @@ cypress/videos/*
 
 # End of https://www.toptal.com/developers/gitignore/api/cypressio
 a*/bundle-size-report.md
+a*/bundle-size-pr-comment.md
 a*/source-map-explorer*.json
 # Manual edits
 # - Add bundle size report markdown file

--- a/projects/ngx-meta/e2e/bundle-size-report.sh
+++ b/projects/ngx-meta/e2e/bundle-size-report.sh
@@ -88,7 +88,7 @@ echo "### 📦 Bundle size ($header)" >"$output_file"
     echo "<!-- $hidden_info -->"
   fi
   if [ -n "$git_ref" ]; then
-    echo "Git ref: $git_ref"
+    echo "Git ref: [$git_ref](https://github.com/davidlj95/ngx/commit/$git_ref)"
   fi
   echo ""
   printf "| Module file | Size |"

--- a/projects/ngx-meta/e2e/bundle-size-report.sh
+++ b/projects/ngx-meta/e2e/bundle-size-report.sh
@@ -88,7 +88,7 @@ echo "### 📦 Bundle size ($header)" >"$output_file"
     echo "<!-- $hidden_info -->"
   fi
   if [ -n "$git_ref" ]; then
-    echo "Git ref: [$git_ref](https://github.com/davidlj95/ngx/commit/$git_ref)"
+    echo "[Git ref: \`$git_ref\`](https://github.com/davidlj95/ngx/commit/$git_ref)"
   fi
   echo ""
   printf "| Module file | Size |"


### PR DESCRIPTION
It's a bit weird. And add an explicit link to Git ref for bundle size reports included in docs
