### PR TITLE
build: allow merging coverage reports locally

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -85,5 +85,5 @@ jobs:
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         if: failure() || success()
         with:
-          directory: ${{ env.COVERAGE_DIR }}
+          file: ${{ env.COVERAGE_DIR }}/lcov.info
           token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
-  COVERAGE_DIR: coverage
+  COVERAGE_DIR: coverage/ngx-meta
 
 jobs:
   e2e:
@@ -85,5 +85,5 @@ jobs:
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         if: failure() || success()
         with:
-          directory: ${{ env.E2E_DIR }}/${{ env.COVERAGE_DIR }}
+          directory: ${{ env.COVERAGE_DIR }}
           token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -85,5 +85,6 @@ jobs:
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         if: failure() || success()
         with:
+          disable_search: true
           file: ${{ env.COVERAGE_DIR }}/lcov.info
           token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -32,5 +32,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:
+          disable_search: true
           file: ${{ env.COVERAGE_DIR }}/lcov.info
           token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -13,7 +13,7 @@ on:
         required: true
 
 env:
-  COVERAGE_DIR: coverage
+  COVERAGE_DIR: coverage/ngx-meta
 
 jobs:
   unit-test:
@@ -32,5 +32,5 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:
-          directory: ${{ env.COVERAGE_DIR }}/ngx-meta
+          directory: ${{ env.COVERAGE_DIR }}
           token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:
-          directory: ${{ env.COVERAGE_DIR }}
+          file: ${{ env.COVERAGE_DIR }}/lcov.info
           token: ${{ secrets.codecov-token }}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "ngx-meta:api-extractor:local": "pnpm run ngx-meta:tsc:lib && pnpm run ngx-meta:api-extractor --local",
     "ngx-meta:api-documenter": "api-documenter markdown -i ./projects/ngx-meta/api-extractor -o ./projects/ngx-meta/docs/content/api",
     "ngx-meta:instrument-for-coverage": "nyc instrument projects/ngx-meta/dist/fesm2022 --in-place",
+    "ngx-meta:coverage:report:all": "pnpm run ngx-meta:coverage:move-to-nyc-output && nyc report --reporter lcov --report-dir coverage/ngx-meta",
+    "ngx-meta:coverage:move-to-nyc-output": "rm -rf .nyc_output && mkdir .nyc_output && cp -f coverage/ngx-meta/*.json .nyc_output",
     "format-check": "prettier --check",
     "format-check-all": "npm run format-check -- .",
     "format": "prettier --ignore-unknown --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6421,7 +6421,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1800.6(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1800.6(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.91.0)
+      '@angular-devkit/build-webpack': 0.1800.6(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.21.3))
       '@angular-devkit/core': 18.0.6(chokidar@3.6.0)
       '@angular/build': 18.0.6(@angular/compiler-cli@18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5))(@types/node@20.13.0)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(terser@5.31.0)(typescript@5.4.5)
       '@angular/compiler-cli': 18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5)
@@ -6435,15 +6435,15 @@ snapshots:
       '@babel/preset-env': 7.24.5(@babel/core@7.24.5)
       '@babel/runtime': 7.24.5
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 18.0.6(@angular/compiler-cli@18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.91.0)
+      '@ngtools/webpack': 18.0.6(@angular/compiler-cli@18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.91.0(esbuild@0.21.3))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.2.11(@types/node@20.13.0)(less@4.2.0)(sass@1.77.2)(terser@5.31.0))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.5)(webpack@5.91.0)
+      babel-loader: 9.1.3(@babel/core@7.24.5)(webpack@5.91.0(esbuild@0.21.3))
       browserslist: 4.23.0
-      copy-webpack-plugin: 11.0.0(webpack@5.91.0)
+      copy-webpack-plugin: 11.0.0(webpack@5.91.0(esbuild@0.21.3))
       critters: 0.0.22
-      css-loader: 7.1.1(webpack@5.91.0)
+      css-loader: 7.1.1(webpack@5.91.0(esbuild@0.21.3))
       esbuild-wasm: 0.21.3
       fast-glob: 3.3.2
       http-proxy-middleware: 3.0.0
@@ -6453,11 +6453,11 @@ snapshots:
       jsonc-parser: 3.2.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 12.2.0(less@4.2.0)(webpack@5.91.0)
-      license-webpack-plugin: 4.0.2(webpack@5.91.0)
+      less-loader: 12.2.0(less@4.2.0)(webpack@5.91.0(esbuild@0.21.3))
+      license-webpack-plugin: 4.0.2(webpack@5.91.0(esbuild@0.21.3))
       loader-utils: 3.2.1
       magic-string: 0.30.10
-      mini-css-extract-plugin: 2.9.0(webpack@5.91.0)
+      mini-css-extract-plugin: 2.9.0(webpack@5.91.0(esbuild@0.21.3))
       mrmime: 2.0.0
       open: 8.4.2
       ora: 5.4.1
@@ -6465,13 +6465,13 @@ snapshots:
       picomatch: 4.0.2
       piscina: 4.5.0
       postcss: 8.4.38
-      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0)
+      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0(esbuild@0.21.3))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.77.2
-      sass-loader: 14.2.1(sass@1.77.2)(webpack@5.91.0)
+      sass-loader: 14.2.1(sass@1.77.2)(webpack@5.91.0(esbuild@0.21.3))
       semver: 7.6.2
-      source-map-loader: 5.0.0(webpack@5.91.0)
+      source-map-loader: 5.0.0(webpack@5.91.0(esbuild@0.21.3))
       source-map-support: 0.5.21
       terser: 5.31.0
       tree-kill: 1.2.2
