### PR TITLE
build: config dep updates for Angular CLI versions

### DIFF
--- a/projects/ngx-meta/e2e/scripts/angular-cli-versions.json
+++ b/projects/ngx-meta/e2e/scripts/angular-cli-versions.json
@@ -4,6 +4,8 @@
   "description": "ngx-meta E2E pinned Angular CLI versions to create sample apps",
   "private": true,
   "packageManager": "pnpm@8.15.6",
+  "//1": "👇 Updated by dependency bot, but restricted to major versions",
+  "//2": "   See Renovate configuration for more information",
   "devDependencies": {
     "a15": "npm:@angular/cli@15.2.11",
     "a16": "npm:@angular/cli@16.2.14",

--- a/renovate.json5
+++ b/renovate.json5
@@ -110,63 +110,27 @@
       ],
       allowedVersions: '0.14.x',
     },
-    // Angular v16.1.x || v16.2.x compatibilities
-    // https://angular.io/guide/versions
-    // https://update.angular.io/?v=15.0-16.0 (zone.js)
+    // Sample apps major versions
     {
-      matchPackagePrefixes: ['@angular', '@angular-devkit'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a16/package.json'],
-      allowedVersions: '^16',
-    },
-    //👇 N/A. Just to have this info somewhere near
-    {
-      matchPackageNames: ['node', '@types/node'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a16/package.json'],
-      allowedVersions: '^16.14.0 || ^18.10.0',
-    },
-    {
-      matchPackageNames: ['typescript'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a16/package.json'],
-      allowedVersions: '>=4.9.3 <5.2.0',
-    },
-    {
-      matchPackageNames: ['rxjs'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a16/package.json'],
-      allowedVersions: '^6.5.3 || ^7.4.0',
-    },
-    {
-      matchPackageNames: ['zone.js'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a16/package.json'],
-      allowedVersions: '0.13.x',
-    },
-    // Angular v15.1.x || v15.2.x compatibilities
-    // https://angular.io/guide/versions
-    // https://github.com/angular/angular/blob/15.2.10/packages/core/package.json (zone.js)
-    {
-      matchPackagePrefixes: ['@angular', '@angular-devkit'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a15/package.json'],
+      matchFileNames: [
+        'projects/ngx-meta/e2e/scripts/angular-cli-versions.json',
+      ],
+      matchPackageNames: 'a15',
       allowedVersions: '^15',
     },
-    //👇 N/A. Just to have this info somewhere near
     {
-      matchPackageNames: ['node', '@types/node'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a15/package.json'],
-      allowedVersions: '^14.20.0 || ^16.13.0 || ^18.10.0',
+      matchFileNames: [
+        'projects/ngx-meta/e2e/scripts/angular-cli-versions.json',
+      ],
+      matchPackageNames: 'a16',
+      allowedVersions: '^16',
     },
     {
-      matchPackageNames: ['typescript'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a15/package.json'],
-      allowedVersions: '>=4.8.2 <5.0.0',
-    },
-    {
-      matchPackageNames: ['rxjs'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a15/package.json'],
-      allowedVersions: '^6.5.3 || ^7.4.0',
-    },
-    {
-      matchPackageNames: ['zone.js'],
-      matchFileNames: ['projects/ngx-meta/e2e/apps/a15/package.json'],
-      allowedVersions: '~0.11.4 || ~0.12.0 || ~0.13.0',
+      matchFileNames: [
+        'projects/ngx-meta/e2e/scripts/angular-cli-versions.json',
+      ],
+      matchPackageNames: 'a17',
+      allowedVersions: '^17',
     },
     // API Documenter to use Markdown tables
     // Watching issue to see if we can upgrade when fixed


### PR DESCRIPTION
# Issue or need

In Angular CLI versions file used to generate sample apps, versions are not constrained in dependency update tool Renovate

So it is currently trying to update older versions than latest to latest version.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Configure Renovate to pin each Angular CLI version to its proper range

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
