### PR TITLE
docs: add more references to global / specific

### DIFF
--- a/projects/ngx-meta/docs/content/guides/set-metadata-using-service.md
+++ b/projects/ngx-meta/docs/content/guides/set-metadata-using-service.md
@@ -64,7 +64,11 @@ export class CoolPageComponent implements OnInit {
 
 That would alter the existing title, but leave rest of metadata elements as they are. Here the `#!typescript satisfies keyof GlobalMetadata` would ensure that `title` actually refers to a global key. For more information about the metadata values JSON, check [its guide](metadata-values-json.md)
 
-If instead you wanted to alter keywords, which is specified under the `standard` key:
+!!! note "Title is a global: many metadata elements may change"
+
+    Given `title` is specified as a global key. So `#!html <title>` element will be changed if [standard module] is present. But `#!html <meta property="og:title">` will be also changed if [Open Graph module] is present.
+
+If instead you wanted to alter keywords, which is specified under the standard's module `standard` key:
 
 ```javascript
 {

--- a/projects/ngx-meta/docs/includes/routing-usage.md
+++ b/projects/ngx-meta/docs/includes/routing-usage.md
@@ -23,6 +23,8 @@ export const routes: Routes = [
 
 That's it, you should see the `#!html <title>`, `#!html <meta name="description">` and `#!html <meta name="keywords">` set in that page with the values you provided ✨
 
+--8<-- "includes/title-description-global.md"
+
 As with the service case, [Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set.
 
 **The [`NgxMetaRouteData`](ngx-meta.ngxmetaroutedata.md) utility type** ensures route data is inside `meta` key of the route's data.

--- a/projects/ngx-meta/docs/includes/service-usage.md
+++ b/projects/ngx-meta/docs/includes/service-usage.md
@@ -25,6 +25,8 @@ export class CoolPageComponent implements OnInit {
 
 That's it, you should see the `#!html <title>`, `#!html <meta name="description">` and `#!html <meta name="keywords">` set in that page with the values you provided ✨
 
+--8<-- "includes/title-description-global.md"
+
 [Typescript's `satisfies` operator][typescript-satisfies] will help you write the proper JSON of metadata values to set. Take a look at [metadata values JSON guide](metadata-values-json.md) for more information about this values JSON.
 
 Check out the [Angular v17 example app]'s [`all-meta-set-by-service.component.ts` file](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/e2e/a17/src/app/all-meta-set-by-service/all-meta-set-by-service.component.ts) for a full component file example

--- a/projects/ngx-meta/docs/includes/title-description-global.md
+++ b/projects/ngx-meta/docs/includes/title-description-global.md
@@ -1,0 +1,3 @@
+!!! note "Title and description may set other metadata elements"
+
+    Given they are specified in global scope. For instance, `#!html <meta property="og:title">` and `#!html <meta property="og:description">` will be set if [Open Graph module] has been added.


### PR DESCRIPTION
# Proposed changes
Explains in get started about global keys setting multiple metadata elements. It's an important concept users should be aware as early as possible.

Adds clarification in `setOne` API docs about many metadata elements changing if setting a global metadata value.

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
