### PR TITLE
fix: only merge image metadata value objects

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,39 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="AnonymousFunctionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="AssignmentResultUsedJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="AssignmentToForLoopParameterJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="AssignmentToFunctionParameterJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="BadExpressionStatementJS" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="BlockStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="BreakStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="BreakStatementWithLabelJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="CallerJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ChainedEqualityJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ChainedFunctionCallJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="CheckDtdRefs" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
@@ -21,6 +54,39 @@
     </inspection_tool>
     <inspection_tool class="CheckXmlFileWithXercesValidator" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="CommaExpressionJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConditionalExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConditionalExpressionWithIdenticalBranchesJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConfusingFloatingPointLiteralJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConfusingPlusesOrMinusesJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConstantConditionalExpressionJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConstantOnLHSOfComparisonJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ConstantOnRHSOfComparisonJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ContinueStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ContinueStatementWithLabelJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="CssBrowserCompatibilityForProperties" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
@@ -163,19 +229,143 @@
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
       <scope name="ngx-meta Angular main HTMLs" level="TEXT ATTRIBUTES" enabled="true" editorAttributes="CONSIDERATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="CyclomaticComplexityJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="10" />
+      </scope>
+      <option name="m_limit" value="10" />
+    </inspection_tool>
+    <inspection_tool class="DebuggerStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="DefaultNotLastCaseInSwitchJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="DivideByZeroJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="DocumentWriteJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="DuplicateConditionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="DynamicallyGeneratedCodeJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6BindWithArrowFunction" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="ES6ClassMemberInitializationOrder" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertIndexedForToForOf" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertLetToConst" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertModuleExportToExport" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertRequireIntoImport" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertToForOf" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6ConvertVarToLetConst" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="ES6DestructuringVariablesMerge" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="ES6MissingAwait" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6PossiblyAsyncFunction" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="ES6PreferShortImport" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6RedundantAwait" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="ES6RedundantNestingInTemplateLiteral" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="ES6ShorthandObjectProperty" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6TopLevelAwaitExpression" enabled="true" level="ERROR" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ES6UnusedImports" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="EmptyCatchBlockJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="EmptyFinallyBlockJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="EmptyStatementBodyJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_reportEmptyBlocks" value="false" />
+      </scope>
+      <option name="m_reportEmptyBlocks" value="false" />
+    </inspection_tool>
+    <inspection_tool class="EmptyTryBlockJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ExceptionCaughtLocallyJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FallThroughInSwitchStatementJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FlowJSConfig" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FlowJSCoverage" enabled="true" level="WEAK WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FlowJSError" enabled="true" level="ERROR" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FlowJSFlagCommentPlacement" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ForLoopReplaceableByWhileJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_ignoreLoopsWithoutConditions" value="false" />
+      </scope>
+      <option name="m_ignoreLoopsWithoutConditions" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ForLoopThatDoesntUseLoopVariableJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FunctionNamingConventionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_regex" value="[a-z][A-Za-z]*" />
+        <option name="m_minLength" value="4" />
+        <option name="m_maxLength" value="32" />
+      </scope>
+      <option name="m_regex" value="[a-z][A-Za-z]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FunctionWithMultipleLoopsJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="FunctionWithMultipleReturnPointsJS" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="HtmlDeprecatedAttribute" enabled="true" level="WARNING" enabled_by_default="true">
@@ -311,13 +501,49 @@
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
       <scope name="ngx-meta Angular main HTMLs" level="TEXT ATTRIBUTES" enabled="true" editorAttributes="CONSIDERATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="IfStatementWithIdenticalBranchesJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="IfStatementWithTooManyBranchesJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="3" />
