### PR TITLE
build(examples): avoid "undefined" as id in links

### DIFF
--- a/projects/ngx-meta/example-apps/templates/module/src/app/app.component.html
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/app.component.html
@@ -5,7 +5,7 @@
 <nav>
   <ul>
     <li *ngFor="let navItem of navItems">
-      <a [routerLink]="navItem.path" [id]="navItem.linkId">
+      <a [routerLink]="navItem.path" [attr.id]="navItem.linkId">
         {{ navItem.displayName }}
       </a>
     </li>

--- a/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.html
+++ b/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.html
@@ -5,7 +5,7 @@
 <nav>
   <ul>
     <li *ngFor="let navItem of navItems">
-      <a [routerLink]="navItem.path" [id]="navItem.linkId">
+      <a [routerLink]="navItem.path" [attr.id]="navItem.linkId">
         {{ navItem.displayName }}
       </a>
     </li>


### PR DESCRIPTION
# Issue or need

In example apps, all route links but root have `undefined` as `id`. That's not correct.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use `attr.id` to set the id of the element instead. If value is `undefined`, it's not set (as expected)

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
