### PR TITLE
ci: avoid fail when can't find PR to comment

### DIFF
--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -65,6 +65,7 @@ jobs:
             return pullRequestNumber
       - name: Find bundle size PR comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        if: steps.pr.outputs.result != ''
         id: fc
         with:
           issue-number: ${{ steps.pr.outputs.result }}
@@ -72,6 +73,7 @@ jobs:
           body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.app_name }}
       - name: Update bundle size PR comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        if: steps.pr.outputs.result != '' && steps.fc.outputs.comment-id != ''
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.result }}


### PR DESCRIPTION
# Issue or need

Recently all jobs of the `Pull request completed` GitHub Actions workflow have been failing. After looking into it, seems the issue is due to the hacky way used to find the PR that triggered a `workflow_run` workflow. GitHub search API is used to find a PR containing a commit whose SHA is the one that triggered the workflow. However, if amending that commit and force-pushing, that doesn't exist anymore. So at the point the `workflow_run` `Pull request completed` workflow runs, no PR is found. Despite it's not found, the job continues and tries to find the comment in the non-existing PR. And it fails there, given no PR (technically, an issue) has been specified.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Skip rest of workflow if can't find the PR with the comment to create or update

In order to test it, amended the commit that created this PR just after creating it. To see if the initial workflow triggered by the initial commit before the amend actually skips rest of job if can't find the PR.

Haven't managed to reproduce it. Anyway, going with this and can improve later

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
