### PR TITLE
build(e2e): clean unused code from experimentation

### DIFF
--- a/projects/ngx-meta/e2e/cypress/support/commands.ts
+++ b/projects/ngx-meta/e2e/cypress/support/commands.ts
@@ -83,10 +83,10 @@ const HTML_SCRIPTS_BUT_JSON_LD = new RegExp(
  *
  * @see Inspired from {@link https://blog.simonireilly.com/posts/server-side-rendering-tests-in-cypress/}
  */
-Cypress.Commands.add<'simulateSSRForGetRequests'>(
-  'simulateSSRForGetRequests',
+Cypress.Commands.add<'simulateSSRForRequest'>(
+  'simulateSSRForRequest',
   (url) => {
-    cy.intercept('GET', url, (req) => {
+    cy.intercept(url, (req) => {
       req.continue((res) => {
         res.body = res.body.replace(HTML_SCRIPTS_BUT_JSON_LD, '')
         res.send()
@@ -116,7 +116,7 @@ declare global {
       getMeta(name: string): Chainable<HTMLMetaElement>
       getMetaWithProperty(property: string): Chainable<HTMLMetaElement>
       shouldHaveContent(): Chainable<Subject>
-      simulateSSRForGetRequests(url: RouteMatcher): Chainable<void>
+      simulateSSRForRequest(url: RouteMatcher): Chainable<void>
       shouldNotContainAppScripts(): Chainable<void>
     }
   }

--- a/projects/ngx-meta/e2e/cypress/support/test-with-ssr-and-csr.ts
+++ b/projects/ngx-meta/e2e/cypress/support/test-with-ssr-and-csr.ts
@@ -1,10 +1,5 @@
 export function testWithSsrAndCsr(
-  options: Partial<Cypress.VisitOptions> &
-    Pick<Cypress.VisitOptions, 'url'> & {
-      interceptRequests?: Parameters<
-        Cypress.Chainable['simulateSSRForGetRequests']
-      >[0]
-    },
+  options: Partial<Cypress.VisitOptions> & Pick<Cypress.VisitOptions, 'url'>,
   tests: {
     ssrAndCsr?: () => void
     ssrOnly?: () => void
@@ -13,7 +8,7 @@ export function testWithSsrAndCsr(
 ) {
   describe('when using SSR only (by manually removing CSR scripts)', () => {
     beforeEach(() => {
-      cy.simulateSSRForGetRequests(options.interceptRequests ?? options.url)
+      cy.simulateSSRForRequest(options.url)
       cy.visit(options)
       cy.shouldNotContainAppScripts()
     })


### PR DESCRIPTION
# Issue or need

When experimenting on how to setup Cypress to test SSR compatibility, introduced maaaaany experiments. Later, cleaned them up. But some escaped.
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove unneeded code:
 - Intercept requests arg
 - `GET` as fixed method. You can specify a method filter as part of `RouteMatcher` object way of matching URLs to intercept.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
