### PR TITLE
build(e2e): generate E2E apps with pinned Angular CLI versions

### DIFF
--- a/projects/ngx-meta/e2e/scripts/angular-cli-versions.json
+++ b/projects/ngx-meta/e2e/scripts/angular-cli-versions.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ngx-meta/e2e-angular-cli-versions",
+  "version": "0.0.0",
+  "description": "ngx-meta E2E pinned Angular CLI versions to create sample apps",
+  "private": true,
+  "packageManager": "pnpm@8.15.6",
+  "devDependencies": {
+    "a15": "npm:@angular/cli@15",
+    "a16": "npm:@angular/cli@16",
+    "a17": "npm:@angular/cli@17"
+  }
+}

--- a/projects/ngx-meta/e2e/scripts/tsconfig.json
+++ b/projects/ngx-meta/e2e/scripts/tsconfig.json
@@ -10,7 +10,9 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    //👇 Read JSON
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,10 @@
   ],
   timezone: 'Europe/Madrid',
   labels: ['dependencies'],
+  npm: {
+    // Keep Angular CLI versions used to generate E2E apps updated
+    fileMatch: ['projects/ngx-meta/e2e/scripts/angular-cli-versions.json'],
+  },
   packageRules: [
     // App for main / E2E apps (main one isn't published)
     // Lib for published package JSONs


### PR DESCRIPTION
# Issue or need

As commented in #504, the now dynamically generated apps for E2E testing use major versions to specify which Angular CLI version to use.

For instance:

```shell
pnpm dlx @angular/cli@17 new
```

To generate Angular v17 apps

This adds **non-determinism**. Generated apps may change if generated using different Angular CLI versions. For instance, when `17.1` version is released after using `17.0` for a while. This could make then E2E apps invalid or introduce failures not related with the change being tested.


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

To solve this, here an `angular-cli-versions.json` file is introduced to maintain the Angular CLI versions used for each app generation.

[Aliases](https://pnpm.io/aliases) are used in order to keep all Angular CLI versions in same file.

> [!NOTE]
> This is not `pnpm` specific. [`npm` supports it too](https://docs.npmjs.com/cli/v10/commands/npm-install#:~:text=npm%20install%20%3Calias%3E%40npm%3A%3Cname%3E%3A)
> We aren't therefore coupled to `pnpm` as package manager because of this

Those can be updated by Renovate given we manually include them in the config as package files. They are not introduced in a regular `package.json` to avoid being installed by mistake. The script should be the only one that installs those Angular CLIs.

> [!NOTE]
> Ensured [Renovate supports aliases too](https://github.com/renovatebot/renovate/blob/37.289.0/lib/modules/manager/npm/extract/common/dependency.ts#L100-L117)

This file is used to extract the exact Angular CLI version to use. 

## Forward thinking
This PR also takes into account how we can cache the Angular CLI and generated Angular E2E app deps. 

Caching includes caching the resolution of pnpm dependencies (aka the lockfile) and the dependencies themselves.

### Angular CLI caching
A `package.json` with only the Angular CLI version in `devDependencies` is copied to the temporary dir where the Angular app will be created.

> We'll need to have a fixed temporary dir to be able to save / restore cache
> Fortunately [`runner.temp` exists for GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context)

Therefore we can later cache both `pnpm-lock.yaml` to cache the dependencies resolution and the global `pnpm` cache store to cache dependencies themselves.

### Angular E2E app deps caching
We can cache the `package.json` and `pnpm-lock.yaml` of generated apps using `@actions/cache` GitHub Action

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
