### PR TITLE
ci(e2e): remove unneded extra env var

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -55,15 +55,15 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ env.E2E_DIR }}/pnpm-lock.yaml
           node-version-file: .node-version # should be one compatible with Angular example app
-      - name: Get Cypress cache dir
-        run: echo "cypress_cache_dir=$HOME/.cache/Cypress" >> "$GITHUB_ENV"
+      - name: Configure Cypress cache directory
+        run: echo "CYPRESS_CACHE_FOLDER=$HOME/.cache/Cypress" >> "$GITHUB_ENV"
       - name: Cypress cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         env:
           cache-name: ngx-meta-e2e-cypress
           e2e_lockfile_hash: ${{ hashFiles(format('{0}/pnpm-lock.yaml', env.E2E_DIR)) }}
         with:
-          path: ${{ env.cypress_cache_dir }}
+          path: ${{ env.CYPRESS_CACHE_FOLDER }}
           key: ${{ env.cache-name }}-${{ env.e2e_lockfile_hash }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -72,8 +72,6 @@ jobs:
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Cypress run
         uses: cypress-io/github-action@8d3918616d8ac34caa2b49afc8b408b6a872a6f5 # v6.7.1
-        env:
-          CYPRESS_CACHE_FOLDER: ${{ env.cypress_cache_dir }}
         with:
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome


### PR DESCRIPTION
# Issue or need

If naming `cypress_cache_dir` as Cypress wants (`CYPRESS_CACHE_FOLDER`), we don't need to define `cypress_cache_dir`

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Follow Cypress namings for cache dir

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
