### PR TITLE
ci(coverage): wait for CI until reporting status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,3 @@ coverage:
         threshold: 5%
 comment:
   hide_project_coverage: false
-
-codecov:
-  require_ci_to_pass: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,10 @@ coverage:
         threshold: 5%
 comment:
   hide_project_coverage: false
+
+codecov:
+  notify:
+    # 👇 Must be in sync with number of uploads needed.
+    #    Which now depends on amount of E2E tests run
+    #    Plus the unit tests coverage
+    after_n_builds: 5


### PR DESCRIPTION
# Issue or need

Multiple reports need to be uploaded in order to provide a holistic coverage view (unit tests + E2E tests run for each Angular example app). However, current Codecov config doesn't wait to report the coverage status. So we get invalid statuses until all reports are uploaded

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Codecov to wait for CI to finish in order to show coverage results by removing the `require_ci_to_pass: false` config

Then, wait for all uploads using `after_n_builds`, as stated in docs.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
