### PR TITLE
test: configure Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 5%
+    project:
+      default:
+        threshold: 5%
+comment:
+  layout: header, diff, files, footer
+  hide_project_coverage: false
+
+codecov:
+  require_ci_to_pass: false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "commitlint-last": "commitlint --verbose --from HEAD~1",
     "ng-lint-staged": "ng-lint-staged lint --max-warnings 0 --fix --",
     "cache-clean": "ng cache clean",
-    "commit": "pnpx @commitlint/prompt-cli"
+    "commit": "pnpx @commitlint/prompt-cli",
+    "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate"
   },
   "private": true,
   "packageManager": "pnpm@9.4.0",


### PR DESCRIPTION
# Issue or need
In #673 Codecov was added to keep track of coverage. Now, let's configure it

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Configure Codecov:
 - Allow 5% coverage drop in patches/project
 - Custom comment layout without condensed details
 - Show project coverage in comment

After checking all it's ok, adding `codecov` checks as required status checks to pass in order for PRs to be merged

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
