### PR TITLE
chore: remove unneeded describe in resolver tests

### DIFF
--- a/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
@@ -20,155 +20,150 @@ import { _makeMetadataResolverOptions } from './ngx-meta-metadata-manager'
 describe('Metadata resolver', () => {
   enableAutoSpy()
 
-  describe('get', () => {
-    const dummyResolverOptions = _makeMetadataResolverOptions(['dummy'])
-    const dummyValues = { foo: 'bar' }
-    const value = 'value'
-    const valueObject = {
-      value: 'value',
-      prop: 'value',
-    }
-    const routeValues = { route: 'values' }
-    let jsonResolver: jasmine.Spy<MetadataJsonResolver>
-    let routeMetadataValues: jasmine.SpyObj<_NgxMetaRouteValuesService>
-    let sut: MetadataResolver
+  const dummyResolverOptions = _makeMetadataResolverOptions(['dummy'])
+  const dummyValues = { foo: 'bar' }
+  const value = 'value'
+  const valueObject = {
+    value: 'value',
+    prop: 'value',
+  }
+  const routeValues = { route: 'values' }
+  let jsonResolver: jasmine.Spy<MetadataJsonResolver>
+  let routeMetadataValues: jasmine.SpyObj<_NgxMetaRouteValuesService>
+  let sut: MetadataResolver
 
-    function mockJsonResolver(returnMap: Map<MetadataValues, unknown>) {
-      jsonResolver.and.callFake((values) =>
-        returnMap.get(values as MetadataValues),
-      )
-    }
-    function injectSpies() {
-      jsonResolver = TestBed.inject(
-        METADATA_JSON_RESOLVER,
-      ) as jasmine.Spy<MetadataJsonResolver>
-      routeMetadataValues = TestBed.inject(
-        _NgxMetaRouteValuesService,
-      ) as jasmine.SpyObj<_NgxMetaRouteValuesService>
-    }
+  function mockJsonResolver(returnMap: Map<MetadataValues, unknown>) {
+    jsonResolver.and.callFake((values) =>
+      returnMap.get(values as MetadataValues),
+    )
+  }
+  function injectSpies() {
+    jsonResolver = TestBed.inject(
+      METADATA_JSON_RESOLVER,
+    ) as jasmine.Spy<MetadataJsonResolver>
+    routeMetadataValues = TestBed.inject(
+      _NgxMetaRouteValuesService,
+    ) as jasmine.SpyObj<_NgxMetaRouteValuesService>
+  }
 
-    describe('when value exists in provided values', () => {
-      beforeEach(() => {
-        sut = makeSut()
-        injectSpies()
-        mockJsonResolver(new Map([[dummyValues, value]]))
-      })
-
-      it('should resolve value using values', () => {
-        sut(dummyValues, dummyResolverOptions)
-
-        expect(jsonResolver).toHaveBeenCalledWith(
-          dummyValues,
-          dummyResolverOptions,
-        )
-      })
-
-      it('should return its value', () => {
-        expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
-      })
+  describe('when value exists in provided values', () => {
+    beforeEach(() => {
+      sut = makeSut()
+      injectSpies()
+      mockJsonResolver(new Map([[dummyValues, value]]))
     })
 
-    describe('when route metadata values exist', () => {
+    it('should resolve value using values', () => {
+      sut(dummyValues, dummyResolverOptions)
+
+      expect(jsonResolver).toHaveBeenCalledWith(
+        dummyValues,
+        dummyResolverOptions,
+      )
+    })
+
+    it('should return its value', () => {
+      expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
+    })
+  })
+
+  describe('when route metadata values exist', () => {
+    beforeEach(() => {
+      sut = makeSut()
+      injectSpies()
+      routeMetadataValues.get.and.returnValue(routeValues)
+      mockJsonResolver(new Map([[routeValues, value]]))
+    })
+
+    it('should resolve value using route metadata values', () => {
+      sut(dummyValues, dummyResolverOptions)
+
+      expect(routeMetadataValues.get).toHaveBeenCalledOnceWith()
+      expect(jsonResolver).toHaveBeenCalledWith(
+        routeValues,
+        dummyResolverOptions,
+      )
+    })
+
+    it('should return value obtained from route metadata values', () => {
+      expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
+    })
+  })
+
+  describe('when defaults exist', () => {
+    const defaults = { default: 'values' }
+    beforeEach(() => {
+      sut = makeSut({ defaults })
+      injectSpies()
+      mockJsonResolver(new Map([[defaults, value]]))
+    })
+
+    it('should resolve value using default values', () => {
+      sut(dummyValues, dummyResolverOptions)
+
+      expect(jsonResolver).toHaveBeenCalledWith(defaults, dummyResolverOptions)
+    })
+
+    it('should return value obtained from defaults', () => {
+      expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
+    })
+  })
+
+  describe('when value exists in values object and route values', () => {
+    describe('when value is an object', () => {
+      const routeValueObject = {
+        routeValue: 'routeValue',
+        prop: 'routeValue',
+      }
+
       beforeEach(() => {
         sut = makeSut()
         injectSpies()
         routeMetadataValues.get.and.returnValue(routeValues)
-        mockJsonResolver(new Map([[routeValues, value]]))
-      })
-
-      it('should resolve value using route metadata values', () => {
-        sut(dummyValues, dummyResolverOptions)
-
-        expect(routeMetadataValues.get).toHaveBeenCalledOnceWith()
-        expect(jsonResolver).toHaveBeenCalledWith(
-          routeValues,
-          dummyResolverOptions,
+        mockJsonResolver(
+          new Map<MetadataValues, unknown>([
+            [routeValues, routeValueObject],
+            [dummyValues, valueObject],
+          ]),
         )
       })
 
-      it('should return value obtained from route metadata values', () => {
-        expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
-      })
-    })
-
-    describe('when defaults exist', () => {
-      const defaults = { default: 'values' }
-      beforeEach(() => {
-        sut = makeSut({ defaults })
-        injectSpies()
-        mockJsonResolver(new Map([[defaults, value]]))
-      })
-
-      it('should resolve value using default values', () => {
-        sut(dummyValues, dummyResolverOptions)
-
-        expect(jsonResolver).toHaveBeenCalledWith(
-          defaults,
-          dummyResolverOptions,
-        )
-      })
-
-      it('should return value obtained from defaults', () => {
-        expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
-      })
-    })
-
-    describe('when value exists in values object and route values', () => {
-      describe('when value is an object', () => {
-        const routeValueObject = {
-          routeValue: 'routeValue',
-          prop: 'routeValue',
-        }
-
-        beforeEach(() => {
-          sut = makeSut()
-          injectSpies()
-          routeMetadataValues.get.and.returnValue(routeValues)
-          mockJsonResolver(
-            new Map<MetadataValues, unknown>([
-              [routeValues, routeValueObject],
-              [dummyValues, valueObject],
-            ]),
-          )
-        })
-
-        it('should return the merged object, with value props having more priority', () => {
-          expect(sut(dummyValues, dummyResolverOptions)).toEqual({
-            ...routeValueObject,
-            ...valueObject,
-          })
-        })
-      })
-
-      describe('when value is not an object', () => {
-        const routeValue = 'routeValue'
-
-        beforeEach(() => {
-          sut = makeSut()
-          injectSpies()
-          routeMetadataValues.get.and.returnValue(routeValues)
-          mockJsonResolver(
-            new Map<MetadataValues, unknown>([
-              [routeValues, routeValue],
-              [dummyValues, value],
-            ]),
-          )
-        })
-
-        it('should return value from values object', () => {
-          expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
+      it('should return the merged object, with value props having more priority', () => {
+        expect(sut(dummyValues, dummyResolverOptions)).toEqual({
+          ...routeValueObject,
+          ...valueObject,
         })
       })
     })
 
-    describe('when neither value, route value or default value exists', () => {
+    describe('when value is not an object', () => {
+      const routeValue = 'routeValue'
+
       beforeEach(() => {
         sut = makeSut()
         injectSpies()
+        routeMetadataValues.get.and.returnValue(routeValues)
+        mockJsonResolver(
+          new Map<MetadataValues, unknown>([
+            [routeValues, routeValue],
+            [dummyValues, value],
+          ]),
+        )
       })
-      it('should return nothing', () => {
-        expect(sut(dummyValues, dummyResolverOptions)).toBeUndefined()
+
+      it('should return value from values object', () => {
+        expect(sut(dummyValues, dummyResolverOptions)).toEqual(value)
       })
+    })
+  })
+
+  describe('when neither value, route value or default value exists', () => {
+    beforeEach(() => {
+      sut = makeSut()
+      injectSpies()
+    })
+    it('should return nothing', () => {
+      expect(sut(dummyValues, dummyResolverOptions)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
# Proposed changes
What title says

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

<!-- Fixes issue # -->
