### PR TITLE
test: specify which tasks are about unit tests

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -15,8 +15,8 @@ install:
 lint:
 	pnpm run lint --max-warnings 0
 
-test:
-	pnpm run test --browsers=ChromeHeadless --no-watch --no-progress \
+unit-test:
+	pnpm run test:unit --browsers=ChromeHeadless --no-watch --no-progress \
 		--reporters progress --code-coverage
 
 run-main:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -9,8 +9,8 @@ on:
         default: ''
 
 jobs:
-  test:
-    name: All tests
+  unit-test:
+    name: Unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -20,5 +20,5 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Run tests
-        run: cd .ci && make test
+      - name: Run unit tests
+        run: cd .ci && make unit-test

--- a/.idea/runConfigurations/Unit_tests__all.xml
+++ b/.idea/runConfigurations/Unit_tests__all.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All tests (all)" type="JavaScriptTestRunnerKarma">
+  <configuration default="false" name="Unit tests: all" type="JavaScriptTestRunnerKarma">
     <config-file value="" />
     <karma-options value="--browsers=ChromeHeadless" />
     <karma-package-dir value="$PROJECT_DIR$/node_modules/@angular/cli" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,11 @@ Unit tests are run with Angular's default test runner [Karma](https://karma-runn
 To run them all
 
 ```sh
-pnpm run test
+pnpm run test:unit
 ```
 
 > [!TIP]
-> There's also a WebStorm run configuration (`All tests`) to run all unit tests and report the results inside the IDE
+> There's also a WebStorm run configuration (`Unit tests: all`) to run all unit tests and report the results inside the IDE
 
 ##### E2E tests
 
@@ -508,7 +508,7 @@ pnpm husky
 
 ### Quirks
 
-#### Can't run tests: `TestBed` error
+#### Can't run unit tests: `TestBed` error
 
 If you see this error:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build && ./postbuild.sh",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test:unit": "ng test",
     "lint": "ng lint",
     "ngx-meta:test": "ng test ngx-meta",
     "ngx-meta:lint": "ng lint ngx-meta",


### PR DESCRIPTION
# Issue or need

As a previous step to add coverage that takes into account both unit & E2E tests, first those tests need to be clearly differentiated


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Replace instances of `test` by `unit-test` where applies. In order to later be able to have a `test` task that runs all tests in case you want to locally generate the merged coverage report.

Also replacing the required status check to merge to `main` branch given the GitHub Actions workflow job name changed.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