+      </scope>
+      <option name="m_limit" value="3" />
+    </inspection_tool>
+    <inspection_tool class="IncompatibleMaskJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="IncrementDecrementResultUsedJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="InfiniteLoopJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="InfiniteRecursionJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="InnerHTMLJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSAccessibilityCheck" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSAnnotator" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSArrowFunctionBracesCanBeRemoved" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSAssignmentUsedAsCondition" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSBitwiseOperatorUsage" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSCheckFunctionSignatures" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSClosureCompilerSyntax" enabled="true" level="WARNING" enabled_by_default="true">
@@ -326,13 +552,46 @@
     <inspection_tool class="JSCommentMatchesSignature" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSComparisonWithNaN" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSConsecutiveCommasInArrayLiteral" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSConstantReassignment" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSDeclarationsAtScopeStart" enabled="true" level="WEAK WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSDeprecatedSymbols" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSDuplicateCaseLabel" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSDuplicatedDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSEqualityComparisonWithCoercion" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSEqualityComparisonWithCoercion.TS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSFileReferences" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSFunctionExpressionToArrowFunction" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSHint" enabled="true" level="ERROR" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSIgnoredPromiseFromCall" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSIncompatibleTypesComparison" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSJQueryEfficiency" enabled="true" level="WARNING" enabled_by_default="true">
@@ -358,22 +617,89 @@
       <option name="queries" value="trace,write,forEach,length,size" />
       <option name="updates" value="pop,push,shift,splice,unshift,add,insert,remove,reverse,copyWithin,fill,sort" />
     </inspection_tool>
+    <inspection_tool class="JSMissingSwitchBranches" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSMissingSwitchDefault" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSNonASCIINames" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSNonStrictModeUsed" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSObjectNullOrUndefined" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSOctalInteger" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true" />
+      </scope>
+      <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidTargetOfIndexedPropertyAccess" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidUsageOfClassThis" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSPotentiallyInvalidUsageOfThis" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSRedundantSwitchStatement" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSReferencingMutableVariableFromClosure" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSRemoveUnnecessaryParentheses" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSStringConcatenationToES6Template" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSSuspiciousEqPlus" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSSuspiciousNameCombination" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <group names="x,width,left,right" />
+        <group names="y,height,top,bottom" />
+        <exclude classes="Math" />
+      </scope>
+      <group names="x,width,left,right" />
+      <group names="y,height,top,bottom" />
+      <exclude classes="Math" />
+    </inspection_tool>
+    <inspection_tool class="JSSwitchVariableDeclarationIssue" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSTestFailedLine" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSTypeOfValues" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSUndeclaredVariable" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSUndefinedPropertyAssignment" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSUnfilteredForInLoop" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSUnnecessarySemicolon" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSUnreachableSwitchBranches" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSUnresolvedExtXType" enabled="true" level="WARNING" enabled_by_default="true">
@@ -385,16 +711,153 @@
     <inspection_tool class="JSUnresolvedReference" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSUnusedAssignment" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSUnusedGlobalSymbols" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSUnusedLocalSymbols" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSUrlImportUsage" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSValidateJSDoc" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSValidateTypes" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="JSVoidFunctionReturnValueUsed" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSXDomNesting" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="JSXNamespaceValidation" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="JSXSyntaxUsed" enabled="true" level="ERROR" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="JSXUnresolvedComponent" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="KarmaConfigFile" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="LabeledStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="LocalVariableNamingConventionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_regex" value="[a-z][A-Za-z]*" />
