### PR TITLE
build(renovate): temporarily pin dts-bundle-generator

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -122,5 +122,11 @@
       matchPackageNames: ['@microsoft/api-documenter'],
       allowedVersions: '7.23.38',
     },
+    // dts-bundle-generator missing namespace import
+    // https://github.com/timocov/dts-bundle-generator/issues/319
+    {
+      matchPackageNames: ['dts-bundle-generator'],
+      allowedVersions: '9.3.1',
+    },
   ],
 }


### PR DESCRIPTION
# Issue or need

New versions of `dts-bundle-generator` output invalid bundled definition files
See:
 - https://github.com/davidlj95/ngx/pull/536
 - https://github.com/timocov/dts-bundle-generator/issues/319

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Pins `dts-bundle-generator` to `9.3.1` to avoid updates until issue is fixed

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
