### PR TITLE
build(e2e): ensure SSR library support

### DIFF
--- a/projects/ngx-meta/e2e/README.md
+++ b/projects/ngx-meta/e2e/README.md
@@ -1,12 +1,14 @@
 # `@davidlj95/ngx-meta` E2E testing infra
 
-Infra in this directory allows to test main library features using [example apps](../example-apps). [Cypress] is used to ensure the metadata elements are inserted into / removed from the page as expected.
+Infra in this directory allows to test main library features using [example apps infra]. [Cypress] is used to ensure the metadata elements are inserted into / removed from the page as expected.
 
 [Cypress]: https://www.cypress.io/
+[example apps infra]: ../example-apps/README.md
 
 ## Example app
 
-First, create the example app to test using [example apps infra](../example-apps).
+First, create the example app and serve the app with SSR in order to pass the SSR tests too.
+Checkout [example apps infra] for more information about example apps and how to operate them.
 
 ## Tasks
 
@@ -37,3 +39,19 @@ Choose E2E testing. Then, choose a browser (Chrome is used in CI/CD). Use Cypres
 There are many run configurations `ngx-meta/e2e:` in WebStorm to help you run E2E tests and see results right in the IDE
 
 Remember to serve an example app first.
+
+## Quirks
+
+### SSR compatibility testing
+
+There is no way in Cypress right now to test a feature is compatible with server side rendering (SSR). When visiting a page, the browser loads the scripts. So we're not sure if what is on the page comes from server side rendering (SSR) or client side rendering (CSR). So, to simulate SSR and ensure the library is compatible with SSR with Cypress, `<script>`s are manually removed to simulate SSR. That's what peeps in the Internet are doing and seems the only way for now. Does the trick, so going for it.
+
+Other options considered:
+
+- **Use plain HTTP requests instead of Cypress**. Faster and less overhead than a Cypress setup. However, we wouldn't be able to test CSR scenarios though. Like that metadata gets cleared when switching routes by navigating to a different page.
+
+Links:
+
+- [Testing server side rendered (SSR) React with Cypress](https://blog.simonireilly.com/posts/server-side-rendering-tests-in-cypress/)
+- [End-to-end Testing for Server-Side Rendered Pages](https://glebbahmutov.com/blog/ssr-e2e/)
+- [Cypress and SSR (Server Side Rendering) on Cypress' GitHub Discussions](https://github.com/cypress-io/cypress/discussions/26595)

--- a/projects/ngx-meta/e2e/cypress/e2e/all-meta-set-by-route.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/all-meta-set-by-route.spec.cy.ts
@@ -11,35 +11,38 @@ import { testSetsJsonLd } from '../support/test-sets-json-ld'
 import { testUnsetsJsonLd } from '../support/test-unsets-json-ld'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 
 describe('All meta set by route', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.allMetaSetByRoute.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.allMetaSetByRoute.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        testNoLibLogsAndNoWarnsOrErrors()
+        testSetsAllStandardMetadata()
+        testSetsAllOpenGraphMetadata()
+        testSetsAllOpenGraphProfileMetadata()
+        testSetsAllTwitterCardMetadata()
+        testSetsJsonLd()
       },
-    })
-  })
-
-  testSetsAllStandardMetadata()
-  testSetsAllOpenGraphMetadata()
-  testSetsAllOpenGraphProfileMetadata()
-  testSetsAllTwitterCardMetadata()
-  testSetsJsonLd()
-  testNoConsoleLogsAreEmitted()
-
-  describe('when going to another route', () => {
-    beforeEach(() => {
-      cy.goToRootPage()
-    })
-
-    testUnsetsAllStandardMetadata()
-    testUnsetsAllOpenGraphMetadata()
-    testUnsetsAllOpenGraphProfileMetadata()
-    testUnsetsAllTwitterCardMetadata()
-    testUnsetsJsonLd()
-    testNoConsoleLogsAreEmitted()
-  })
+      csrOnly: () => {
+        describe('when going to another route', () => {
+          beforeEach(() => {
+            cy.goToRootPage()
+          })
+          testNoLibLogsAndNoWarnsOrErrors()
+          testUnsetsAllStandardMetadata()
+          testUnsetsAllOpenGraphMetadata()
+          testUnsetsAllOpenGraphProfileMetadata()
+          testUnsetsAllTwitterCardMetadata()
+          testUnsetsJsonLd()
+        })
+      },
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/e2e/all-meta-set-by-service.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/all-meta-set-by-service.spec.cy.ts
@@ -4,24 +4,28 @@ import { testSetsAllOpenGraphMetadata } from '../support/test-sets-all-open-grap
 import { testSetsAllOpenGraphProfileMetadata } from '../support/test-sets-all-open-graph-profile-metadata'
 import { testSetsAllTwitterCardMetadata } from '../support/test-sets-all-twitter-card-metadata'
 import { testSetsJsonLd } from '../support/test-sets-json-ld'
