### PR TITLE
ci: allow dependabot long commit message lines

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -1,0 +1,35 @@
+import { RuleConfigSeverity, UserConfig } from '@commitlint/types'
+import * as child_process from 'child_process'
+import { promisify } from 'util'
+import configConventional from '@commitlint/config-conventional'
+
+const COMMITLINT_CONFIG: UserConfig = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': async () => {
+      // Dependabot writes long message lines
+      // Can't be customized right now to avoid that behaviour
+      // https://github.com/dependabot/dependabot-core/issues/1460
+      // We have to make an exception then
+      // Only checking last commit as dependabot only commits once per PR
+      if (await lastCommitIsFromDependabot()) {
+        return [RuleConfigSeverity.Disabled]
+      }
+      return configConventional.rules['body-max-line-length']
+    },
+  },
+}
+
+const lastCommitIsFromDependabot = async () => {
+  const lastCommitAuthor = (
+    await asyncExec("git show -s --format='%an'", {
+      encoding: 'utf-8',
+    })
+  ).stdout.trim()
+  return lastCommitAuthor === DEPENDABOT_AUTHOR_NAME
+}
+
+const asyncExec = promisify(child_process.exec)
+const DEPENDABOT_AUTHOR_NAME = 'dependabot[bot]'
+
+export default COMMITLINT_CONFIG

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-}


### PR DESCRIPTION
# Proposed changes
See https://github.com/davidlj95/website/pull/328

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
