### PR TITLE
ci(e2e): remove `wait-on` to rely on Cypress wait

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -66,7 +66,6 @@ jobs:
         env:
           CYPRESS_CACHE_FOLDER: ${{ env.cypress_cache_dir }}
         with:
-          wait-on: http://localhost:4200
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
           # 👇 Action doesn't support pnpm caching right now


### PR DESCRIPTION
# Issue or need

See https://github.com/davidlj95/ngx/discussions/561

# Proposed changes

When running locally, discovered that Cypress actually does some retries until starting tests in case the app is not ready.

Given that now apps are served with SSR and start-up times are almost instant, removing the `wait-on` in CI/CD to decouple `baseUrl` from there.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
