### PR TITLE
ci: add retries to bundle size PR comment job

### DIFF
--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -45,6 +45,11 @@ jobs:
         id: pr
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
+          retries: 3
+          #👇 Default except 403, which is the rate limit sometimes raised
+          # https://github.com/davidlj95/ngx/actions/runs/8362399318/job/22892884496
+          # https://github.com/octokit/plugin-retry.js/blob/v7.0.3/src/index.ts#L14
+          retry-exempt-status-codes: 400,401,404,422,451
           script: |
             const response = await github.rest.search.issuesAndPullRequests({
               q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',


### PR DESCRIPTION
# Proposed changes
Adds retries when rate limit is reached for PR bundle size comment job

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

Fixes issue #456
