### PR TITLE
ci(e2e): add caching for generated e2e apps

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -43,11 +43,49 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          cache: 'pnpm'
-          cache-dependency-path: |
-            ${{ env.E2E_SCRIPTS_DIR }}/pnpm-lock.yaml
-            ${{ env.E2E_APP_DIR }}/pnpm-lock.yaml
+          # Can't cache here, given some cache-dependency-paths do not exist yet
+          # Hence can't be used to create a proper cache key
+          # https://github.com/actions/setup-node/blob/v4.0.2/src/cache-restore.ts#L30-L42
           node-version-file: '.node-version' # TODO: may vary depending on Angular version
+        # 👇 For caching, see below
+        # - PNPM store: https://github.com/pnpm/action-setup/tree/v3.0.0?tab=readme-ov-file#use-cache-to-reduce-installation-time
+        # - Angular CLI version: from versions file. Using `jq` built-in in runner to fetch it
+      - name: Get caching key info
+        run: |
+          echo "pnpm_store_path=$(pnpm store path --silent)" >> $GITHUB_ENV
+          echo "angular_cli_version=$(jq -r \
+            '.devDependencies.a${{ matrix.version }}' \
+            '${{ env.E2E_SCRIPTS_DIR }}/angular-cli-versions.json' |
+            sed 's|npm:@angular/cli@||g'
+          )" >> $GITHUB_ENV
+          echo "week_of_year=$(date --utc '+%V')" >> $GITHUB_ENV
+      - name: Cache dependencies and Angular CLI/app resolution
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        env:
+          cache-name: ngx-meta-e2e-apps
+          e2e_scripts_lockfile_hash: ${{ hashFiles(format('{0}/pnpm-lock.yaml', env.E2E_SCRIPTS_DIR)) }}
+        with:
+          # To cache (line by line):
+          # - pnpm global store
+          # - Angular CLI dependency resolution (lockfile)
+          # - Angular app dependency resolution (lockfile)
+          path: |
+            ${{ env.pnpm_store_path }}
+            ${{ runner.temp }}/pnpm-lock.yaml
+            ${{ env.E2E_APP_DIR }}/pnpm-lock.yaml
+          # Key is designed to be invalidated if:
+          # - E2E script dependencies change
+          # - Angular CLI version is updated
+          # - Week of year (UTC) changes
+          # Last one is because we can't know before generating the Angular app
+          # which patch version of Angular will be installed.
+          # Angular CLI creates an app with same minor version:
+          # https://github.com/angular/angular-cli/blob/17.3.4/packages/schematics/angular/utility/latest-versions.ts#L20-L21
+          # So patch is up to dependency resolution step
+          # By invalidating cache each week so if a patch release appears it
+          # will be taken into account in max 1 week time
+          # Patch releases shouldn't break anything anyway
+          key: ${{ env.cache-name }}-${{ env.e2e_scripts_lockfile_hash }}-${{ env.angular_cli_version }}-${{ env.week_of_year }}
       - name: Install E2E scripts dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}
@@ -55,7 +93,9 @@ jobs:
         run: pnpm run build
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}
       - name: Create E2E app
