### PR TITLE
docs: move prebuild to script + allow missing bundle size reports

### DIFF
--- a/projects/ngx-meta/docs/Makefile
+++ b/projects/ngx-meta/docs/Makefile
@@ -4,23 +4,7 @@ build: prebuild
 	poetry run mkdocs build
 
 prebuild:
-	mkdir -p content/fonts
-	# `cp -L` is required.
-	# In GitHub Actions, symlinks are used and copied symlinks are invalid
-	# https://github.com/davidlj95/ngx/actions/runs/7741714508/job/21109249970
-	cp -Lr node_modules/@fontsource* content/fonts
-	find content/fonts -name '*.md' -delete
-	# Everything but last 4 lines
-	sed "$$(($$(wc -l < ../src/README.md)-4)),\$$d" ../src/README.md | \
-		sed "s|../docs/content||g" | \
-		sed "s/> \([A-Z]\)/    \1/g" | \
-		sed "s/> \[!IMPORTANT\]/!!! warning \"Alpha version\"\n/g" \
-		> includes/README.md
-	cp ../src/CHANGELOG.md includes/
-	# Bundle size
-	cp ../e2e/a15/bundle-size-report.md includes/a15-bundle-size-report.md
-	cp ../e2e/a16/bundle-size-report.md includes/a16-bundle-size-report.md
-	cp ../e2e/a17/bundle-size-report.md includes/a17-bundle-size-report.md
+	./prebuild.sh
 
 install:
 	poetry install --no-root

--- a/projects/ngx-meta/docs/prebuild.sh
+++ b/projects/ngx-meta/docs/prebuild.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# Prepares the documentation site before building
+CONTENTS_DIR="content"
+INCLUDES_DIR="includes"
+
+# 🆎 Fonts
+FONTS_DIR="$CONTENTS_DIR/fonts"
+
+echo "ℹ️ Copying downloaded fonts"
+mkdir -p "$FONTS_DIR"
+# 👇 `cp -L` is required
+# In GitHub Actions, symlinks are used and copied symlinks are invalid
+# https://github.com/davidlj95/ngx/actions/runs/7741714508/job/21109249970
+cp -Lr "node_modules/@fontsource"* "content/fonts"
+find "$FONTS_DIR" -name '*.md' -delete
+
+# 🏡 README.md
+echo "ℹ️ Copying trimmed README file"
+README_FILENAME="README.md"
+README_FILE="../src/$README_FILENAME"
+TAIL_LINES_TO_TRIM=4
+# Everything but last x lines
+sed "$(($(wc -l < $README_FILE) - TAIL_LINES_TO_TRIM)),\$d" $README_FILE |
+  sed "s|../docs/content||g" | # Fix logo path
+  sed "s/> \([A-Z]\)/    \1/g" | # Remove quoted block + proper admonition 👇
+  sed "s/> \[!IMPORTANT\]/!!! warning \"Alpha version\"\n/g" \
+    > "$INCLUDES_DIR/$README_FILENAME"
+
+# 📅 CHANGELOG.md
+echo "ℹ️ Copying CHANGELOG file"
+cp ../src/CHANGELOG.md "$INCLUDES_DIR/"
+
+# 📦 Bundle size
+echo "ℹ️ Copying bundle size reports"
+e2e_app_dir_pattern="../e2e/a"
+for e2e_app_dir in "$e2e_app_dir_pattern"*; do
+  version="$(echo "$e2e_app_dir" | sed "s|$e2e_app_dir_pattern||g")"
+  report_filename="bundle-size-report.md"
+  report_file="$e2e_app_dir/$report_filename"
+  destination_file="includes/a$version-$report_filename"
+
+  if [ -r "$report_file" ]; then
+    cp "$report_file" "$destination_file"
+    echo "ℹ️ Copying Angular v$version E2E app bundle size report"
+  else
+    echo "⚠️ Bundle size report for version $version not found"
+  fi
+done


### PR DESCRIPTION
# Proposed changes
Allows to build docs site with missing bundle size reports (useful locally in dev)

Moves script with tasks needed before building doc site to a script, as:
 - `Makefile` was getting convoluted
 - Writing scripts in `Makefile` needs escaping `$`, which can be a PIA


# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
