### PR TITLE
docs: add semantic release simulation docs

### DIFF
--- a/.env.release.sample
+++ b/.env.release.sample
@@ -1,0 +1,25 @@
+# GitHub token
+# You can use a classic one or a fine-grained one
+#
+# ## Clasic
+# https://github.com/settings/tokens/new
+# Selecting "public_repo" scope is enough
+#
+# ## Fine-grained
+# https://github.com/settings/personal-access-tokens/new
+# Default settings are okay (as it's a public repo)
+#
+#GH_TOKEN=
+
+# NPM token
+# You can use a classic one or a granular access one
+# https://www.npmjs.com/settings
+#
+# ## Classic
+# "Read-only" is enough
+#
+# ## Granular Access
+# "Read-only" access to packages and scopes is enough.
+# If being a package collaborator, you can select this package.
+# Otherwise select "All packages".
+#NPM_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -373,5 +373,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/angular,vim,visualstudiocode,node,webstorm+iml,macos,linux,windows
+.npmrc
 # Manual edits
 # - Comment `.idea` in Angular to include IDE configs
+# - Add `.npmrc` to set registry to simulate releases, but avoid committing that

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "lint-staged": "lint-staged",
     "commitlint-edit-msg": "commitlint --verbose --edit",
     "commitlint-last": "commitlint --verbose --from HEAD~1",
-    "semantic-release": "semantic-release",
     "ng-lint-staged": "ng-lint-staged lint --max-warnings 0 --fix --",
     "cache-clean": "ng cache clean",
     "commit": "pnpx @commitlint/prompt-cli"


### PR DESCRIPTION
# Issue or need

In latest release, `main` was added as `dist-tag` to the package. But `latest` wasn't.

About `main` dist tag, it's because an error in Semantic Release configuration. `channel` defines the tag used when publishing in npm. And by default it takes the name of the branch (unless it's the first release branch). So that's why `main` as there. It has been there since the beginning, after checking `git notes` created by semantic release and GitHub Actions logs.

About `latest` not being there, still don't know why exactly. Nothing in semantic release or the npm plugin seems to have changed to alter that behavior. Makes sense, as it would be a breaking change and therefore a  documented one. It was there for previous releases. Though that may change soon in [`npm` v11](https://github.com/npm/rfcs/pull/776).

To be able to find that, simulated releases with semantic release. It's not an easy task though and has its quirks. The more the further you want to simulate. So writing them in a guide in case a release needs to be debugged or rehearsed in the future.

> Tried to create a script for releases rehearsal but there are so many quirks and things can go so wrong that script would be very complex. Better to rely on human intel for now.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Document the release rehearsal steps. In `CONTRIBUTING.md` where all processes are explained.

Will manually fix the invalid semantic release notes (should be in `null` / default channel instead of `main` channel) and semantic release configuration manually after merging this PR. Now that can first safely ensure the proper release config will be in place.
<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
