### PR TITLE
docs: improve contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Hey 👋 Glad you're here 😊 Contributions are very welcome ❤️
 
+> [!TIP]
+>
+> [GitHub provides a full table of contents](https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/). Right now it can be enabled clicking the list icon button.
+
 - [Code of conduct](#code-of-conduct)
 - [Submission guidelines](#submission-guidelines)
   - [Discussions](#discussions)
@@ -256,7 +260,9 @@ If the command is not installed, linting will be skipped and a warning will be s
 
 It is also included to run as part of [Git hooks].
 
-> [!NOTE] > [`actionlint` uses `shellcheck` to lint shell scripts inside `run` blocks in GitHub Actions workflows](https://github.com/rhysd/actionlint/blob/main/docs/checks.md#shellcheck-integration-for-run). In CI/CD the [Docker image includes `shellcheck` and `pyflakes`](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#docker) so those checks will run. If locally you don't have those commands available, `actionlint` won't run those checks. This means different results may be obtained from running in CI/CD vs running locally. Install those (mainly `shellcheck`) to have the same behaviour in CI/CD and locally.
+> [!NOTE]
+>
+> [`actionlint` uses `shellcheck` to lint shell scripts inside `run` blocks in GitHub Actions workflows](https://github.com/rhysd/actionlint/blob/main/docs/checks.md#shellcheck-integration-for-run). In CI/CD the [Docker image includes `shellcheck` and `pyflakes`](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#docker) so those checks will run. If locally you don't have those commands available, `actionlint` won't run those checks. This means different results may be obtained from running in CI/CD vs running locally. Install those (mainly `shellcheck`) to have the same behaviour in CI/CD and locally.
 
 #### API Report
 


### PR DESCRIPTION
# Issue or need

Contributors guide note about `actionlint` isn't properly formatted. Also, could add an automatic table of contents to avoid having to update the currently manual one

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Fix the note syntax

Seems there's no way for GitHub to generate an automatic table of contents inside the document. But the web UI allows you to see one. So adding that tip in the guide

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