+
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
 
 describe('All meta set by service', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.allMetaSetByService.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.allMetaSetByService.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        testNoLibLogsAndNoWarnsOrErrors()
+        testSetsAllStandardMetadata()
+        testSetsAllOpenGraphMetadata()
+        testSetsAllOpenGraphProfileMetadata()
+        testSetsAllTwitterCardMetadata()
+        testSetsJsonLd()
       },
-    })
-  })
-
-  testNoConsoleLogsAreEmitted()
-  testSetsAllStandardMetadata()
-  testSetsAllOpenGraphMetadata()
-  testSetsAllOpenGraphProfileMetadata()
-  testSetsAllTwitterCardMetadata()
-  testSetsJsonLd()
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/e2e/defaults.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/defaults.spec.cy.ts
@@ -1,26 +1,29 @@
 import { ROUTES } from '../fixtures/routes'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
 import DEFAULTS_JSON from '../fixtures/defaults.json'
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 
 describe('Defaults', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.root.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.root.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        it('should set default author', () => {
+          cy.fixture('defaults.json').then((defaults: typeof DEFAULTS_JSON) => {
+            cy.getMeta('author')
+              .shouldHaveContent()
+              .and('eq', defaults.standard.author)
+          })
+        })
+
+        testNoLibLogsAndNoWarnsOrErrors()
       },
-    })
-  })
-
-  it('should set default author', () => {
-    cy.fixture('defaults.json').then((defaults: typeof DEFAULTS_JSON) => {
-      cy.getMeta('author')
-        .shouldHaveContent()
-        .and('eq', defaults.standard.author)
-    })
-  })
-
-  testNoConsoleLogsAreEmitted()
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/e2e/meta-late-loaded-custom.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-late-loaded-custom.spec.cy.ts
@@ -1,42 +1,46 @@
 import { ROUTES } from '../fixtures/routes'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
 import CUSTOM_METADATA_JSON from '../fixtures/custom-metadata.json'
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 
 describe('Meta late loaded + custom', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.metaLateLoaded.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.metaLateLoaded.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        testNoLibLogsAndNoWarnsOrErrors()
+        it('should set late loaded + custom metadata', () => {
+          cy.fixture('custom-metadata.json').then(
+            (customMetadata: typeof CUSTOM_METADATA_JSON) => {
+              cy.getMeta(customMetadata.custom.keyName)
+                .shouldHaveContent()
+                .and('eq', customMetadata.custom.title)
+            },
+          )
+        })
       },
