### PR TITLE
build(examples): add serve port to common serve run script

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
-  APP_PORT: 4200
 
 jobs:
   e2e:
@@ -61,15 +60,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Serve app
         run: pnpm run ci:serve &
-        env:
-          PORT: ${{ env.APP_PORT }}
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Cypress run
         uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a # v6.6.1
         env:
           CYPRESS_CACHE_FOLDER: ${{ env.cypress_cache_dir }}
         with:
-          wait-on: http://localhost:${{ env.APP_PORT }}
+          wait-on: http://localhost:4200
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
           # 👇 Action doesn't support pnpm caching right now

--- a/projects/ngx-meta/e2e/cypress.config.ts
+++ b/projects/ngx-meta/e2e/cypress.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
   e2e: {
+    //👇 Keep in sync with `add-ci-run-scripts.ts`
     baseUrl: 'http://localhost:4200',
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on: unknown, config: unknown) {
       // implement node event listeners here
     },
   },

--- a/projects/ngx-meta/example-apps/src/add-ci-run-scripts.ts
+++ b/projects/ngx-meta/example-apps/src/add-ci-run-scripts.ts
@@ -8,6 +8,9 @@ const BUILD_SSR_RUN_SCRIPT = 'build:ssr'
 const SERVE_SSR_RUN_SCRIPT_PREFIX = 'serve:ssr'
 const CI_BUILD_RUN_SCRIPT = 'ci:build'
 const CI_SERVE_RUN_SCRIPT = 'ci:serve'
+//👇 Keep in sync with `cypress.config.ts`
+const SSR_PORT_ENV_VAR = 'PORT'
+const SSR_SERVE_PORT = 4200
 const BUILD_WITH_SOURCE_MAPS = 'ng build --source-map'
 
 export async function addCiRunScripts(opts: {
@@ -38,6 +41,7 @@ export async function addCiRunScripts(opts: {
   if (!serveSsrRunScript) {
     throw new Error('Cannot find SSR run script for app')
   }
-  appPkgJson.scripts[CI_SERVE_RUN_SCRIPT] = `pnpm run ${serveSsrRunScript}`
+  appPkgJson.scripts[CI_SERVE_RUN_SCRIPT] =
+    `export ${SSR_PORT_ENV_VAR}=${SSR_SERVE_PORT} && pnpm run ${serveSsrRunScript}`
   await writeFile(appPkgJsonFile, jsonToString(appPkgJson))
 }


### PR DESCRIPTION
# Issue or need

Serving the example app in a port that E2E tests will use is done in CI/CD pipeline. In local, you have to either change Cypress `baseUrl`'s port to `4000` (default port when you serve with SSR an Angular app in production) or run the Angular app in port `4200` by exporting `PORT=4200` env var as done in CI/CD.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Export `PORT=4200` env var as part of run script to serve the example app. This way we do the same in local and in CI/CD when serving apps and running E2E tests against them.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
