### PR TITLE
build(bundle-size): update reporting file name

### DIFF
--- a/projects/ngx-meta/bundle-size/report.sh
+++ b/projects/ngx-meta/bundle-size/report.sh
@@ -185,9 +185,14 @@ NO_BASE_EXISTS_MSG="Not available"
     LIB_NAME="ngx-meta"
     beautified_file="$(
       echo "$file" |
-        sed 's|webpack:///||' |                                             # Angular webpack builds (<v17 with esbuild)
-        sed 's|node_modules/.pnpm/file[\+\.a-z_@0-9]*/||' |                 # Installed lib with file:
-        sed "s|node_modules/@${LIB_SCOPE}/$LIB_NAME/fesm2022/$LIB_SCOPE-||" # Lib location after file:+..+...
+        sed 's|webpack:///||' | # Angular webpack builds (<v17 with esbuild)
+        sed 's|node_modules/||g' |
+        sed 's|.pnpm/||' |
+        sed "s|@${LIB_SCOPE}+${LIB_NAME}@||g" | # Appeared in pnpm v9
+        sed 's|file[\+\.a-z_@0-9]*/||' |
+        sed "s|@${LIB_SCOPE}/$LIB_NAME/||" |
+        sed 's|fesm2022/||' |
+        sed "s|$LIB_SCOPE-||" # Appears in file name
     )"
     input_bytes_size="$(get_size_for_file "$input_lib_sizes" "$file")"
     total_input_bytes_size="$((total_input_bytes_size + input_bytes_size))"


### PR DESCRIPTION
# Issue or need

In `pnpm` upgrade to v9, the path to modules installed with `file:` changed (see #550) so bundle size reports did no longer properly shorten the module path

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Take into account change in beautification of module file for bundle size analysis reports

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