+        <option name="m_minLength" value="1" />
+        <option name="m_maxLength" value="32" />
+      </scope>
+      <option name="m_regex" value="[a-z][A-Za-z]*" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="LoopStatementThatDoesntLoopJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="MagicNumberJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NegatedConditionalExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NegatedIfStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NestedAssignmentJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NestedConditionalExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NestedFunctionCallJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NestedFunctionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_includeAnonymousFunctions" value="false" />
+      </scope>
+      <option name="m_includeAnonymousFunctions" value="false" />
+    </inspection_tool>
+    <inspection_tool class="NestedSwitchStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NestingDepthJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="5" />
+      </scope>
+      <option name="m_limit" value="5" />
+    </inspection_tool>
+    <inspection_tool class="NodeCoreCodingAssistance" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NonBlockStatementBodyJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NpmUsedModulesInstalled" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="NpmVulnerableApiCode" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ObjectAllocationIgnoredJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="OverlyComplexArithmeticExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="6" />
+      </scope>
+      <option name="m_limit" value="6" />
+    </inspection_tool>
+    <inspection_tool class="OverlyComplexBooleanExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="3" />
+      </scope>
+      <option name="m_limit" value="3" />
+    </inspection_tool>
+    <inspection_tool class="PackageJsonMismatchedDependency" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ParameterNamingConventionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_regex" value="[a-z][A-Za-z]*" />
+        <option name="m_minLength" value="1" />
+        <option name="m_maxLength" value="32" />
+      </scope>
+      <option name="m_regex" value="[a-z][A-Za-z]*" />
+      <option name="m_minLength" value="1" />
+      <option name="m_maxLength" value="32" />
+    </inspection_tool>
+    <inspection_tool class="ParametersPerFunctionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="5" />
+      </scope>
+      <option name="m_limit" value="5" />
+    </inspection_tool>
+    <inspection_tool class="PlatformDetectionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="PointlessArithmeticExpressionJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_ignoreExpressionsContainingConstants" value="false" />
+      </scope>
+      <option name="m_ignoreExpressionsContainingConstants" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBooleanExpressionJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ReplaceAssignmentWithOperatorAssignmentJS" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="RequiredAttributes" enabled="true" level="WARNING" enabled_by_default="true">
@@ -406,11 +869,169 @@
       </scope>
       <option name="myAdditionalRequiredHtmlAttributes" value="" />
     </inspection_tool>
+    <inspection_tool class="ReservedWordUsedAsNameJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ReturnFromFinallyBlockJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ReuseOfLocalVariableJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ShiftOutOfRangeJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="SillyAssignmentJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="StandardJS" enabled="true" level="ERROR" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="StatementsPerFunctionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_limit" value="30" />
+      </scope>
+      <option name="m_limit" value="30" />
+    </inspection_tool>
+    <inspection_tool class="StringLiteralBreaksHTMLJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="Stylelint" enabled="true" level="ERROR" enabled_by_default="false">
       <scope name="SVG Inkscape assets" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
       <scope name="ngx-meta Angular main HTMLs" level="TEXT ATTRIBUTES" enabled="true" editorAttributes="CONSIDERATION_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="SuspiciousTypeOfGuard" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TailRecursionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TextLabelInSwitchStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ThisExpressionReferencesGlobalObjectJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ThreeNegationsPerFunctionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="ThrowFromFinallyBlockJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TrivialConditionalJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TrivialIfJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptAbstractClassConstructorCanBeMadeProtected" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptCheckImport" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptConfig" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptDuplicateUnionOrIntersectionType" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptExplicitMemberType" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptFieldCanBeMadeReadonly" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptJSXUnresolvedComponent" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptLibrary" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptMissingAugmentationImport" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptMissingConfigOption" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptRedundantGenericType" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptSmartCast" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptSuspiciousConstructorParameterAssignment" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptUMDGlobal" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptUnresolvedReference" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptValidateGenericTypes" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptValidateJSTypes" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptValidateTypes" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryContinueJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLabelJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+        <option name="m_ignoreAnnotatedVariables" value="false" />
+      </scope>
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryReturnJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnreachableCodeJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="UnterminatedStatementJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="ignoreSemicolonAtEndOfBlock" value="true" />
+      </scope>
+      <option name="ignoreSemicolonAtEndOfBlock" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnusedCatchParameterJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="m_ignoreCatchBlocksWithComments" value="false" />
+      </scope>
+      <option name="m_ignoreCatchBlocksWithComments" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UpdateDependencyToLatestVersion" enabled="true" level="INFORMATION" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="VoidExpressionJS" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
     <inspection_tool class="WebpackConfigHighlighting" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="WithStatementJS" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="XHTMLIncompatabilitiesJS" enabled="true" level="WARNING" enabled_by_default="false">
       <scope name="ngx-meta API Extractor report" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="XmlDefaultAttributeValue" enabled="true" level="WARNING" enabled_by_default="true">

