### PR TITLE
build: configure Renovate for v18 with shared preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,11 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   // 👇 Defined in https://github.com/renovatebot/renovate/blob/37.71.1/lib/config/presets/internal/config.ts
-  extends: ['config:best-practices', 'config:js-app'],
+  extends: [
+    'config:best-practices',
+    'config:js-app',
+    'github>davidlj95/renovate-config:angular/v18.0.x',
+  ],
   prHourlyLimit: 0,
   prConcurrentLimit: 5,
   schedule: [
@@ -54,54 +58,32 @@
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       automerge: true,
     },
-    // Angular v17.3.x compatibilities
-    // https://angular.dev/reference/versions
-    // https://angular.dev/update-guide?v=16.0-17.0&l=1
+    // Angular v18
     {
       matchDepPrefixes: ['@angular'],
       matchFileNames: ['package.json'],
-      allowedVersions: '^17',
-    },
-    {
-      matchDepNames: ['node', '@types/node'],
-      matchFileNames: ['package.json'],
-      allowedVersions: '^18.13.0 || ^20.9.0',
-    },
-    {
-      matchDepNames: ['typescript'],
-      matchFileNames: ['package.json'],
-      allowedVersions: '>=5.2.0 <5.5.0',
-    },
-    {
-      matchDepNames: ['rxjs'],
-      matchFileNames: ['package.json'],
-      allowedVersions: '^6.5.3 || ^7.4.0',
-    },
-    {
-      matchDepNames: ['zone.js'],
-      matchFileNames: ['package.json'],
-      allowedVersions: '0.14.x',
+      allowedVersions: '^18',
     },
     // Example apps major versions
     {
       matchFileNames: [
         'projects/ngx-meta/example-apps/src/angular-cli-versions.json',
       ],
-      matchDepNames: 'v15',
+      matchDepNames: ['v15'],
       allowedVersions: '^15',
     },
     {
       matchFileNames: [
         'projects/ngx-meta/example-apps/src/angular-cli-versions.json',
       ],
-      matchDepNames: 'v16',
+      matchDepNames: ['v16'],
       allowedVersions: '^16',
     },
     {
       matchFileNames: [
         'projects/ngx-meta/example-apps/src/angular-cli-versions.json',
       ],
-      matchDepNames: 'v17',
+      matchDepNames: ['v17'],
       allowedVersions: '^17',
     },
     // API Documenter to use Markdown tables


### PR DESCRIPTION
# Issue or need
Update dependencies but only if compatible with Angular v18

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes
Update Renovate config with Angular v18 shared preset + use 18 major for `@angular` pkgs

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
