### PR TITLE
build: use default channel for prereleases

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -6,7 +6,7 @@ module.exports = {
     //👇 Fake branch so that we can release beta versions in `main`
     //   until we can release 1.0.0
     'semantic-release',
-    { name: 'main', prerelease: 'beta' },
+    { name: 'main', prerelease: 'beta', channel: false },
   ],
   plugins: [
     '@semantic-release/commit-analyzer',

--- a/projects/ngx-meta/src/package.json
+++ b/projects/ngx-meta/src/package.json
@@ -47,8 +47,7 @@
   "scripts": {},
   "publishConfig": {
     "access": "public",
-    "provenance": true,
-    "tag": "latest"
+    "provenance": true
   },
   "sideEffects": false
 }


### PR DESCRIPTION
# Issue or need

Until now, semantic releases have been done in the `main` channel by mistake. This meant having a `main` NPM dist tag for every release.  In order to get the `latest` tag for pre-releases, [`tag` was set to `latest` in `package.json`'s `publishConfig`](https://github.com/davidlj95/ngx/commit/09e28eb5df2bcc78c5326617a04e33466c0e0f9c).

But that's a misconfiguration workaround. The proper way is to indicate pre-releases on the default channel in semantic release. Which means using the `latest` dist tag on npm.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use default channel for pre-releases in semantic release configuration. Remove `tag` in `package.json` used to add `latest` apart from `main` dist tag.

In order to migrate existing releases to the default channel, manually updated git notes. Git notes are used by semantic release to track in which channel(s) a release has been performed.

Relevant commands:
 - `git for-each-ref 'refs/notes/*' # to list local notes refs`
   -  May add `--format '%(refname)' --shell` 
 - `git ls-remote 'refs/notes/*' # to list remote notes`
 - `git fetch origin 'refs/notes/*:refs/notes/*' # to fetch remote notes`
 - `git update-ref -d 'refs/notes/<ref>' # to remove local ref`
 - `git push --delete origin 'refs/notes/<ref>' # to remove remote ref`
 - `git notes --ref <note-ref> add -f -m 'content' <ref> # to add a note to a ref`

Notes content is (to indicate default branch):

```shell
{"channels":[null]}
```

Notes ref name is ([recently changed though](https://github.com/semantic-release/semantic-release/issues/2085))
```
semantic-release-{gitTag}
```

https://github.com/semantic-release/semantic-release/blob/v23.1.1/lib/git.js#L344-L350

Name was before `semantic-release` for all tags

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
