### PR TITLE
build(e2e): reduce Cypress time out to fail fast

### DIFF
--- a/projects/ngx-meta/e2e/cypress.config.ts
+++ b/projects/ngx-meta/e2e/cypress.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+  //👇 Trying it out. Should be fine for CI/CD too
+  defaultCommandTimeout: 1000,
 })


### PR DESCRIPTION
# Issue or need

Given E2E tests use case, waiting for 4s for something to fail is too long.


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Reducing it to 1s

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
