### PR TITLE
ci: remove npm update step to verify signatures

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -43,14 +43,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Setup
         uses: ./.github/actions/setup
-      # Why this? https://github.com/npm/cli/issues/7279
-      # Why this way? https://github.com/actions/setup-node/issues/213
-      # Why only here? Because only the npm audit signatures command is affected
-      - name: Install latest npm
-        run: |
-          npm install -g npm@latest &&
-          npm --version &&
-          npm list -g --depth 0
       - name: Installed dependencies integrity check
         run: npm audit signatures
       - name: Download distribution files


### PR DESCRIPTION
# Issue or need

There's no longer need to update `npm` to audit signatures properly
 
Given [in latest release](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240407.1), `npm` bundled version `10.5.0` is already capable of auditing.

Relates to https://github.com/npm/cli/issues/7279
 
# Proposed changes
Remove `npm` update step in release process

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
