### PR TITLE
build(renovate): remove dts-bundle-generator pin

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -129,11 +129,5 @@
       matchPackageNames: ['@microsoft/api-documenter'],
       allowedVersions: '7.23.38',
     },
-    // dts-bundle-generator missing namespace import
-    // https://github.com/timocov/dts-bundle-generator/issues/319
-    {
-      matchPackageNames: ['dts-bundle-generator'],
-      allowedVersions: '9.3.1',
-    },
   ],
 }


### PR DESCRIPTION
# Issue or need

[`dts-bundle-generator` bug](https://github.com/timocov/dts-bundle-generator/issues/319) was fixed and a new release with the fix has been released. So no need to pin that lib to a specific version to avoid the bug.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove dependency pin from Renovate config

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