-    })
-  })
+      csrOnly: () => {
+        describe('when going to another route', () => {
+          beforeEach(() => {
+            cy.goToRootPage()
+          })
 
-  testNoConsoleLogsAreEmitted()
-  it('should set late loaded + custom metadata', () => {
-    cy.fixture('custom-metadata.json').then(
-      (customMetadata: typeof CUSTOM_METADATA_JSON) => {
-        cy.getMeta(customMetadata.custom.keyName)
-          .shouldHaveContent()
-          .and('eq', customMetadata.custom.title)
+          testNoLibLogsAndNoWarnsOrErrors()
+          it('should unset late loaded + custom metadata', () => {
+            cy.fixture('custom-metadata.json').then(
+              (metadata: typeof CUSTOM_METADATA_JSON) => {
+                cy.getMeta(metadata.custom.keyName).should('not.exist')
+              },
+            )
+          })
+        })
       },
-    )
-  })
-
-  describe('when going to another route', () => {
-    beforeEach(() => {
-      cy.goToRootPage()
-    })
-
-    testNoConsoleLogsAreEmitted()
-    it('should unset late loaded + custom metadata', () => {
-      cy.fixture('custom-metadata.json').then(
-        (metadata: typeof CUSTOM_METADATA_JSON) => {
-          cy.getMeta(metadata.custom.keyName).should('not.exist')
-        },
-      )
-    })
-  })
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
@@ -6,40 +6,44 @@ import { testSetsAllTwitterCardMetadata } from '../support/test-sets-all-twitter
 import { testSetsJsonLd } from '../support/test-sets-json-ld'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
 import { testUnsetsAllStandardMetadata } from '../support/test-unsets-all-standard-metadata'
 import { testUnsetsAllOpenGraphMetadata } from '../support/test-unsets-all-open-graph-metadata'
 import { testUnsetsAllOpenGraphProfileMetadata } from '../support/test-unsets-all-open-graph-profile-metadata'
 import { testUnsetsAllTwitterCardMetadata } from '../support/test-unsets-all-twitter-card-metadata'
 import { testUnsetsJsonLd } from '../support/test-unsets-json-ld'
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 
 describe('Meta set by route and service', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.metaSetByRouteAndService.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.metaSetByRouteAndService.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        testNoLibLogsAndNoWarnsOrErrors()
+        testSetsAllStandardMetadata()
+        testSetsAllOpenGraphMetadata({ type: 'book' })
+        testSetsAllOpenGraphProfileMetadata({ gender: 'female' })
+        testSetsAllTwitterCardMetadata({ card: 'summary_large_image' })
+        testSetsJsonLd()
       },
-    })
-  })
+      csrOnly: () => {
+        describe('when going to another route', () => {
+          beforeEach(() => {
+            cy.goToRootPage()
+          })
 
-  testNoConsoleLogsAreEmitted()
-  testSetsAllStandardMetadata()
-  testSetsAllOpenGraphMetadata({ type: 'book' })
-  testSetsAllOpenGraphProfileMetadata({ gender: 'female' })
-  testSetsAllTwitterCardMetadata({ card: 'summary_large_image' })
-  testSetsJsonLd()
-
-  describe('when going to another route', () => {
-    beforeEach(() => {
-      cy.goToRootPage()
-    })
-
-    testUnsetsAllStandardMetadata()
-    testUnsetsAllOpenGraphMetadata()
-    testUnsetsAllOpenGraphProfileMetadata()
-    testUnsetsAllTwitterCardMetadata()
-    testUnsetsJsonLd()
-    testNoConsoleLogsAreEmitted()
-  })
+          testUnsetsAllStandardMetadata()
+          testUnsetsAllOpenGraphMetadata()
+          testUnsetsAllOpenGraphProfileMetadata()
+          testUnsetsAllTwitterCardMetadata()
+          testUnsetsJsonLd()
+          testNoLibLogsAndNoWarnsOrErrors()
+        })
+      },
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/e2e/one-meta-set-by-service.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/one-meta-set-by-service.spec.cy.ts
@@ -1,8 +1,8 @@
 import { ROUTES } from '../fixtures/routes'
 import {
   spyOnConsole,
-  testNoConsoleLogsAreEmitted,
-} from '../support/no-console-logs-are-emitted'
+  testNoLibLogsAndNoWarnsOrErrors,
+} from '../support/test-no-lib-logs-and-no-warns-or-errors'
 import ONE_METADATA_JSON from '../fixtures/one-metadata.json'
 import { openGraphTitleShouldEqual } from '../support/test-sets-all-open-graph-metadata'
 import {
@@ -12,37 +12,40 @@ import {
 import { twitterCardTitleShouldEqual } from '../support/test-sets-all-twitter-card-metadata'
 import { openGraphDescriptionShouldNotExist } from '../support/test-unsets-all-open-graph-metadata'
 import { twitterCardDescriptionShouldNotExist } from '../support/test-unsets-all-twitter-card-metadata'
+import { testWithSsrAndCsr } from '../support/test-with-ssr-and-csr'
 
 describe('One meta set by service', () => {
-  beforeEach(() => {
-    cy.visit(ROUTES.oneMetaSetByService.path, {
-      onBeforeLoad(win: Cypress.AUTWindow) {
-        spyOnConsole(win)
-      },
-    })
-  })
+  testWithSsrAndCsr(
+    {
+      url: ROUTES.oneMetaSetByService.path,
+      onBeforeLoad: spyOnConsole,
+    },
+    {
+      ssrAndCsr: () => {
+        testNoLibLogsAndNoWarnsOrErrors()
 
-  testNoConsoleLogsAreEmitted()
+        it('should set all title metadata elements', () => {
+          cy.fixture('one-metadata.json').then(
+            (metadata: typeof ONE_METADATA_JSON) => {
+              const expectedTitle = metadata.global.value
+              standardTitleShouldEqual(expectedTitle)
+              openGraphTitleShouldEqual(expectedTitle)
+              twitterCardTitleShouldEqual(expectedTitle)
+            },
+          )
+        })
 
-  it('should set all title metadata elements', () => {
-    cy.fixture('one-metadata.json').then(
-      (metadata: typeof ONE_METADATA_JSON) => {
-        const expectedTitle = metadata.global.value
-        standardTitleShouldEqual(expectedTitle)
-        openGraphTitleShouldEqual(expectedTitle)
-        twitterCardTitleShouldEqual(expectedTitle)
+        it('should set specific description standard element', () => {
+          cy.fixture('one-metadata.json').then(
+            (metadata: typeof ONE_METADATA_JSON) => {
+              const expectedDescription = metadata.jsonPath.value
+              standardDescriptionShouldEqual(expectedDescription)
+              openGraphDescriptionShouldNotExist()
+              twitterCardDescriptionShouldNotExist()
+            },
+          )
+        })
       },
-    )
-  })
-
-  it('should set specific description standard element', () => {
-    cy.fixture('one-metadata.json').then(
-      (metadata: typeof ONE_METADATA_JSON) => {
-        const expectedDescription = metadata.jsonPath.value
-        standardDescriptionShouldEqual(expectedDescription)
-        openGraphDescriptionShouldNotExist()
-        twitterCardDescriptionShouldNotExist()
-      },
-    )
-  })
+    },
+  )
 })

--- a/projects/ngx-meta/e2e/cypress/support/json-ld.ts
+++ b/projects/ngx-meta/e2e/cypress/support/json-ld.ts
@@ -1,0 +1,1 @@
+export const JSON_LD_MIME = 'application/ld+json'

--- a/projects/ngx-meta/e2e/cypress/support/test-no-lib-logs-and-no-warns-or-errors.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-no-lib-logs-and-no-warns-or-errors.ts
@@ -2,24 +2,20 @@
 // https://docs.cypress.io/faq/questions/using-cypress-faq#How-do-I-spy-on-consolelog
 // https://docs.cypress.io/examples/recipes#Stubbing-and-spying
 // https://github.com/cypress-io/cypress-example-recipes/blob/decceecf8ff3a60e2b2f2dfa2461b4c3672949ff/examples/stubbing-spying__window/cypress/e2e/spy-before-load.cy.js
-export function spyOnConsole(window: Cypress.AUTWindow) {
-  cy.spy(window.console as Console, 'log').as('console.log')
-  cy.spy(window.console as Console, 'warn').as('console.warn')
-  cy.spy(window.console as Console, 'info').as('console.info')
-  cy.spy(window.console as Console, 'error').as('console.error')
+
+export function spyOnConsole(autWindow: Cypress.AUTWindow) {
+  cy.spy(autWindow.console as Console, 'log').as('console.log')
+  cy.spy(autWindow.console as Console, 'warn').as('console.warn')
+  cy.spy(autWindow.console as Console, 'info').as('console.info')
+  cy.spy(autWindow.console as Console, 'error').as('console.error')
 }
 
 const NGX_META_LOG_MSG_MATCHER = 'NgxMeta'
 
-export function testNoConsoleLogsAreEmitted() {
-  it('should not emit any console logs', () => {
+export const testNoLibLogsAndNoWarnsOrErrors = () =>
+  it('should not emit console logs related to the library or any warnings or errors', () => {
     // noinspection CYUnresolvedAlias
     cy.get('@console.log').should(
-      'not.have.been.calledWithMatch',
-      NGX_META_LOG_MSG_MATCHER,
-    )
-    // noinspection CYUnresolvedAlias
-    cy.get('@console.warn').should(
       'not.have.been.calledWithMatch',
       NGX_META_LOG_MSG_MATCHER,
     )
@@ -29,9 +25,7 @@ export function testNoConsoleLogsAreEmitted() {
       NGX_META_LOG_MSG_MATCHER,
     )
     // noinspection CYUnresolvedAlias
-    cy.get('@console.error').should(
-      'not.have.been.calledWithMatch',
-      NGX_META_LOG_MSG_MATCHER,
-    )
+    cy.get('@console.warn').should('not.have.been.called')
+    // noinspection CYUnresolvedAlias
+    cy.get('@console.error').should('not.have.been.called')
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-metadata.ts
@@ -1,6 +1,6 @@
 import ALL_METADATA_JSON from '../fixtures/all-metadata.json'
 
-export function testSetsAllOpenGraphMetadata(openGraphOverrides: object = {}) {
+export const testSetsAllOpenGraphMetadata = (openGraphOverrides: object = {}) =>
   it('should set all Open Graph metadata', () => {
     cy.fixture('all-metadata.json').then(
       (jsonMetadata: typeof ALL_METADATA_JSON) => {
@@ -48,7 +48,6 @@ export function testSetsAllOpenGraphMetadata(openGraphOverrides: object = {}) {
       },
     )
   })
-}
 
 export function openGraphTitleShouldEqual(title: string) {
   cy.getMetaWithProperty('og:title').shouldHaveContent().and('eq', title)

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-profile-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-open-graph-profile-metadata.ts
@@ -1,8 +1,8 @@
 import ALL_METADATA_JSON from '../fixtures/all-metadata.json'
 
-export function testSetsAllOpenGraphProfileMetadata(
+export const testSetsAllOpenGraphProfileMetadata = (
   openGraphProfileOverrides: object = {},
-) {
+) =>
   it('should set all Open Graph profile metadata', () => {
     cy.fixture('all-metadata.json').then(
       (jsonMetadata: typeof ALL_METADATA_JSON) => {
@@ -31,4 +31,3 @@ export function testSetsAllOpenGraphProfileMetadata(
       },
     )
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-standard-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-standard-metadata.ts
@@ -1,6 +1,6 @@
 import ALL_METADATA_JSON from '../fixtures/all-metadata.json'
 
-export function testSetsAllStandardMetadata() {
+export const testSetsAllStandardMetadata = () =>
   it('should set all standard metadata', () => {
     cy.fixture('all-metadata.json').then(
       (metadata: typeof ALL_METADATA_JSON) => {
@@ -26,7 +26,6 @@ export function testSetsAllStandardMetadata() {
       },
     )
   })
-}
 
 export function standardTitleShouldEqual(title: string) {
   cy.title().should('eq', title)

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-all-twitter-card-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-all-twitter-card-metadata.ts
@@ -1,8 +1,8 @@
 import ALL_METADATA_JSON from '../fixtures/all-metadata.json'
 
-export function testSetsAllTwitterCardMetadata(
+export const testSetsAllTwitterCardMetadata = (
   twitterCardOverrides: object = {},
-) {
+) =>
   it('should set all Twitter card metadata', () => {
     cy.fixture('all-metadata.json').then(
       (jsonMetadata: typeof ALL_METADATA_JSON) => {
@@ -41,7 +41,6 @@ export function testSetsAllTwitterCardMetadata(
       },
     )
   })
-}
 
 export function twitterCardTitleShouldEqual(title: string) {
   cy.getMeta('twitter:title').shouldHaveContent().and('eq', title)

--- a/projects/ngx-meta/e2e/cypress/support/test-sets-json-ld.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-sets-json-ld.ts
@@ -1,14 +1,14 @@
 import ALL_METADATA_JSON from '../fixtures/all-metadata.json'
+import { JSON_LD_MIME } from './json-ld'
 
-export function testSetsJsonLd() {
+export const testSetsJsonLd = () =>
   it('should set JSON LD metadata', () => {
     cy.fixture('all-metadata.json').then(
       (metadata: typeof ALL_METADATA_JSON) => {
-        cy.get('script[type="application/ld+json"]').should(
+        cy.get(`script[type="${JSON_LD_MIME}"]`).should(
           'have.text',
           JSON.stringify(metadata.jsonLd),
         )
       },
     )
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-all-open-graph-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-all-open-graph-metadata.ts
@@ -1,4 +1,4 @@
-export function testUnsetsAllOpenGraphMetadata() {
+export const testUnsetsAllOpenGraphMetadata = () =>
   it('should unset all Open Graph metadata', () => {
     cy.getMetaWithProperty('og:title').should('not.exist')
     cy.getMetaWithProperty('og:type').should('not.exist')
@@ -13,7 +13,6 @@ export function testUnsetsAllOpenGraphMetadata() {
     cy.getMetaWithProperty('og:locale').should('not.exist')
     cy.getMetaWithProperty('og:site_name').should('not.exist')
   })
-}
 
 export function openGraphDescriptionShouldNotExist() {
   cy.getMetaWithProperty('og:description').should('not.exist')

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-all-open-graph-profile-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-all-open-graph-profile-metadata.ts
@@ -1,8 +1,7 @@
-export function testUnsetsAllOpenGraphProfileMetadata() {
+export const testUnsetsAllOpenGraphProfileMetadata = () =>
   it('should unset all Open Graph profile metadata', () => {
     cy.getMetaWithProperty('og:profile:first_name').should('not.exist')
     cy.getMetaWithProperty('og:profile:last_name').should('not.exist')
     cy.getMetaWithProperty('og:profile:username').should('not.exist')
     cy.getMetaWithProperty('og:profile:gender').should('not.exist')
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-all-standard-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-all-standard-metadata.ts
@@ -1,4 +1,4 @@
-export function testUnsetsAllStandardMetadata() {
+export const testUnsetsAllStandardMetadata = () =>
   it('should unset all standard metadata', () => {
     cy.getMeta('description').should('not.exist')
     // It's actually set because of the default
@@ -9,4 +9,3 @@ export function testUnsetsAllStandardMetadata() {
     cy.get('link[rel="canonical"]').should('not.exist')
     cy.get('html').should('not.have.attr', 'lang')
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-all-twitter-card-metadata.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-all-twitter-card-metadata.ts
@@ -1,4 +1,4 @@
-export function testUnsetsAllTwitterCardMetadata() {
+export const testUnsetsAllTwitterCardMetadata = () =>
   it('should unset all Twitter card metadata', () => {
     cy.getMeta('twitter:card').should('not.exist')
     cy.getMeta('twitter:site').should('not.exist')
@@ -10,7 +10,6 @@ export function testUnsetsAllTwitterCardMetadata() {
     cy.getMeta('twitter:image').should('not.exist')
     cy.getMeta('twitter:image:alt').should('not.exist')
   })
-}
 
 export function twitterCardDescriptionShouldNotExist() {
   cy.getMeta('twitter:description').should('not.exist')

--- a/projects/ngx-meta/e2e/cypress/support/test-unsets-json-ld.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-unsets-json-ld.ts
@@ -1,5 +1,6 @@
-export function testUnsetsJsonLd() {
+import { JSON_LD_MIME } from './json-ld'
+
+export const testUnsetsJsonLd = () =>
   it('should unset JSON LD metadata', () => {
-    cy.get('script[type="application/ld+json"]').should('not.exist')
+    cy.get(`script[type="${JSON_LD_MIME}"]`).should('not.exist')
   })
-}

--- a/projects/ngx-meta/e2e/cypress/support/test-with-ssr-and-csr.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-with-ssr-and-csr.ts
@@ -1,0 +1,41 @@
+export function testWithSsrAndCsr(
+  options: Partial<Cypress.VisitOptions> &
+    Pick<Cypress.VisitOptions, 'url'> & {
+      interceptRequests?: Parameters<
+        Cypress.Chainable['simulateSSRForGetRequests']
+      >[0]
+    },
+  tests: {
+    ssrAndCsr?: () => void
+    ssrOnly?: () => void
+    csrOnly?: () => void
+  },
+) {
+  describe('when using SSR only (by manually removing CSR scripts)', () => {
+    beforeEach(() => {
+      cy.simulateSSRForGetRequests(options.interceptRequests ?? options.url)
+      cy.visit(options)
+      cy.shouldNotContainAppScripts()
+    })
+
+    if (tests.ssrAndCsr) {
+      tests.ssrAndCsr()
+    }
+    if (tests.ssrOnly) {
+      tests.ssrOnly()
+    }
+  })
+
+  describe('when using CSR', () => {
+    beforeEach(() => {
+      cy.visit(options)
+    })
+
+    if (tests.ssrAndCsr) {
+      tests.ssrAndCsr()
+    }
+    if (tests.csrOnly) {
+      tests.csrOnly()
+    }
+  })
+}

--- a/projects/ngx-meta/example-apps/README.md
+++ b/projects/ngx-meta/example-apps/README.md
@@ -79,6 +79,14 @@ To serve the app, change to its directory and run
 pnpm start
 ```
 
+To serve it with SSR, build it first (see below). You can then use the common run script
+
+```sh
+pnpm run ci:serve
+```
+
+Which will serve the app in a port where E2E tests will be run against. This is the same run script used in CI/CD to execute E2E tests.
+
 #### Build
 
 To build it, change to its directory and use
@@ -87,12 +95,31 @@ To build it, change to its directory and use
 pnpm run build
 ```
 
-> [!NOTE]
-> In order to analyze the app's bundle with `source-map-explorer`, remember to build it with
->
-> ```shell
-> pnpm run build --source-map
-> ```
+##### For bundle size analysis
+
+In order to analyze the app's bundle size with [bundle size analysis infra](../bundle-size/README.md), remember to build it with source maps included:
+
+```shell
+pnpm run build --source-map
+```
+
+##### With server side rendering
+
+To build the app for browser and for server, run (if present):
+
+```shell
+pnpm run build:ssr
+```
+
+Apps using Angular v17's `application` builder do not have a `build:ssr` run script. That's because a regular `build` will build for browser and server if SSR is enabled.
+
+##### With everything
+
+To build the app ready for bundle size analysis and E2E tests (hence with server code built), run
+
+```shell
+pnpm run ci:build
+```
 
 ## Tips
 


### PR DESCRIPTION
# Issue or need

`ngx-meta` lib should work with server side rendering (SSR). As it's very important for the metadata being set to be present in the served HTML before rendering on client side. This way bots, crawlers & machines visiting the site can read the metadata without rendering the site's JavaScript code. Hence without having to do the client side rendering (CSR).

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Now that example apps are served with SSR, E2E tests with Cypress need to be updated so that example apps are rendered without client side rendering to ensure server side rendered code includes metadata.

To simulate disabling client side rendering, the `<script>` elements on the page are removed before inserting them in the browser (seems it's the only way we can do this right now in Cypress).

However, it's still useful to test that client side rendering works as expected. 

To do so, introduced a helper that allows testing same cases in SSR / CSR. Or just for SSR case. Or just for CSR case.

Other changes:
 - Rename console helper to better reflect what is actually testing
 - Test helpers creating `it` tests to return what `it` returns. Just in case that helps the testing framework.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
