### PR TITLE
ci(examples): use app name instead of version

### DIFF
--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -22,19 +22,19 @@ env:
 
 jobs:
   bundle-size-pr-comment:
-    name: Bundle size - PR comment - Angular ${{ matrix.version }}
+    name: Bundle size - PR comment - Angular ${{ matrix.app_name }}
     if: github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [v15, v16, v17]
+        app_name: [v15, v16, v17]
     steps:
       - name: Download bundle size analysis results
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
         with:
-          name: ${{ env.BUNDLE_SIZE_ARTIFACT_NAME_PREFIX }}${{ matrix.version }}
+          name: ${{ env.BUNDLE_SIZE_ARTIFACT_NAME_PREFIX }}${{ matrix.app_name }}
           #👇 Need to specify it, otherwise, `run-id` argument won't be taken into account
           # https://github.com/actions/download-artifact/tree/v4.1.4#:~:text=current%20workflow%20run.-,github%2Dtoken%3A,-%23%20The%20repository
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
         with:
           issue-number: ${{ steps.pr.outputs.result }}
           comment-author: github-actions[bot]
-          body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.version }}
+          body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.app_name }}
       - name: Update bundle size PR comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -28,15 +28,15 @@ env:
 
 jobs:
   analysis:
-    name: Analysis - Angular ${{ matrix.version }}
+    name: Analysis - Angular ${{ matrix.app_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [v15, v16, v17]
+        app_name: [v15, v16, v17]
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.version }}
-      OUTPUT_DIR: out/${{ matrix.version }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.app_name }}
+      OUTPUT_DIR: out/${{ matrix.app_name }}
     defaults:
       run:
         working-directory: ${{ env.BUNDLE_SIZE_DIR }}
@@ -48,7 +48,7 @@ jobs:
       - name: Download example app distribution files
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
         with:
-          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.version }}
+          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
           path: ${{ env.EXAMPLE_APP_DIR }}/dist
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
@@ -61,7 +61,7 @@ jobs:
       - name: Install bundle size analysis dependencies
         run: pnpm install --frozen-lockfile
       - name: Analyze main bundle size
-        run: pnpm run analyze ${{ matrix.version }} --json
+        run: pnpm run analyze ${{ matrix.app_name }} --json
       - name: Fetch bundle size analysis results from 'main' branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         if: github.event_name == 'pull_request'
@@ -71,7 +71,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'heads/main',
-              check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.version }}',
+              check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.app_name }}',
               per_page: 1,
             })
             const checkRuns = checkRunResponse.data.check_runs
@@ -89,34 +89,34 @@ jobs:
       - name: Generate bundle size PR comment
         if: github.event_name == 'pull_request'
         run: >
-          pnpm run report ${{ matrix.version }}
+          pnpm run report ${{ matrix.app_name }}
           --git-ref '${{ github.event.pull_request.head.sha }}'
-          --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.version }}'
+          --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.app_name }}'
           --base-file '${{ env.OUTPUT_DIR }}/source-map-explorer-main.json'
           --output-file '${{ env.OUTPUT_DIR }}/bundle-size-pr-comment.md'
       - name: Generate bundle size report
-        run: pnpm run report ${{ matrix.version }} --git-ref '${{ github.sha }}'
+        run: pnpm run report ${{ matrix.app_name }} --git-ref '${{ github.sha }}'
       - name: Upload bundle size analysis results
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.version }}
+          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.app_name }}
           path: ${{ env.BUNDLE_SIZE_DIR }}/${{ env.OUTPUT_DIR }}
           retention-days: 5
 
   store:
     needs: analysis
     if: github.event_name == 'push'
-    name: Store - Angular ${{ matrix.version }}
+    name: Store - Angular ${{ matrix.app_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [v15, v16, v17]
+        app_name: [v15, v16, v17]
     steps:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
         with:
-          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.version }}
+          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.app_name }}
       - name: Create check run
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -126,7 +126,7 @@ jobs:
             return github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.version }}',
+              name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.app_name }}',
               head_sha: context.sha,
               // In case you're testing this in a PR, you'll want the head SHA
               // otherwise, `context.sha` refers to the GitHub PR merge branch
@@ -134,9 +134,9 @@ jobs:
               // head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               output: {
-                title: 'Bundle size - Angular ${{ matrix.version }}',
+                title: 'Bundle size - Angular ${{ matrix.app_name }}',
                 summary: 'Sizes of the library modules when packed inside a ' +
-                         'main bundle of an Angular ${{ matrix.version }} ' +
+                         'main bundle of an Angular ${{ matrix.app_name }} ' +
                          'app. In bytes. Thanks to `source-map-explorer` :)',
                 text: smeJsonString,
               }

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -17,14 +17,14 @@ env:
 
 jobs:
   e2e:
-    name: E2E tests - Angular ${{ matrix.version }}
+    name: E2E tests - Angular ${{ matrix.app_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [v15, v16, v17]
+        app_name: [v15, v16, v17]
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.version }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.app_name }}
     defaults:
       run:
         working-directory: ${{ env.E2E_DIR }}
@@ -36,7 +36,7 @@ jobs:
       - name: Download example app distribution files
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
         with:
-          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.version }}
+          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
           path: ${{ env.EXAMPLE_APP_DIR }}/dist
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
@@ -67,7 +67,7 @@ jobs:
           start: >
             pnpm
             http-server
-            ../examples/apps/${{ matrix.version }}/dist/${{ matrix.version }}/browser
+            ../examples/apps/${{ matrix.app_name }}/dist/${{ matrix.app_name }}/browser
             --proxy http://localhost:${{ env.APP_PORT }}?
             --port ${{ env.APP_PORT }}
           wait-on: http://localhost:${{ env.APP_PORT }}

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -19,14 +19,14 @@ env:
 
 jobs:
   example-app:
-    name: Example app - Angular ${{ matrix.version }}
+    name: Example app - Angular ${{ matrix.app_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        version: [v15, v16, v17]
+        app_name: [v15, v16, v17]
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.version }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.app_name }}
     defaults:
       run:
         working-directory: ${{ env.EXAMPLES_DIR }}
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "pnpm_store_path=$(pnpm store path --silent)" >> $GITHUB_ENV
           echo "angular_cli_version=$(jq -r \
-            '.devDependencies.a${{ matrix.version }}' \
+            '.devDependencies.a${{ matrix.app_name }}' \
             'angular-cli-versions.json' |
             sed 's|npm:@angular/cli@||g'
           )" >> $GITHUB_ENV
@@ -94,7 +94,7 @@ jobs:
         run: pnpm run build
       - name: Create example app
         run: >
-          pnpm run create-example-app ${{ matrix.version }}
+          pnpm run create-example-app ${{ matrix.app_name }}
           --tmp-dir=${{ runner.temp }}
       - name: Build example app
         run: pnpm build --source-map # with source map for bundle size analysis
@@ -103,7 +103,7 @@ jobs:
         if: ${{ inputs.example-app-artifact-name-prefix != '' }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.version }}
+          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
           path: |
             ${{ env.EXAMPLE_APP_DIR }}/dist
           retention-days: 5


### PR DESCRIPTION
# Issue or need

Before #523 many CI/CD infra were mentioning Angular major versions to refer to created example app names

Now that the abstraction is not leaked anymore, we can change the CI/CD matrix name used to loop thrugh example app names too


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Rename example apps matrix name from `version` to `app_name`

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
