### PR TITLE
docs: fix API ref md links downgrading api-documenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@angular/compiler-cli": "17.3.2",
     "@commitlint/cli": "19.2.1",
     "@commitlint/config-conventional": "19.1.0",
-    "@microsoft/api-documenter": "7.24.1",
+    "@microsoft/api-documenter": "7.23.38",
     "@microsoft/api-extractor": "7.43.0",
     "@semantic-release/changelog": "6.0.3",
     "@types/jasmine": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ devDependencies:
     specifier: 19.1.0
     version: 19.1.0
   '@microsoft/api-documenter':
-    specifier: 7.24.1
-    version: 7.24.1(@types/node@20.9.4)
+    specifier: 7.23.38
+    version: 7.23.38(@types/node@20.9.4)
   '@microsoft/api-extractor':
     specifier: 7.43.0
     version: 7.43.0(@types/node@20.9.4)
@@ -2638,8 +2638,8 @@ packages:
       call-bind: 1.0.5
     dev: true
 
-  /@microsoft/api-documenter@7.24.1(@types/node@20.9.4):
-    resolution: {integrity: sha512-DX332aznb5SWpOLGuymvzg2OZsQ5+dCbSm8yvVYqTylDgSAiPouvKrdlWPoEeicuLU8wzxSl3xv7DMb6xgYwPw==}
+  /@microsoft/api-documenter@7.23.38(@types/node@20.9.4):
+    resolution: {integrity: sha512-2uvz4456atUkm9BDfN4YnSsBtZtkvQUYos7/TSdADwlzDHNA+0KGuKS9+722O7zGvHZG5qHfoNi/mlQrxhi47w==}
     hasBin: true
     dependencies:
       '@microsoft/api-extractor-model': 7.28.13(@types/node@20.9.4)


### PR DESCRIPTION
# Issue or need
Some API reference links in documentation were not working. They displayed the markdown syntax `[link text](link URL)`, but were not processsed as links.

After reviewing the generated Markdown files and latest releases from `api-documenter` and `mkdocs-material`, seems that [`api-documenter` recently started to use HTML tables instead of Markdown tables in `v7.24.0`](https://github.com/microsoft/rushstack/blob/9413e2e9d78d1ab72e595257c09dc3a01443f368/apps/api-documenter/CHANGELOG.md#7240). And seems `mkdocs-material` doesn't handle that well.

# Proposed changes

Downgrade `api-documenter` to a previous version where files were pure Markdown. Will see how to solve it better.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
