### PR TITLE
docs: add bundle size back

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -63,7 +63,9 @@ jobs:
         run: |
           for artifact_dir in ${{ inputs.bundle-size-artifact-name-prefix }}*; do
             version="$(echo "$artifact_dir" | sed "s/^${{ inputs.bundle-size-artifact-name-prefix }}//")"
-            cp "$artifact_dir/bundle-size-report.md" "projects/ngx-meta/e2e/a$version"
+            bundle_size_app_dir="projects/ngx-meta/bundle-size/a$version"
+            mkdir -p "$bundle_size_app_dir"
+            cp "$artifact_dir/bundle-size-report.md" "$bundle_size_app_dir"
           done
       - name: Install poetry # pipx comes built-in in GitHub runner
         run: pipx install poetry

--- a/projects/ngx-meta/docs/prebuild.sh
+++ b/projects/ngx-meta/docs/prebuild.sh
@@ -30,11 +30,11 @@ cp ../src/CHANGELOG.md "$INCLUDES_DIR/"
 
 # 📦 Bundle size
 echo "ℹ️ Copying bundle size reports"
-e2e_app_dir_pattern="../e2e/a"
-for e2e_app_dir in "$e2e_app_dir_pattern"*; do
-  version="$(echo "$e2e_app_dir" | sed "s|$e2e_app_dir_pattern||g")"
+bundle_size_app_dir_pattern="../bundle-size/a"
+for bundle_size_app_dir in "$bundle_size_app_dir_pattern"*; do
+  version="$(echo "$bundle_size_app_dir" | sed "s|$bundle_size_app_dir_pattern||g")"
   report_filename="bundle-size-report.md"
-  report_file="$e2e_app_dir/$report_filename"
+  report_file="$bundle_size_app_dir/$report_filename"
   destination_file="includes/a$version-$report_filename"
 
   if [ -r "$report_file" ]; then


### PR DESCRIPTION
# Issue or need

After #499 directories for bundle size reports changed. Docs weren't updated to reflect this change and "Bundle size" page of docs no longer included size reports 

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Update location of bundle size reports to find them and include them in docs. Both locally and in CI/CD

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