--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -139,12 +139,13 @@ export const _makeMetadataManager: <T>(id: NgxMetaMetadataManager<T>['id'], reso
 export const makeMetadataManagerProviderFromSetterFactory: <T>(setterFactory: MetadataSetterFactory<T>, opts: {
     d?: FactoryProvider['deps'];
     id?: string;
-    jP: ReadonlyArray<string>;
-    g?: string;
+    jP: MetadataResolverOptions['jsonPath'];
+    g?: MetadataResolverOptions['global'];
+    m?: MetadataResolverOptions['objectMerge'];
 }) => FactoryProvider;
 
 // @internal (undocumented)
-export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global']) => MetadataResolverOptions;
+export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global'], objectMerge?: MetadataResolverOptions['objectMerge']) => MetadataResolverOptions;
 
 // @internal (undocumented)
 class MetadataRegistry {
@@ -166,6 +167,8 @@ export interface MetadataResolverOptions {
     readonly global?: string;
     // (undocumented)
     readonly jsonPath: ReadonlyArray<string>;
+    // (undocumented)
+    readonly objectMerge?: boolean;
 }
 
 // @public

--- a/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
+++ b/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
@@ -1,4 +1,3 @@
-// Relates to https://github.com/davidlj95/ngx/issues/426
 import { TestBed } from '@angular/core/testing'
 import {
   METADATA_RESOLVER,
@@ -9,6 +8,10 @@ import { Provider } from '@angular/core'
 import { MockProvider } from 'ng-mocks'
 import { DEFAULTS_TOKEN } from '../core/src/defaults-token'
 
+// Relates to https://github.com/davidlj95/ngx/issues/426
+// TBH, this is needed cause both Metadata JSON resolver and Metadata resolver
+// may merge objs
+// We could extract merging into a common place and test that there
 describe('Metadata value resolver object merging', () => {
   type Values = { obj: object; specific?: { obj: object } }
   const baseResolverOptions: MetadataResolverOptions = {

--- a/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
+++ b/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
@@ -1,0 +1,98 @@
+// Relates to https://github.com/davidlj95/ngx/issues/426
+import { TestBed } from '@angular/core/testing'
+import {
+  METADATA_RESOLVER,
+  METADATA_RESOLVER_PROVIDER,
+} from '../core/src/metadata-resolver'
+import { MetadataResolverOptions, MetadataValues } from '../core'
+import { Provider } from '@angular/core'
+import { MockProvider } from 'ng-mocks'
+import { DEFAULTS_TOKEN } from '../core/src/defaults-token'
+
+describe('Metadata value resolver object merging', () => {
+  type Values = { obj: object; specific?: { obj: object } }
+  const baseResolverOptions: MetadataResolverOptions = {
+    jsonPath: [
+      'specific' satisfies keyof Values,
+      'obj' satisfies keyof Exclude<Values['specific'], undefined>,
+    ],
+    global: 'obj' satisfies keyof Values,
+  }
+
+  describe('when object merging resolver option is disabled (default)', () => {
+    const resolverOptions = baseResolverOptions
+
+    it('should not merge global and specific values', () => {
+      const GLOBAL_DUMMY_OBJ = new URL('https://example.org/global-dummy')
+      const SPECIFIC_DUMMY_OBJ = new URL('https://example.org/specific-dummy')
+      const sut = makeSut()
+
+      const values = {
+        obj: GLOBAL_DUMMY_OBJ,
+        specific: { obj: SPECIFIC_DUMMY_OBJ },
+      } satisfies Values
+      const resolved = sut(values, resolverOptions)
+
+      expect(resolved).toEqual(SPECIFIC_DUMMY_OBJ)
+    })
+
+    it('should not merge default value and value from arg values', () => {
+      const VALUES_DUMMY_OBJ = new URL('https://example.org/values-dummy')
+      const DEFAULT_DUMMY_OBJ = new URL('https://example.org/default-dummy')
+
+      const sut = makeSut({
+        defaults: { obj: DEFAULT_DUMMY_OBJ } satisfies Values,
+      })
+
+      const values = { obj: VALUES_DUMMY_OBJ } satisfies Values
+      const resolved = sut(values, resolverOptions)
+
+      expect(resolved).toEqual(VALUES_DUMMY_OBJ)
+    })
+  })
+  describe('when object merging resolver option is enabled', () => {
+    const resolverOptions: MetadataResolverOptions = {
+      ...baseResolverOptions,
+      objectMerge: true,
+    }
+
+    it('should merge global and specific values', () => {
+      const GLOBAL_OBJ = { shared: 'shared', global: 'global' }
+      const SPECIFIC_OBJ = { shared: 'overridden-shared', specific: 'specific' }
+
+      const sut = makeSut()
+
+      const values = {
+        obj: GLOBAL_OBJ,
+        specific: { obj: SPECIFIC_OBJ },
+      }
+      const resolved = sut(values, resolverOptions)
+
+      expect(resolved).toEqual({ ...GLOBAL_OBJ, ...SPECIFIC_OBJ })
+    })
+
+    it('should merge default value and value from arg values', () => {
+      const DEFAULTS_OBJ = { shared: 'shared', default: 'default' }
+      const VALUES_OBJ = { shared: 'overridden-shared', specific: 'specific' }
+
+      const sut = makeSut({
+        defaults: { obj: DEFAULTS_OBJ } satisfies Values,
+      })
+
+      const values = { obj: VALUES_OBJ } satisfies Values
+      const resolved = sut(values, resolverOptions)
+
+      expect(resolved).toEqual({ ...DEFAULTS_OBJ, ...VALUES_OBJ })
+    })
+  })
+})
+
+function makeSut(opts: { defaults?: MetadataValues } = {}) {
+  const DEFAULT_PROVIDER: Provider[] = opts.defaults
+    ? [MockProvider(DEFAULTS_TOKEN, opts.defaults)]
+    : []
+  TestBed.configureTestingModule({
+    providers: [METADATA_RESOLVER_PROVIDER, ...DEFAULT_PROVIDER],
+  })
+  return TestBed.inject(METADATA_RESOLVER)
+}

--- a/projects/ngx-meta/src/core/src/make-metadata-manager-provider-from-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/make-metadata-manager-provider-from-setter-factory.ts
@@ -1,6 +1,7 @@
 import {
   _makeMetadataManager,
   _makeMetadataResolverOptions,
+  MetadataResolverOptions,
   MetadataSetter,
   NgxMetaMetadataManager,
 } from './ngx-meta-metadata-manager'
@@ -35,6 +36,7 @@ export type MetadataSetterFactory<T> = (
  *               Defaults to resolver options `jsonPath` joined by dots.
  *               `jP` is the `jsonPath` that will be used for the {@link MetadataResolverOptions.jsonPath}
  *               `g` is the `global` that will be used for the {@link MetadataResolverOptions.global}
+ *               `m` is the `objectMerge` that will be used for the {@link MetadataResolverOptions.objectMerge}
  *
  * @public
  */
@@ -46,9 +48,11 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
     // ID of the manager
     id?: string
     // JSON Path
-    jP: ReadonlyArray<string>
+    jP: MetadataResolverOptions['jsonPath']
     // Global
-    g?: string
+    g?: MetadataResolverOptions['global']
+    // Object merge
+    m?: MetadataResolverOptions['objectMerge']
   },
 ): FactoryProvider => {
   const deps = opts.d ?? []
@@ -58,7 +62,7 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
     useFactory: (...deps: unknown[]) =>
       _makeMetadataManager(
         opts.id ?? opts.jP.join('.'),
-        _makeMetadataResolverOptions(opts.jP, opts.g),
+        _makeMetadataResolverOptions(opts.jP, opts.g, opts.m),
         setterFactory(...deps),
       ),
     deps,

--- a/projects/ngx-meta/src/core/src/metadata-json-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-json-resolver.spec.ts
@@ -113,27 +113,61 @@ describe('Metadata JSON Resolver', () => {
       })
     })
 
-    describe('and it is and object, and a global object exists too', () => {
-      const valueObject = { value: 'value', prop: 'value' }
-      const globalValueObject = {
-        globalValue: 'globalValue',
-        prop: 'globalValue',
-      }
-      const resolverOptions = _makeMetadataResolverOptions(
-        [key, subKey],
-        global,
-      )
-      const values = {
-        [global]: globalValueObject,
-        [key]: {
-          [subKey]: valueObject,
-        },
-      }
+    describe('and a global exists too', () => {
+      describe('when object merging is disabled', () => {
+        const values = {
+          [global]: global,
+          [key]: {
+            [subKey]: value,
+          },
+        }
+        const resolverOptions = _makeMetadataResolverOptions(
+          [key, subKey],
+          global,
+          false,
+        )
 
-      it('should merge both objects, with specific value taking priority', () => {
-        expect(sut(values, resolverOptions)).toEqual({
-          ...globalValueObject,
-          ...valueObject,
+        it('should return specific value', () => {
+          expect(sut(values, resolverOptions)).toEqual(value)
+        })
+      })
+
+      describe('when object merging is enabled', () => {
+        const resolverOptions = _makeMetadataResolverOptions(
+          [key, subKey],
+          global,
+          true,
+        )
+
+        describe('when values are not objects', () => {
+          const values = {
+            [global]: global,
+            [key]: {
+              [subKey]: value,
+            },
+          }
+
+          it('should return specific value', () => {
+            expect(sut(values, resolverOptions)).toEqual(value)
+          })
+        })
+
+        describe('when values are objects', () => {
+          const GLOBAL_OBJECT = { shared: 'shared', global }
+          const VALUE_OBJECT = { shared: 'overridden', value }
+          const values = {
+            [global]: GLOBAL_OBJECT,
+            [key]: {
+              [subKey]: VALUE_OBJECT,
+            },
+          }
+
+          it('should return merged objects', () => {
+            expect(sut(values, resolverOptions)).toEqual({
+              ...GLOBAL_OBJECT,
+              ...VALUE_OBJECT,
+            })
+          })
         })
       })
     })

--- a/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
@@ -1,7 +1,7 @@
 import { MetadataValues } from './metadata-values'
-import { isObject } from './is-object'
 import { InjectionToken } from '@angular/core'
 import { MetadataResolverOptions } from './ngx-meta-metadata-manager'
+import { isObject } from './is-object'
 
 export type MetadataJsonResolver = (
   values: MetadataValues | undefined,
@@ -28,14 +28,18 @@ export const METADATA_JSON_RESOLVER = new InjectionToken<MetadataJsonResolver>(
         resolverOptions.global !== undefined
           ? (values as IndexedObject)[resolverOptions.global]
           : undefined
-      if (value !== undefined && !globalValue) {
-        return value
-      }
-      if (isObject(value) && isObject(globalValue)) {
+      if (
+        isObject(value) &&
+        isObject(globalValue) &&
+        resolverOptions.objectMerge
+      ) {
         return {
           ...globalValue,
           ...value,
         }
+      }
+      if (value !== undefined) {
+        return value
       }
       return globalValue
     },

--- a/projects/ngx-meta/src/core/src/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.ts
@@ -2,12 +2,12 @@ import { FactoryProvider, InjectionToken, Optional } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
 import { DEFAULTS_TOKEN } from './defaults-token'
-import { isObject } from './is-object'
 import {
   METADATA_JSON_RESOLVER,
   MetadataJsonResolver,
 } from './metadata-json-resolver'
 import { MetadataResolverOptions } from './ngx-meta-metadata-manager'
+import { isObject } from './is-object'
 
 /**
  * @internal
@@ -32,9 +32,18 @@ export const METADATA_RESOLVER_FACTORY: (
     const value = jsonResolver(values, resolverOptions)
     const routeValue = jsonResolver(routeMetadataValues?.get(), resolverOptions)
     const defaultValue = jsonResolver(defaults ?? undefined, resolverOptions)
-    return isObject(value) && (isObject(routeValue) || isObject(defaultValue))
-      ? { ...(defaultValue as object), ...(routeValue as object), ...value }
-      : [value, routeValue, defaultValue].find((v) => v !== undefined)
+    if (
+      isObject(value) &&
+      (isObject(routeValue) || isObject(defaultValue)) &&
+      resolverOptions.objectMerge
+    ) {
+      return {
+        ...(defaultValue as object),
+        ...(routeValue as object),
+        ...value,
+      }
+    }
+    return [value, routeValue, defaultValue].find((v) => v !== undefined)
   }
 export const METADATA_RESOLVER_PROVIDER: FactoryProvider = {
   provide: METADATA_RESOLVER,

--- a/projects/ngx-meta/src/core/src/ngx-meta-metadata-manager.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-metadata-manager.ts
@@ -34,6 +34,7 @@ export abstract class NgxMetaMetadataManager<Value = unknown> {
 export interface MetadataResolverOptions {
   readonly jsonPath: ReadonlyArray<string>
   readonly global?: string
+  readonly objectMerge?: boolean
 }
 
 /**
@@ -61,4 +62,5 @@ export const _makeMetadataManager = <T>(
 export const _makeMetadataResolverOptions = (
   jsonPath: MetadataResolverOptions['jsonPath'],
   global?: MetadataResolverOptions['global'],
-): MetadataResolverOptions => ({ jsonPath, global })
+  objectMerge?: MetadataResolverOptions['objectMerge'],
+): MetadataResolverOptions => ({ jsonPath, global, objectMerge })

--- a/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
@@ -1,6 +1,7 @@
 import {
   GlobalMetadata,
   makeMetadataManagerProviderFromSetterFactory,
+  MetadataResolverOptions,
   MetadataSetterFactory,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
@@ -20,6 +21,8 @@ export const makeOpenGraphMetadataProvider = <Key extends keyof OpenGraph>(
     g?: keyof GlobalMetadata
     // Setter factory. Defaults to setting the property to the given value.
     s?: MetadataSetterFactory<OpenGraph[Key]>
+    // Object merging. Defaults to false
+    m?: MetadataResolverOptions['objectMerge']
   } = {},
 ): FactoryProvider =>
   makeMetadataManagerProviderFromSetterFactory(
@@ -33,5 +36,6 @@ export const makeOpenGraphMetadataProvider = <Key extends keyof OpenGraph>(
       d: [NgxMetaMetaService],
       jP: [OPEN_GRAPH_KEY, key],
       g: opts.g,
+      m: opts.m,
     },
   )

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -50,5 +50,5 @@ export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
  */
 export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
   _GLOBAL_IMAGE,
-  { s: __OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: _GLOBAL_IMAGE },
+  { s: __OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: _GLOBAL_IMAGE, m: true },
 )

--- a/projects/ngx-meta/src/twitter-card/src/make-twitter-card-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/make-twitter-card-metadata-provider.ts
@@ -1,6 +1,7 @@
 import {
   GlobalMetadata,
   makeMetadataManagerProviderFromSetterFactory,
+  MetadataResolverOptions,
   MetadataSetterFactory,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
@@ -20,6 +21,8 @@ export const makeTwitterCardMetadataProvider = <Key extends keyof TwitterCard>(
     g?: keyof GlobalMetadata
     // Setter factory. Defaults to setting the property to the given value.
     s?: MetadataSetterFactory<TwitterCard[Key]>
+    // Object merge
+    m?: MetadataResolverOptions['objectMerge']
   } = {},
 ): FactoryProvider =>
   makeMetadataManagerProviderFromSetterFactory(
@@ -33,5 +36,6 @@ export const makeTwitterCardMetadataProvider = <Key extends keyof TwitterCard>(
       d: [NgxMetaMetaService],
       jP: [TWITTER_KEY, key],
       g: opts.g,
+      m: opts.m,
     },
   )

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
@@ -19,4 +19,5 @@ export const TWITTER_CARD_IMAGE_METADATA_PROVIDER =
         value?.alt,
       )
     },
+    m: true,
   })


### PR DESCRIPTION
# Proposed changes
Currently when resolving metadata values, if more than one value is found, and both are objects, they will be merged.

This can lead to issues. For instance, if specifying a default `canonicalUrl` URL object and a specific `canonicalUrl` URL object. It will mess up the URL object by merging them.

To solve it, a new resolver option is added: `objectMerge`. It allows to explicitly enable or disabled the object merging when more than one metadata value is found and they're both objects. 

This way a metadata provider can specify if when resolving the value, values will be merged if they're objects or not

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.

Fixes issue #426
