### PR TITLE
build(lint): fix lint-staged config for GH Actions

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*": ["pnpm run format"],
   "projects/ngx-meta/src/**/*.ts": ["pnpm run ng-lint-staged"],
-  ".github/**/*.y[a]ml": ["pnpm run lint:gh-actions"]
+  ".github/**/*.{yml,yaml}": ["pnpm run lint:gh-actions"]
 }


### PR DESCRIPTION
# Issue or need

In #692 , the config to run `actionlint` in `pre-commit` `git` hook via `husky` + `lint-staged` seems was faulty. As a recent CI/CD run failed, but nothing failed locally when comitting.

After investigating, seems the issue lies in the `.lintstagedrc.json` glob to capture GitHub Action files.
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use `{}` to capture both `yaml` and `yml` files

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
