### PR TITLE
chore: update links angular.io -> angular.dev

### DIFF
--- a/projects/ngx-meta/api-extractor/tsconfig.api-extractor.json
+++ b/projects/ngx-meta/api-extractor/tsconfig.api-extractor.json
@@ -1,4 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* To learn more about Typescript configuration file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+   For Angular-specific options: https://angular.dev/reference/configs/angular-compiler-options */
 {
   "extends": "../src/tsconfig.lib.json",
   "compilerOptions": {

--- a/projects/ngx-meta/docs/content/guides/late-loading-modules.md
+++ b/projects/ngx-meta/docs/content/guides/late-loading-modules.md
@@ -99,7 +99,7 @@ export class BlogModule {}
 
 If you migrated to standalone apps, where need for Angular modules is reduced, you may have followed [Angular's guide about lazy loading in standalone apps]
 
-[Angular's guide about lazy loading in standalone apps]: https://angular.io/guide/standalone-components#routing-and-lazy-loading
+[Angular's guide about lazy loading in standalone apps]: https://v16.angular.io/guide/standalone-components#routing-and-lazy-loading
 
 In there, to lazy load a route, you either dynamically import a component or many routes. If you dynamically import a component, check out next chapter about [adding a metadata module in a component](#component). Otherwise, keep reading.
 

--- a/projects/ngx-meta/docs/includes/common-links.md
+++ b/projects/ngx-meta/docs/includes/common-links.md
@@ -16,4 +16,4 @@
 [Twitter Cards module]: /built-in-modules/twitter-cards/
 [bundle size issue]: https://github.com/davidlj95/ngx/issues/112
 [tree shaking]: https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking
-[Angular actively supported versions]: https://angular.io/guide/releases#actively-supported-versions
+[Angular actively supported versions]: https://angular.dev/reference/releases#actively-supported-versions

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
@@ -16,8 +16,9 @@ export const NAVIGATION_END_EVENT_TYPE = new NavigationEnd(0, '', '').type
 
 @Injectable({ providedIn: 'root' })
 export class NgxMetaRouterListenerService implements OnDestroy {
-  // Replace by `takeUntilDestroyed` when stable
-  // https://angular.io/api/core/rxjs-interop/takeUntilDestroyed
+  // Replace by `takeUntilDestroyed` when stable & oldest Angular supported version is v16 where it was introduced
+  // https://angular.dev/api/core/rxjs-interop/takeUntilDestroyed
+  // https://github.com/angular/angular/commit/e8831984601da631afc29f9fd72d36f57696f936
   private sub?: Subscription
 
   constructor(

--- a/projects/ngx-meta/src/tsconfig.lib.json
+++ b/projects/ngx-meta/src/tsconfig.lib.json
@@ -1,4 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* To learn more about Typescript configuration file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+   For Angular-specific options: https://angular.dev/reference/configs/angular-compiler-options */
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {

--- a/projects/ngx-meta/src/tsconfig.lib.prod.json
+++ b/projects/ngx-meta/src/tsconfig.lib.prod.json
@@ -1,4 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* To learn more about Typescript configuration file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+   For Angular-specific options: https://angular.dev/reference/configs/angular-compiler-options */
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {

--- a/projects/ngx-meta/src/tsconfig.spec.json
+++ b/projects/ngx-meta/src/tsconfig.spec.json
@@ -1,4 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* To learn more about Typescript configuration file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+   For Angular-specific options: https://angular.dev/reference/configs/angular-compiler-options */
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {

--- a/projects/ngx-meta/src/types/angular.d.ts
+++ b/projects/ngx-meta/src/types/angular.d.ts
@@ -6,7 +6,7 @@ declare global {
   /**
    * Used to know if we're in dev mode, in the same fashion Angular does
    *
-   * Public API `isDevMode` (https://angular.io/api/core/isDevMode) is more
+   * Public API `isDevMode` (https://angular.dev/api/core/isDevMode) is more
    * stable. However, given it's a function call, code under `if(isDevMode())`
    * can not tree-shaken. So to allow tree-shaking, using a `const` in the
    * same fashion Angular does for their packages. Simplifying the type to be

--- a/renovate.json5
+++ b/renovate.json5
@@ -55,8 +55,8 @@
       automerge: true,
     },
     // Angular v17.3.x compatibilities
-    // https://angular.io/guide/versions
-    // https://update.angular.io/?v=16.0-17.0 (zone.js)
+    // https://angular.dev/reference/versions
+    // https://angular.dev/update-guide?v=16.0-17.0&l=1
     {
       matchDepPrefixes: ['@angular'],
       matchFileNames: ['package.json'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* To learn more about Typescript configuration file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
+   For Angular-specific options: https://angular.dev/reference/configs/angular-compiler-options */
 {
   "compileOnSave": false,
   "compilerOptions": {


### PR DESCRIPTION
# Issue or need
After [Angular v18 release](https://blog.angular.dev/angular-v18-is-now-available-e79d5ac0affe) now Angular.dev is the official documentation site. There are links around pointing to angular.io

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use the angular.dev documentation site pages instead. Some of them don't exist anymore, so replacing them with other links or pointers to old versions of docs in angular.io

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
