### PR TITLE
build(e2e): use JSON to share service overrides

### DIFF
--- a/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
+++ b/projects/ngx-meta/e2e/cypress/e2e/meta-set-by-route-and-service.spec.cy.ts
@@ -6,6 +6,7 @@ import {
 } from '../support/console'
 import { shouldContainAllStandardMetadata } from '../support/metadata/standard'
 import { shouldContainAllOpenGraphMetadata } from '../support/metadata/open-graph'
+import ROUTE_SERVICE_OVERRIDES_JSON from '../fixtures/route-service-overrides.json'
 import { shouldContainAllOpenGraphProfileMetadata } from '../support/metadata/open-graph-profile'
 import { shouldContainAllTwitterCardMetadata } from '../support/metadata/twitter-card'
 import { shouldContainJsonLdMetadata } from '../support/metadata/json-ld'
@@ -21,15 +22,15 @@ describe('Meta set by route and service', () => {
       ssrAndCsr: () => {
         shouldNotEmitUnwantedConsoleLogs()
         shouldContainAllStandardMetadata()
-        shouldContainAllOpenGraphMetadata({
-          type: 'book',
-        })
-        shouldContainAllOpenGraphProfileMetadata({
-          gender: 'female',
-        })
-        shouldContainAllTwitterCardMetadata({
-          card: 'summary_large_image',
-        })
+        shouldContainAllOpenGraphMetadata(
+          ROUTE_SERVICE_OVERRIDES_JSON.openGraph,
+        )
+        shouldContainAllOpenGraphProfileMetadata(
+          ROUTE_SERVICE_OVERRIDES_JSON.openGraph.profile,
+        )
+        shouldContainAllTwitterCardMetadata(
+          ROUTE_SERVICE_OVERRIDES_JSON.twitterCard,
+        )
         shouldContainJsonLdMetadata()
       },
       csrOnly: () => {

--- a/projects/ngx-meta/e2e/cypress/fixtures/route-service-overrides.json
+++ b/projects/ngx-meta/e2e/cypress/fixtures/route-service-overrides.json
@@ -1,0 +1,11 @@
+{
+  "openGraph": {
+    "type": "book",
+    "profile": {
+      "gender": "female"
+    }
+  },
+  "twitterCard": {
+    "card": "summary_large_image"
+  }
+}

--- a/projects/ngx-meta/example-apps/templates/module/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -1,15 +1,7 @@
 import { Component, OnInit } from '@angular/core'
 import { NgxMetaService } from '@davidlj95/ngx-meta/core'
 import { ActivatedRoute } from '@angular/router'
-import {
-  OPEN_GRAPH_PROFILE_GENDER_FEMALE,
-  OPEN_GRAPH_TYPE_BOOK,
-  OpenGraphMetadata,
-} from '@davidlj95/ngx-meta/open-graph'
-import {
-  TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
-  TwitterCardMetadata,
-} from '@davidlj95/ngx-meta/twitter-card'
+import ROUTE_SERVICE_OVERRIDES_JSON from '@/e2e/cypress/fixtures/route-service-overrides.json'
 
 @Component({
   selector: 'app-meta-set-by-route-and-service',
@@ -17,18 +9,7 @@ import {
 })
 export class MetaSetByRouteAndServiceComponent implements OnInit {
   protected readonly routeData: unknown
-  protected readonly overriddenMetadata: OpenGraphMetadata &
-    TwitterCardMetadata = {
-    openGraph: {
-      type: OPEN_GRAPH_TYPE_BOOK,
-      profile: {
-        gender: OPEN_GRAPH_PROFILE_GENDER_FEMALE,
-      },
-    },
-    twitterCard: {
-      card: TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
-    },
-  } as const
+  protected readonly overriddenMetadata = ROUTE_SERVICE_OVERRIDES_JSON
 
   constructor(
     activatedRoute: ActivatedRoute,

--- a/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
+++ b/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-set-by-route-and-service/meta-set-by-route-and-service.component.ts
@@ -2,15 +2,7 @@ import { Component, OnInit } from '@angular/core'
 import { NgxMetaService } from '@davidlj95/ngx-meta/core'
 import { JsonPipe } from '@angular/common'
 import { ActivatedRoute } from '@angular/router'
-import {
-  OPEN_GRAPH_PROFILE_GENDER_FEMALE,
-  OPEN_GRAPH_TYPE_BOOK,
-  OpenGraphMetadata,
-} from '@davidlj95/ngx-meta/open-graph'
-import {
-  TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
-  TwitterCardMetadata,
-} from '@davidlj95/ngx-meta/twitter-card'
+import ROUTE_SERVICE_OVERRIDES_JSON from '@/e2e/cypress/fixtures/route-service-overrides.json'
 
 @Component({
   selector: 'app-meta-set-by-route-and-service',
@@ -20,18 +12,7 @@ import {
 })
 export class MetaSetByRouteAndServiceComponent implements OnInit {
   protected readonly routeData: unknown
-  protected readonly overriddenMetadata: OpenGraphMetadata &
-    TwitterCardMetadata = {
-    openGraph: {
-      type: OPEN_GRAPH_TYPE_BOOK,
-      profile: {
-        gender: OPEN_GRAPH_PROFILE_GENDER_FEMALE,
-      },
-    },
-    twitterCard: {
-      card: TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE,
-    },
-  } as const
+  protected readonly overriddenMetadata = ROUTE_SERVICE_OVERRIDES_JSON
 
   constructor(
     activatedRoute: ActivatedRoute,


### PR DESCRIPTION
# Issue or need

E2E tests related to a service overriding metadata set by a route rely on template files of example apps setting same specific values that test expects

If we change a value in templates, we should update the expectation too.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

To avoid having 2 sources of truth of what overrides to set, creating a JSON to specify those.

This way, no sync needed: both tests and template files code override whatever JSON says. So implementation and expectations are in sync.

We loose something though:
1. Showcasing the constants to refer to Open Graph types/profile genders/Twitter Card types.
1. Keeping track that constants above are tree-shakeable. If using `enum`s for those, the whole enum would be included just by pointing to one constant. Given an `enum` is an object and objects do not favour tree shaking.

There are fixes though:
1. That info already appears in those properties API reference
1. Will take into account in every PR review from now on. Manual, not automated. But nothing's perfect in this world!

Trade-offs everywhere
<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
