### PR TITLE
ci(examples): fix cache key

### DIFF
--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Get caching key info
         run: |
           echo "pnpm_store_path=$(pnpm store path --silent)" >> $GITHUB_ENV
+          # 👇 Actually not 100% app name, but app name's version
+          #    Good enough for now though. In future we can introduce
+          #    some script to get Angular CLI version for a given app name
           echo "angular_cli_version=$(jq -r \
             '.devDependencies.${{ matrix.app_name }}' \
             'angular-cli-versions.json' |

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "pnpm_store_path=$(pnpm store path --silent)" >> $GITHUB_ENV
           echo "angular_cli_version=$(jq -r \
-            '.devDependencies.a${{ matrix.app_name }}' \
+            '.devDependencies.${{ matrix.app_name }}' \
             'angular-cli-versions.json' |
             sed 's|npm:@angular/cli@||g'
           )" >> $GITHUB_ENV

--- a/projects/ngx-meta/examples/src/create-example-app.ts
+++ b/projects/ngx-meta/examples/src/create-example-app.ts
@@ -22,6 +22,8 @@ type AngularCliVersion =
 
 interface ExampleApp {
   readonly name: string
+  //👇 Right now name + CLI version MUST match
+  //   See example apps workflow cache info step for more info
   readonly cliVersion: AngularCliVersion
   readonly angularCliNewArguments?: ReadonlyArray<string>
   readonly standalone: boolean


### PR DESCRIPTION
# Issue or need

After one of the recent PRs (probably #523) cache for example apps CI/CD workflow stopped working as intended

Reason is `angular_cli_version` part of the key is `null`

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Refer to proper `devDependencies` key to restore proper cache key

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