-        run: pnpm run create-sample-app a${{ matrix.version }}
+        run: >
+          pnpm run create-sample-app a${{ matrix.version }}
+          --tmp-dir=${{ runner.temp }}
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}
       - name: Build Angular v${{ matrix.version }} E2E app
         run: pnpm build --source-map # with source map for bundle size analysis

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -86,10 +86,6 @@ jobs:
           # will be taken into account in max 1 week time
           # Patch releases shouldn't break anything anyway
           key: ${{ env.cache-name }}-${{ env.e2e_scripts_lockfile_hash }}-${{ env.angular_cli_version }}-${{ env.week_of_year }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
       - name: Install E2E scripts dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -82,7 +82,7 @@ jobs:
           # Angular CLI creates an app with same minor version:
           # https://github.com/angular/angular-cli/blob/17.3.4/packages/schematics/angular/utility/latest-versions.ts#L20-L21
           # So patch is up to dependency resolution step
-          # By invalidating cache each week so if a patch release appears it
+          # By invalidating cache each week, if a patch release appears it
           # will be taken into account in max 1 week time
           # Patch releases shouldn't break anything anyway
           key: ${{ env.cache-name }}-${{ env.e2e_scripts_lockfile_hash }}-${{ env.angular_cli_version }}-${{ env.week_of_year }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -97,6 +97,10 @@ jobs:
           pnpm run create-sample-app a${{ matrix.version }}
           --tmp-dir=${{ runner.temp }}
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
       - name: Build Angular v${{ matrix.version }} E2E app
         run: pnpm build --source-map # with source map for bundle size analysis
         working-directory: ${{ env.E2E_APP_DIR }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -86,6 +86,10 @@ jobs:
           # will be taken into account in max 1 week time
           # Patch releases shouldn't break anything anyway
           key: ${{ env.cache-name }}-${{ env.e2e_scripts_lockfile_hash }}-${{ env.angular_cli_version }}-${{ env.week_of_year }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
       - name: Install E2E scripts dependencies
         run: pnpm install --frozen-lockfile
         working-directory: ${{ env.E2E_SCRIPTS_DIR }}

--- a/projects/ngx-meta/e2e/scripts/src/create-sample-app.ts
+++ b/projects/ngx-meta/e2e/scripts/src/create-sample-app.ts
@@ -257,11 +257,15 @@ async function installApp(appDir: string) {
 
 async function installLibrary(appDir: string) {
   Log.step('Installing (linking) library')
-  const installCommand = execa('pnpm', ['add', getRelativeLibraryDistDir()], {
-    cwd: appDir,
-    all: true,
-    env: { FORCE_COLOR: true.toString() },
-  })
+  const installCommand = execa(
+    'pnpm',
+    ['install', getRelativeLibraryDistDir()],
+    {
+      cwd: appDir,
+      all: true,
+      env: { FORCE_COLOR: true.toString() },
+    },
+  )
   Log.stream(installCommand.all)
   await installCommand
 }

--- a/projects/ngx-meta/e2e/scripts/src/create-sample-app.ts
+++ b/projects/ngx-meta/e2e/scripts/src/create-sample-app.ts
@@ -197,21 +197,11 @@ function cleanUpTmpDir(tmpDir: string) {
 
 async function installCli(tmpDir: string) {
   Log.step('Installing Angular CLI')
-  const installCommand = execa(
-    'pnpm',
-    [
-      'install',
-      // 👇 On CI pipeline, allow updating lockfile if needed
-      //    Given cached lockfile will be updated after updating Angular CLI version
-      //    https://pnpm.io/cli/install#--frozen-lockfile
-      '--frozen-lockfile=false',
-    ],
-    {
-      cwd: tmpDir,
-      all: true,
-      env: { FORCE_COLOR: true.toString() },
-    },
-  )
+  const installCommand = execa('pnpm', ['install'], {
+    cwd: tmpDir,
+    all: true,
+    env: { FORCE_COLOR: true.toString() },
+  })
   Log.stream(installCommand.all)
   await installCommand
 }


### PR DESCRIPTION
# Issue or need

After #504, we are no longer caching in the CI/CD (E2E workflow) the:
 - Resolution of E2E app dependencies: `pnpm-lock.yaml` is ignored
 - E2E app dependencies: as `pnpm-lock.yaml` not in repo, a custom cache strategy is needed cause we can't use `setup-node` helpers

Also because of #504 we're running `ng new` everytime, so we need to download Angular CLI everytime as Angular CLI is not taken into account for caching in CI/CD

Now that Angular CLI version is pinned (see #511), we can
 - Cache dependency resolution for specific Angular CLI version (otherwise we'd cache resolution for a semver range, which changes over time)
 - Cache Angular CLI at specific version to avoid downloading it each time

Introducing cache back here, with a custom cache strategy that allows 
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes
Use `@actions/cache` to create a custom caching strategy

See comments in code for details

## Alternatives considered:
### Commit generated app lockfiles to the repository
But:
- Takes space (many lines in each)
- Could be duplicated: I'm thinking of adding also another test scenario to the matrix: standalone / non-standalone APIs tests for same Angular version
- Generates security dep updates noise (though that can be disabled with a rule)
  - Not sure if only having a lockfile will trigger those.

Same for adding `package.json` files of generated apps, but with addition of:
- Dependency update mgmt: we'd need to keep all of those deps updated. Which means:
  - PRs for Angular CLI monorepo: 1 per major version -> 3 PRs -> 2 extra ones (1 is already needed for current Angular version)
  - PRs for Angular monorepo: 1 per major version (this could be joined with previous by config) -> 3 PRs -> 2 extra ones (1 is already needed for current Angular version)
  - PRs for `zone.js`: 1 per major version -> 3 PRs -> 2 extra ones (1 is already needed for current Angular version)
  - PRs for SSR deps: `express`, `ng-universal` for Angular versions before v17

Anyway it's quite a good alternative to keep in mind.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
