### PR TITLE
refactor: add execa wrapper

### DIFF
--- a/projects/ngx-meta/example-apps/src/create-angular-app.ts
+++ b/projects/ngx-meta/example-apps/src/create-angular-app.ts
@@ -1,8 +1,8 @@
 import { SemVer } from 'semver'
 import { Log } from './utils.js'
-import { execa } from 'execa'
 import { join } from 'path'
 import { supportsNgNewWithSsr } from './supports-ng-new-with-ssr.js'
+import { execa } from './execa.js'
 
 export async function createAngularApp(opts: {
   name: string
@@ -27,7 +27,7 @@ export async function createAngularApp(opts: {
     '--style=css',
   ]
   const ANGULAR_CLI_NEW_SSR_ARG = '--ssr'
-  const ngNewCommand = execa(
+  await execa(
     'pnpm',
     [
       'ng',
@@ -37,10 +37,8 @@ export async function createAngularApp(opts: {
       ...(opts.extraArgs ?? []),
       ...(ngNewSupportsSsr ? [ANGULAR_CLI_NEW_SSR_ARG] : []),
     ],
-    { cwd: opts.dir, all: true, env: { FORCE_COLOR: true.toString() } },
+    { cwd: opts.dir },
   )
-  Log.stream(ngNewCommand.all)
-  await ngNewCommand
   Log.ok('Angular app created')
   return join(opts.dir, opts.name)
 }

--- a/projects/ngx-meta/example-apps/src/disable-analytics.ts
+++ b/projects/ngx-meta/example-apps/src/disable-analytics.ts
@@ -1,20 +1,12 @@
 import { Log } from './utils.js'
-import { execa } from 'execa'
+import { execa } from './execa.js'
 
 export async function disableAnalytics(opts: {
   cliBinary: string
   appDir: string
 }) {
   Log.step('Disabling Angular analytics')
-  const disableAnalyticsCommand = execa(
-    opts.cliBinary,
-    ['config', 'cli.analytics', false.toString()],
-    {
-      cwd: opts.appDir,
-      all: true,
-      env: { FORCE_COLOR: true.toString() },
-    },
-  )
-  Log.stream(disableAnalyticsCommand.all)
-  await disableAnalyticsCommand
+  return execa(opts.cliBinary, ['config', 'cli.analytics', false.toString()], {
+    cwd: opts.appDir,
+  })
 }

--- a/projects/ngx-meta/example-apps/src/execa.ts
+++ b/projects/ngx-meta/example-apps/src/execa.ts
@@ -1,0 +1,16 @@
+import { execa as unwrappedExeca, Options } from 'execa'
+import { Log } from './utils.js'
+
+export const execa = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: Options,
+) => {
+  const process = unwrappedExeca(file, args, {
+    all: true,
+    env: { FORCE_COLOR: true.toString() },
+    ...options,
+  })
+  Log.stream(process.all)
+  return process
+}

--- a/projects/ngx-meta/example-apps/src/install.ts
+++ b/projects/ngx-meta/example-apps/src/install.ts
@@ -1,5 +1,5 @@
 import { Log } from './utils.js'
-import { execa } from 'execa'
+import { execa } from './execa.js'
 
 export async function install({
   projectDir,
@@ -9,11 +9,7 @@ export async function install({
   what: string
 }) {
   Log.step(`Installing ${what}`)
-  const installCommand = execa('pnpm', ['install'], {
+  return execa('pnpm', ['install'], {
     cwd: projectDir,
-    all: true,
-    env: { FORCE_COLOR: true.toString() },
   })
-  Log.stream(installCommand.all)
-  await installCommand
 }

--- a/projects/ngx-meta/example-apps/src/setup-ssr.ts
+++ b/projects/ngx-meta/example-apps/src/setup-ssr.ts
@@ -3,8 +3,8 @@ import { supportsNgNewWithSsr } from './supports-ng-new-with-ssr.js'
 import { Log } from './utils.js'
 import { writeFile } from 'fs/promises'
 import { join } from 'path'
-import { execa } from 'execa'
 import { NPMRC_FILENAME } from './constants.js'
+import { execa } from './execa.js'
 
 export async function setupSsr(opts: {
   cliBinary: string
@@ -27,29 +27,17 @@ export async function setupSsr(opts: {
   // Current docs SSR guide do this with `ng add @angular/ssr`, which starts at v17
   // https://v16.angular.io/guide/universal
   Log.step('Setting up SSR using @nguniversal')
-  const ngAddNgUniversalCommand = execa(
+  await execa(
     opts.cliBinary,
     ['add', '--skip-confirmation', '@nguniversal/express-engine'],
     {
       cwd: opts.appDir,
-      all: true,
-      env: { FORCE_COLOR: true.toString() },
     },
   )
-  Log.stream(ngAddNgUniversalCommand.all)
-  await ngAddNgUniversalCommand
   // Seems there's no way to avoid installing deps
   // https://github.com/angular/angular-cli/blob/16.2.14/packages/angular/cli/src/commands/add/cli.ts#L304
   Log.step('Removing node modules and %s', NPMRC_FILENAME)
-  const rmNodeModulesAndLockfileCommand = execa(
-    'rm',
-    ['-rf', 'node_modules', NPMRC_FILENAME],
-    {
-      cwd: opts.appDir,
-      all: true,
-      env: { FORCE_COLOR: true.toString() },
-    },
-  )
-  Log.stream(rmNodeModulesAndLockfileCommand.all)
-  await rmNodeModulesAndLockfileCommand
+  await execa('rm', ['-rf', 'node_modules', NPMRC_FILENAME], {
+    cwd: opts.appDir,
+  })
 }


### PR DESCRIPTION
# Issue or need
Calls to `execa` in example apps creation scripts follow same pattern:
 - Create process with some default options: `FORCE_COLOR` & `all: true`
 - Stream output from `stdout` / `stderr`
 - Await process to finish


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes
Introduce wrapper to avoid repeating that around

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
