### PR TITLE
build(examples): upload whole app and e2e test with SSR

### DIFF
--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4
         with:
           name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
-          path: ${{ env.EXAMPLE_APP_DIR }}/dist
+          path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - name: Setup Node.js

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
+  APP_PORT: 4200
 
 jobs:
   e2e:
@@ -33,11 +34,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Download example app distribution files
+      - name: Download example app
         uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4
         with:
           name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
-          path: ${{ env.EXAMPLE_APP_DIR }}/dist
+          path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       - name: Setup Node.js
@@ -45,7 +46,7 @@ jobs:
         with:
           cache: pnpm
           cache-dependency-path: ${{ env.E2E_DIR }}/pnpm-lock.yaml
-          node-version-file: .node-version
+          node-version-file: .node-version # should be one compatible with Angular example app
       - name: Get Cypress cache dir
         run: echo "cypress_cache_dir=$HOME/.cache/Cypress" >> $GITHUB_ENV
       - name: Cypress cache
@@ -58,18 +59,16 @@ jobs:
           key: ${{ env.cache-name }}-${{ env.e2e_lockfile_hash }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Serve app
+        run: pnpm run ci:serve &
+        env:
+          PORT: ${{ env.APP_PORT }}
+        working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Cypress run
         uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a # v6.6.1
         env:
           CYPRESS_CACHE_FOLDER: ${{ env.cypress_cache_dir }}
-          APP_PORT: 4200
         with:
-          start: >
-            pnpm
-            http-server
-            ../examples/apps/${{ matrix.app_name }}/dist/${{ matrix.app_name }}/browser
-            --proxy http://localhost:${{ env.APP_PORT }}?
-            --port ${{ env.APP_PORT }}
           wait-on: http://localhost:${{ env.APP_PORT }}
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -108,13 +108,12 @@ jobs:
       - name: Remove unneeded files
         run: >
           rm -rf src .angular .vscode .gitignore README.md server.ts
-            angular.json tsconfig*.json
+          angular.json tsconfig*.json
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Upload example app
         if: ${{ inputs.example-app-artifact-name-prefix != '' }}
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4
         with:
           name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
-          path: |
-            ${{ env.EXAMPLE_APP_DIR }}
+          path: ${{ env.EXAMPLE_APP_DIR }}
           retention-days: 5

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -102,11 +102,19 @@ jobs:
       - name: Build example app
         run: pnpm ci:build # includes SSR and source maps
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
-      - name: Upload example app distribution files
+      - name: Remove development dependencies
+        run: pnpm install --prod --frozen-lockfile
+        working-directory: ${{ env.EXAMPLE_APP_DIR }}
+      - name: Remove unneeded files
+        run: >
+          rm -rf src .angular .vscode .gitignore README.md server.ts
+            angular.json tsconfig*.json
+        working-directory: ${{ env.EXAMPLE_APP_DIR }}
+      - name: Upload example app
         if: ${{ inputs.example-app-artifact-name-prefix != '' }}
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4
         with:
           name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
           path: |
-            ${{ env.EXAMPLE_APP_DIR }}/dist
+            ${{ env.EXAMPLE_APP_DIR }}
           retention-days: 5

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        app_name: [v15]
+        app_name: [v15, v16, v17]
     env:
       EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.app_name }}
     defaults:
@@ -102,22 +102,34 @@ jobs:
       - name: Build example app
         run: pnpm ci:build # includes SSR and source maps
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
+        # 👇 We can't do just `pnpm prune --prod` or `pnpm i --prod`
+        #    GitHub Actions `actions/upload-artifact` doesn't like symlinks
+        #    Original error in CI:
+        #    ```
+        #    With the provided path, there will be 130112 files uploaded
+        #    Error: EMFILE: too many open files, open '/home/runner/work/ngx...
+        #    ```
+        #    See https://github.com/actions/upload-artifact/issues/418
+        #    So we need to perform an installation with hoisted node linker
+        #    https://pnpm.io/npmrc#node-linker
+        #    After that, neither of previous commands work :(
+        #    Neither does `pnpm deploy --prod`. So easiest is remove and reinstall
       - name: Remove development dependencies
-        run: pnpm install --prod --frozen-lockfile
-        working-directory: ${{ env.EXAMPLE_APP_DIR }}
-      - name: Remove unneeded files
-        run: >
-          rm -rf src .angular .vscode .gitignore README.md server.ts
-          angular.json tsconfig*.json
+        run: |
+          rm -rf node_modules/
+          echo "node-linker=hoisted" > .npmrc
+          pnpm install --prod --frozen-lockfile
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Upload example app
         if: ${{ inputs.example-app-artifact-name-prefix != '' }}
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4
         with:
           name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app_name }}
-          path: ${{ env.EXAMPLE_APP_DIR }}
+          path: |
+            ${{ env.EXAMPLE_APP_DIR }}/node_modules/
+            !${{ env.EXAMPLE_APP_DIR }}/node_modules/.bin
+            !${{ env.EXAMPLE_APP_DIR }}/node_modules/.pnpm
+            !${{ env.EXAMPLE_APP_DIR }}/node_modules/*.yaml
+            ${{ env.EXAMPLE_APP_DIR }}/dist
+            ${{ env.EXAMPLE_APP_DIR }}/package.json
           retention-days: 5

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        app_name: [v15, v16, v17]
+        app_name: [v15]
     env:
       EXAMPLE_APP_DIR: projects/ngx-meta/examples/apps/${{ matrix.app_name }}
     defaults:
@@ -102,6 +102,10 @@ jobs:
       - name: Build example app
         run: pnpm ci:build # includes SSR and source maps
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
       - name: Remove development dependencies
         run: pnpm install --prod --frozen-lockfile
         working-directory: ${{ env.EXAMPLE_APP_DIR }}


### PR DESCRIPTION
# Issue or need

Until now example apps in CI/CD were served using client side rendering (CSR) to run E2E tests against them. However, this way we're not testing that the library properly handles server side rendering (SSR).

After recent changes in infra, we can now serve the app with SSR to properly test the library functionalities when example app is running with SSR\*

> That won't be enough, given Cypress renders the app in a browser and therefore it could be that the `<meta>` elements in there render only in the client. We'll need a bit of work to ensure that ⚙️

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Upload whole app instead of just distribution files\* and serve the app using SSR when running E2E tests

> \*Just running the `server\.[m]?js` isn't enough as there are some dependencies from `node_modules` that need to be there

In order to avoid uploading too many things, before uploading the artifact containing the example app development dependencies are removed. Only needed files are uploaded (`dist` + `node_modules` + `package.json`)

A quirk appeared when removing development dependencies & later uploading artifact. Checkout CI/CD workflow for example apps for more info.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
