### PR TITLE
test: report coverage via Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -7,6 +7,13 @@ on:
         type: string
         required: false
         default: ''
+    secrets:
+      codecov-token:
+        description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
+        required: true
+
+env:
+  COVERAGE_DIR: coverage
 
 jobs:
   unit-test:
@@ -22,3 +29,8 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run unit tests
         run: cd .ci && make unit-test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          directory: ${{ env.COVERAGE_DIR }}/ngx-meta
+          token: ${{ secrets.codecov-token }}

--- a/angular.json
+++ b/angular.json
@@ -28,7 +28,8 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "tsConfig": "projects/ngx-meta/src/tsconfig.spec.json",
-            "polyfills": ["zone.js", "zone.js/testing"]
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "karmaConfig": "projects/ngx-meta/src/karma.conf.js"
           }
         },
         "lint": {

--- a/projects/ngx-meta/src/karma.conf.js
+++ b/projects/ngx-meta/src/karma.conf.js
@@ -1,0 +1,36 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true, // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../../coverage/ngx-meta'),
+      subdir: '.',
+      reporters: [{ type: 'text-summary' }, { type: 'lcov' }],
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    restartOnFileChange: true,
+  })
+}


### PR DESCRIPTION
# Issue or need

Code coverage isn't being tracked right now. Though is being checked in unit tests thanks to Karma.


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

In order to track code coverage in every change, adding Codecov to the project

To do so, first generated a Karma config file in order to allow generating an `lcov` code coverage report that can be uploaded to Codecov

As next step, could include in that coverage the E2E tests coverage.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
