### PR TITLE
ci(e2e): add Codecov secret for main wf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
     with:
       example-app-artifact-name-prefix: ngx-meta-example-app-
       example-app-artifact-name-coverage-suffix: -coverage
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:
     needs: example-apps
     name: Bundle size


### PR DESCRIPTION
# Issue or need

Badge wasn't reflecting the coverage increase after taking into account E2E tests coverage in #679 . After digging a bit, seems that the issue is that the secret isn't passed in the main workflow file

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Pass the secret

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
