### PR TITLE
refactor: add "@/ngx-meta/test" path mapping

### DIFF
--- a/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 
 import { MockProvider, MockProviders } from 'ng-mocks'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
 import { MetadataValues } from './metadata-values'
 import { Provider } from '@angular/core'

--- a/projects/ngx-meta/src/core/src/ngx-meta-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-meta.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing'
 import { NgxMetaMetaService } from './ngx-meta-meta.service'
 import { MockProvider } from 'ng-mocks'
 import { Meta } from '@angular/platform-browser'
-import { enableAutoSpy } from '@davidlj95/ngx-meta/__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { makeKeyValMetaDefinition } from './make-key-val-meta-definition'
 
 describe('NgxMeta meta service', () => {

--- a/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 
 import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MockProviders } from 'ng-mocks'
 import { Router } from '@angular/router'
 

--- a/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 import { NgxMetaService } from './ngx-meta.service'
 import { MockProvider, MockProviders } from 'ng-mocks'
 import { makeMetadataManagerSpy } from './__tests__/make-metadata-manager-spy'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { METADATA_RESOLVER, MetadataResolver } from './metadata-resolver'
 import { MetadataRegistry } from './metadata-registry'
 

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 import { MockProviders } from 'ng-mocks'
 import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { OpenGraphImage } from './open-graph-image'
 import { OpenGraph } from './open-graph'
 import { __OPEN_GRAPH_IMAGE_SETTER_FACTORY } from './open-graph-image-metadata-provider'

--- a/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
 import { VERSION } from '@angular/core'
 import { Standard } from './standard'

--- a/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
 import { Standard } from './standard'
 import { __STANDARD_KEYWORDS_METADATA_SETTER_FACTORY } from './standard-keywords-metadata-provider'

--- a/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.spec.ts
@@ -1,4 +1,4 @@
-import { enableAutoSpy } from '../../__tests__/enable-auto-spy'
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
 import { Title } from '@angular/platform-browser'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,8 @@
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "paths": {
-      // 👇 Changed to add secondary entry points
-      // "ngx-meta": ["./dist/ngx-meta"],
       "@davidlj95/ngx-meta/*": ["./projects/ngx-meta/src/*"],
-      "@davidlj95/ngx-meta": ["./projects/ngx-meta/src"]
+      "@/ngx-meta/test/*": ["./projects/ngx-meta/src/__tests__/*"]
     },
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
# Proposed changes
Add `@test` path mapping to reduce changes in test helpers imports

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
