### PR TITLE
build(deps): use app config in Renovate for main pkg.json

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,13 +14,14 @@
   timezone: 'Europe/Madrid',
   labels: ['dependencies'],
   packageRules: [
-    // Library for main, app for E2E apps
+    // App for main / E2E apps (main one isn't published)
+    // Lib for published package JSONs
     {
-      matchFileNames: ['package.json'],
+      matchFileNames: ['projects/ngx-meta/src/package.json'],
       extends: ['config:js-lib'],
     },
     {
-      matchFileNames: ['projects/ngx-meta/e2e/**/*'],
+      matchFileNames: ['package.json', 'projects/ngx-meta/e2e/**/*'],
       extends: ['config:js-app'],
     },
     // Semantic commit messages & PR titles. Mocks @dependabot ones:


### PR DESCRIPTION
# Proposed changes

Uses Renovate `config:js-app` for main `package.json`. We can pin all deps, given they're used for build (that `package.json` won't be published)

Uses Renovate `config:js-lib` for published `ngx-meta` `package.json` 

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
