### PR TITLE
docs: add Codecov to README.md

### DIFF
--- a/projects/ngx-meta/src/README.md
+++ b/projects/ngx-meta/src/README.md
@@ -1,26 +1,33 @@
 ![<ngx-meta/> for Angular](../docs/content/images/logo.png)
 
-[![Angular](https://img.shields.io/badge/Works_with-Angular-red?logo=angular&logoColor=white&link=https%3A%2F%2Fangular.dev%2F)](https://angular.dev/)
+[![Angular](https://img.shields.io/badge/Works_with-Angular_v15--v18-f11653?logo=angular&logoColor=white&link=https%3A%2F%2Fangular.dev%2F)](https://angular.dev/)
 [![Supports Angular SSR/Universal](https://custom-icon-badges.demolab.com/badge/Supports-Angular_SSR%2FUniversal-blue.svg?logo=angular-universal&link=https%3A%2F%2Fangular.dev%2Fguide%2Fssr)][SSR]
-[![NPM Version](https://img.shields.io/npm/v/%40davidlj95%2Fngx-meta?logo=npm&label=Latest%20version&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40davidlj95%2Fngx-meta)](https://www.npmjs.com/package/@davidlj95/ngx-meta)
+
 [![NPM Downloads](https://img.shields.io/npm/dt/%40davidlj95%2Fngx-meta?logo=npm&label=NPM%20downloads&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40davidlj95%2Fngx-meta)](https://www.npmjs.com/package/@davidlj95/ngx-meta)
 [![NPM License](https://img.shields.io/npm/l/%40davidlj95%2Fngx-meta?logo=npm&label=License&link=https%3A%2F%2Fgithub.com%2Fdavidlj95%2Fngx%2Fblob%2Fmain%2Fprojects%2Fngx-meta%2Fsrc%2FLICENSE)](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/src/LICENSE)
+[![NPM Version](https://img.shields.io/npm/v/%40davidlj95%2Fngx-meta?logo=npm&label=Latest%20version&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40davidlj95%2Fngx-meta)](https://www.npmjs.com/package/@davidlj95/ngx-meta)
 [![Main CI/CD workflow](https://github.com/davidlj95/ngx/actions/workflows/main.yml/badge.svg)](https://github.com/davidlj95/ngx/actions/workflows/main.yml)
+[![Codecov](https://codecov.io/gh/davidlj95/ngx/graph/badge.svg)](https://codecov.io/gh/davidlj95/ngx)
 [![GitHub last commit (branch)](https://img.shields.io/github/last-commit/davidlj95/ngx/main?logo=github&label=Last%20commit&link=https%3A%2F%2Fgithub.com%2Fdavidlj95%2Fngx%2Fcommits%2Fmain%2F)](https://github.com/davidlj95/ngx/commits/main/)
-[![Unit tests with Jasmine](https://img.shields.io/badge/Unit_tests_with-Jasmine-8A4182?logo=Jasmine&logoColor=white&link=https%3A%2F%2Fjasmine.github.io)](https://jasmine.github.io)
-[![Unit tests with Karma](https://custom-icon-badges.demolab.com/badge/Unit_tests_with-Karma-42beae.svg?logo=karma-runner&link=https%3A%2F%2Fkarma-runner.github.io)](https://karma-runner.github.io)
-[![Tested with Cypress](https://img.shields.io/badge/E2E_tests_with-Cypress-green?logo=cypress&link=https%3A%2F%2Fwww.cypress.io)](https://www.cypress.io)
+
 [![Coded in Typescript](https://img.shields.io/badge/Coded_in-TypeScript-007ACC?logo=typescript&logoColor=white&link=https%3A%2F%2Fwww.typescriptlang.org)](https://www.typescriptlang.org)
-[![Linted with ESLint](https://img.shields.io/badge/Linted_with-eslint-3A33D1?logo=eslint&logoColor=white&link=https%3A%2F%2Feslint.org)](https://eslint.org)
+[![Git](https://img.shields.io/badge/VCS-Git-f05032?logo=git&logoColor=f05032&link=https%3A%2F%git-scm.com%2F)](https://git-scm.com/)
+[![GitHub](https://img.shields.io/badge/Repository_hosted_in-GitHub-181717?logo=github&logoColor=181717&link=https%3A%2F%github.com%2F)](https://github.com/)
+[![Package manager: pnpm](https://img.shields.io/badge/Package_manager-pnpm-f69220?logo=pnpm&link=https%3A%2F%2Fpnpm.io%2F)](https://pnpm.io/)
+[![Unit tests with Jasmine](https://img.shields.io/badge/Unit_tests_with-Jasmine-8A4182?logo=Jasmine&logoColor=white&link=https%3A%2F%2Fjasmine.github.io)](https://jasmine.github.io)
+[![Unit tests ran by Karma](https://custom-icon-badges.demolab.com/badge/Unit_tests_ran_by-Karma-42beae.svg?logo=karma-runner&link=https%3A%2F%2Fkarma-runner.github.io)](https://karma-runner.github.io)
+[![E2E tests with Cypress](https://img.shields.io/badge/E2E_tests_with-Cypress-69D3A7?logo=cypress&link=https%3A%2F%2Fwww.cypress.io)](https://www.cypress.io)
+[![Code coverage with Codecov](https://img.shields.io/badge/Code_coverage_with-Codecov-F01F7A?logo=codecov&logoColor=F01F7A&link=https%3A%2F%2F.codecov.io)](https://codecov.io)
+[![Linted with ESLint](https://img.shields.io/badge/Linted_with-ESLint-3A33D1?logo=eslint&logoColor=white&link=https%3A%2F%2Feslint.org)](https://eslint.org)
 [![Formatted with Prettier](https://img.shields.io/badge/Formatted_with-prettier-1A2C34?logo=prettier&logoColor=F7BA3E&link=https%3A%2F%2Fprettier.io)](https://prettier.io)
-[![Commits follow Conventional Commits convention](https://img.shields.io/badge/Commits_convention-Conventional_Commits-%23FE5196?logo=conventionalcommits&logoColor=white&link=https%3A%2F%2Fconventionalcommits.org)](https://conventionalcommits.org)
-[![Commit hooks with Husky](https://img.shields.io/badge/Commit_hooks_with-Husky%F0%9F%90%B6-1a1a1e?link=https%3A%2F%2Ftypicode.github.io%2Fhusky%2F)](https://typicode.github.io/husky/)
+[![Commits follow Conventional Commits convention](https://img.shields.io/badge/Commits_convention-Conventional_Commits-FE5196?logo=conventionalcommits&logoColor=white&link=https%3A%2F%2Fconventionalcommits.org)](https://conventionalcommits.org)
+[![Git hooks with Husky](https://img.shields.io/badge/Git_hooks_with-Husky%F0%9F%90%B6-1a1a1e?link=https%3A%2F%2Ftypicode.github.io%2Fhusky%2F)](https://typicode.github.io/husky/)
+[![GitHub Actions](https://img.shields.io/badge/CI%2FCD%20with-GitHub_Actions-2088FF?logo=githubactions&logoColor=2088FF&link=https%3A%2F%github.com%2Ffeatures%2Factions)](https://github.com/features/actions)
 [![Released with Semantic Release](https://img.shields.io/badge/Released_with-Semantic_Release-e10079?logo=semantic-release&link=https%3A%2F%2Fgithub.com%2Fsemantic-release%2Fsemantic-release)](https://github.com/semantic-release/semantic-release)
 [![Dependencies updated with Renovate](https://img.shields.io/badge/Dependencies_updated_with-Renovate-1a1f6c?logo=renovate&link=https%3A%2F%2Frenovatebot.com)](https://renovatebot.com)
 [![Docs with Material for Mkdocs](https://img.shields.io/badge/Docs_with-Material_for_Mkdocs-526CFE?logo=materialformkdocs&logoColor=white&link=https%3A%2F%2Fsquidfunk.github.io%2Fmkdocs-material%2F)](https://squidfunk.github.io/mkdocs-material/)
 [![API Report/Docs with API Extractor](https://custom-icon-badges.demolab.com/badge/API_Report_&_Docs_with-API_Extractor-383938.svg?logo=api-extractor&link=https%3A%2F%2Fapi-extractor.com%2F)](https://api-extractor.com/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)
-[![Package manager: pnpm](https://img.shields.io/badge/Package_manager-pnpm-f69220?logo=pnpm&link=https%3A%2F%2Fpnpm.io%2F)](https://pnpm.io/)
 
 Set your Angular site's metadata: standard meta tags, Open Graph,
 Twitter Cards, JSON-LD structured data and more.


### PR DESCRIPTION
# Issue or need

README.md doesn't include a Codecov badge in tooling part

Also the badges in README are not categorized, everything is dropped there: tooling used, package info (downloads, license, latest version, passing CI), framework support

Finally, it's not clear which Angular versions the library is compatible with

# Proposed changes

Adds Codecov badge to README.md indicating coverage

Splits badges by categories so information is categorized

Add to the Angular badge the version range it's compatible with

Adds Codecov, Git, GitHub & GitHub Actions to tooling

Minor badges edits

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