@@ -6484,7 +6484,7 @@ snapshots:
       webpack-dev-middleware: 7.2.1(webpack@5.91.0)
       webpack-dev-server: 5.0.4(webpack@5.91.0)
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.91.0)
+      webpack-subresource-integrity: 5.1.0(webpack@5.91.0(esbuild@0.21.3))
     optionalDependencies:
       esbuild: 0.21.3
       karma: 6.4.3
@@ -6507,7 +6507,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1800.6(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.91.0)':
+  '@angular-devkit/build-webpack@0.1800.6(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.21.3))':
     dependencies:
       '@angular-devkit/architect': 0.1800.6(chokidar@3.6.0)
       rxjs: 7.8.1
@@ -8235,7 +8235,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
     optional: true
 
-  '@ngtools/webpack@18.0.6(@angular/compiler-cli@18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.91.0)':
+  '@ngtools/webpack@18.0.6(@angular/compiler-cli@18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.91.0(esbuild@0.21.3))':
     dependencies:
       '@angular/compiler-cli': 18.0.5(@angular/compiler@18.0.5(@angular/core@18.0.5(rxjs@7.8.1)(zone.js@0.14.6)))(typescript@5.4.5)
       typescript: 5.4.5
@@ -9191,7 +9191,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  babel-loader@9.1.3(@babel/core@7.24.5)(webpack@5.91.0):
+  babel-loader@9.1.3(@babel/core@7.24.5)(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       '@babel/core': 7.24.5
       find-cache-dir: 4.0.0
@@ -9595,7 +9595,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@11.0.0(webpack@5.91.0):
+  copy-webpack-plugin@11.0.0(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -9652,7 +9652,7 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-loader@7.1.1(webpack@5.91.0):
+  css-loader@7.1.1(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -11055,7 +11055,7 @@ snapshots:
       picocolors: 1.0.0
       shell-quote: 1.8.1
 
-  less-loader@12.2.0(less@4.2.0)(webpack@5.91.0):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       less: 4.2.0
     optionalDependencies:
@@ -11082,7 +11082,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.91.0):
+  license-webpack-plugin@4.0.2(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -11326,7 +11326,7 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.91.0):
+  mini-css-extract-plugin@2.9.0(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -11985,7 +11985,7 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0):
+  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.0
@@ -12283,7 +12283,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@14.2.1(sass@1.77.2)(webpack@5.91.0):
+  sass-loader@14.2.1(sass@1.77.2)(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -12551,7 +12551,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-loader@5.0.0(webpack@5.91.0):
+  source-map-loader@5.0.0(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
@@ -13048,7 +13048,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.91.0):
+  webpack-subresource-integrity@5.1.0(webpack@5.91.0(esbuild@0.21.3)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.91.0(esbuild@0.21.3)

--- a/projects/ngx-meta/e2e/.nycrc.json
+++ b/projects/ngx-meta/e2e/.nycrc.json
@@ -1,3 +1,4 @@
 {
-  "reporter": ["lcov"]
+  "reporter": ["lcov", "json"],
+  "report-dir": "../../../coverage/ngx-meta"
 }

--- a/projects/ngx-meta/e2e/package.json
+++ b/projects/ngx-meta/e2e/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
+    "postcypress:run": "mv -f ../../../coverage/ngx-meta/coverage-final.json ../../../coverage/ngx-meta/e2e.json",
     "//1": "👇 Coverage reporting tools like Codecov usually require paths relative to repo root",
-    "coverage:relative-path-fix": "sed -i.bak 's|SF:..|SF:projects/ngx-meta|' coverage/lcov.info"
+    "coverage:relative-path-fix": "sed -i.bak 's|SF:..|SF:projects/ngx-meta|' ../../../coverage/ngx-meta/lcov.info"
   },
   "packageManager": "pnpm@9.6.0",
   "private": true,

--- a/projects/ngx-meta/src/karma.conf.js
+++ b/projects/ngx-meta/src/karma.conf.js
@@ -27,7 +27,11 @@ module.exports = function (config) {
     coverageReporter: {
       dir: require('path').join(__dirname, '../../../coverage/ngx-meta'),
       subdir: '.',
-      reporters: [{ type: 'text-summary' }, { type: 'lcov' }],
+      reporters: [
+        { type: 'text-summary' },
+        { type: 'lcov' },
+        { type: 'json', file: 'unit-test.json' },
+      ],
     },
     reporters: ['progress', 'kjhtml'],
     browsers: ['Chrome'],


### PR DESCRIPTION
# Issue or need

Currently Codecov gets several coverage reports (1 for unit tests  + 1 for each example app E2E test run). Then, it merges those reports and presents a final coverage report.

However global coverage should be able to be measured locally.
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Allow measuring global coverage locally by:
 - Outputting all coverage info to same directory. In this case `coverage/ngx-meta`. Only E2E tests modified, unit ones were already configured.
 - Output coverage in `istanbul.js` JSON format (to merge it easily, see referenced below for the reason)
 - Add run script to merge JSON reports into a global coverage report
 - Specify in CI/CD which coverage report files to upload to Codecov. Otherwise `coverage-final.json` generated in E2E tests by Cypress with `istanbul.js` was uploaded along with `lcov.info`. Could upload that one instead, but `lcov` seems more universal / widely accepted. Also still emitting `lcov` in order to be able to locally see HTML reports & work with other tools. Like WebStorm's coverage window.

Inspired from https://github.com/davidlj95/website/pull/656

Next step: document how to operate coverage in contributing guide

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
