### PR TITLE
docs: remove 1 indent level from contributing guide [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,13 @@ Hey 👋 Glad you're here 😊 Contributions are very welcome ❤️
   - [Tools](#tools)
   - [Quirks](#quirks)
 
-## Code of conduct
+# Code of conduct
 
 To keep the project open and inclusive, please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) (TL;DR: don't be an a\*\*hole)
 
-## Submission Guidelines
+# Submission Guidelines
 
-### Discussions
+## Discussions
 
 If you want to discuss an idea, improvement, feature request or something related to one of the libraries hosted in this repository, please do by visiting the [GitHub Discussions] page. And remember to follow the [code of conduct](#code-of-conduct)
 
@@ -32,7 +32,7 @@ If you want to discuss an idea, improvement, feature request or something relate
 - ✅ **Do use** [GitHub Discussions] to talk about ideas, enhancement, improvements, feature requests or anything else
 - ❌ **Do not** use [GitHub Issues] to suggest new features or enhancements.
 
-### Issues
+## Issues
 
 Before submitting an issue, please do search the [GitHub Issues] tracker first. An issue may exist already.
 
@@ -49,7 +49,7 @@ If you know the bug and can provide a bug fix, your pull request is more than we
 - ❤️ **Do** open a pull request with a bug fix, if you are able to provide one
 - ❌ **Do not** use [GitHub Issues] to talk about non-issues. Use [GitHub Discussions] instead.
 
-### Pull requests
+## Pull requests
 
 Happy to see you want to provide some code or docs 🥰
 
@@ -71,7 +71,7 @@ A reviewer will check your code and provide feedback. If everything's ready, the
 - ✅ **Do** search [GitHub Pull Requests] to find an existing pull request first. Even if it's in closed state.
 - ✅ **Do** describe your changes with a description
 
-## Developing
+# Developing
 
 You can go and just start writing code. The CI/CD will tell you if you fail to comply with a required code style / convention. However, if you want to know them in advance:
 
@@ -80,9 +80,9 @@ You can go and just start writing code. The CI/CD will tell you if you fail to c
 - **Take a look at [tools](#tools)** recommended to help you develop
 - **Something strange happens? [Quirks](#quirks)** may help
 
-### Conventions
+## Conventions
 
-#### Commit messages
+### Commit messages
 
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention is used to format commit messages. This means commit messages must be in the shape of:
 
@@ -110,7 +110,7 @@ There is no formal convention on scopes. Though for `ngx-meta`, metadata module 
 
 See [linting section about commit messages](#commit-messages-1) to know how to ensure commit conventions are followed.
 
-#### TSDoc comments
+### TSDoc comments
 
 Every exported member must be documented using [TSDoc](https://tsdoc.org/). Specifically, [API Extractor subset of TSDoc](https://api-extractor.com/pages/tsdoc/doc_comment_syntax/)
 
@@ -118,25 +118,25 @@ At least, it must provide the visibility of the exported member. Mainly either [
 
 Check out [API Report](#api-report) section for more information
 
-#### Testing
+### Testing
 
 Do add an E2E test when adding some metadata to ensure it's add and removed as expected.
 
 Avoid unit tests for setting a specific metadata if the logic to set the metadata is straight forward (ie: no `if`s or loops).
 
-#### Documentation
+### Documentation
 
 Remember to add some docs to the [comparison page](projects/ngx-meta/docs/content/why/comparison.md) when adding new metadata.
 
 If adding a whole metadata module, add it to the built-in modules section too.
 
-#### CI/CD jobs
+### CI/CD jobs
 
 To easily reproduce locally CI/CD jobs, most commands run by CI/CD are stored in [`.ci/Makefile` file](.ci/Makefile).
 
 For instance, you can run `make build` (or just `make` in this case) to ensure the command used to build is the same one the CI/CD job will use.
 
-#### Release and versioning
+### Release and versioning
 
 Every release is identified by a version number that follows [Semantic Versioning 2.0 specification](https://semver.org/)
 
@@ -147,9 +147,9 @@ Every push to main branch analyzes all commits since latest release. Based on co
 
 See [release task](#release) for more information about how to operate releases.
 
-### Tasks
+## Tasks
 
-#### Package management
+### Package management
 
 As you can see in [`package.json`'s](package.json) `packageManager` field, `pnpm` is used to manage packages. [`corepack`](https://github.com/nodejs/corepack) is used to manage the package manager 🤯
 
@@ -159,7 +159,7 @@ To install packages needed to develop, do
 pnpm install
 ```
 
-#### Build
+### Build
 
 After installing dependencies as seen in [package management](#package-management), just run
 
@@ -169,9 +169,9 @@ pnpm run build
 
 To build all libraries
 
-#### Test
+### Test
 
-##### Unit tests
+#### Unit tests
 
 Unit tests are run with Angular's default test runner [Karma](https://karma-runner.github.io) and written in [Jasmine](https://jasmine.github.io/)
 
@@ -184,11 +184,11 @@ pnpm run test:unit
 > [!TIP]
 > There's also a WebStorm run configuration (`Unit tests: all`) to run all unit tests and report the results inside the IDE
 
-##### E2E tests
+#### E2E tests
 
 Refer to [`ngx-meta`'s E2E `README` for more information](projects/ngx-meta/e2e/README.md)
 
-#### Format
+### Format
 
 [Prettier](https://prettier.io/) is used for consistent code formatting.
 
@@ -208,7 +208,7 @@ To fix them all
 
 [Git hooks] are provided to automatically ensure code is formatted before committing it.
 
-#### Lint
+### Lint
 
 To lint everything, run
 
@@ -216,7 +216,7 @@ To lint everything, run
 pnpm run lint
 ```
 
-##### Commit messages
+#### Commit messages
 
 [`commitlint`](https://commitlint.js.org/) is used to enforce the [commit messages conventions](#commit-messages).
 
@@ -234,7 +234,7 @@ pnpm run commitlint-last
 
 [Git hooks] are provided to automatically ensure your message follows the convention when committing.
 
-##### Most code: TS, JS, HTML...
+#### Most code: TS, JS, HTML...
 
 [ESLint](https://eslint.org/) is used to lint the project amongst [Angular ESLint](https://github.com/angular-eslint/angular-eslint). As recommended by Angular when doing `ng lint`.
 
@@ -246,7 +246,7 @@ pnpm run lint:code
 
 [Git hooks] are provided to automatically lint changed files when committing. Thanks to [`lint-staged`](https://github.com/lint-staged/lint-staged)
 
-##### GitHub Actions code (optional)
+#### GitHub Actions code (optional)
 
 [`actionlint`](https://github.com/rhysd/actionlint) provides linting for GitHub Actions workflows & actions. Checkout the repository's instructions on how to install the tool in your machine.
 
@@ -264,7 +264,7 @@ It is also included to run as part of [Git hooks].
 >
 > [`actionlint` uses `shellcheck` to lint shell scripts inside `run` blocks in GitHub Actions workflows](https://github.com/rhysd/actionlint/blob/main/docs/checks.md#shellcheck-integration-for-run). In CI/CD the [Docker image includes `shellcheck` and `pyflakes`](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#docker) so those checks will run. If locally you don't have those commands available, `actionlint` won't run those checks. This means different results may be obtained from running in CI/CD vs running locally. Install those (mainly `shellcheck`) to have the same behaviour in CI/CD and locally.
 
-#### API Report
+### API Report
 
 [API Extractor] generates a report of the exposed API of a package in order to keep track of public API signatures. In order to for instance help detecting breaking changes.
 
@@ -288,7 +288,7 @@ It will generate the API Report file for you to commit it.
 
 CI/CD will ensure the API Report is up-to-date with current code.
 
-#### API Reference docs
+### API Reference docs
 
 [API Extractor] also generates the base to generate API Reference docs. **Run it first** as explained in previous step before generating API Reference docs.
 
@@ -300,15 +300,15 @@ pnpm run ngx-meta:api-documenter
 
 To generate API Reference docs, which will end up in the [documentation](#documentation) directory.
 
-#### Docs
+### Docs
 
 Check out [`ngx-meta` docs `README.md` to operate docs project](projects/ngx-meta/docs/README.md)
 
-#### Release
+### Release
 
 [Semantic Release] is used to create releases by analyzing [commit messages' semantic information](#commit-messages). Here you'll find how to simulate a release.
 
-##### Dry run: working on a branch
+#### Dry run: working on a branch
 
 Semantic Release [behaves differently depending on the checked out branch](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#workflow-configuration).
 
@@ -325,15 +325,15 @@ For instance, add the following to the `branches` configuration in the `.release
 }
 ```
 
-###### Beware of the `channel` option
+##### Beware of the `channel` option
 
 Default is `undefined` for first release branch, but branch name for the rest. So in order to properly simulate the release process, you'll have to manually configure that. [`false` can be used to indicate default distribution channel](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#branches-properties).
 
-###### Branch needs to be pushed
+##### Branch needs to be pushed
 
 Otherwise, it [does not exist for semantic release](https://github.com/semantic-release/semantic-release/blob/v23.1.1/lib/branches/expand.js#L11). Same for commits on that branch. If not pushed, it's like they don't exist.
 
-##### Dry run: minimal
+#### Dry run: minimal
 
 To have a minimal idea of what would happen when running the release process, you can run [Semantic Release] in [dry run mode](https://semantic-release.gitbook.io/semantic-release/usage/configuration#dryrun). This includes: authentication checks, commit analysis to see if a new release is needed and the release notes for it in case it's needed.
 
@@ -368,13 +368,13 @@ pnpm semantic-release --dry-run
 
 This is useful to know the version bumped and release notes generated, but prepare and publish NPM steps are skipped. Keep reading to know how to dry run them.
 
-##### "Dry run": publish
+#### "Dry run": publish
 
 What if you want to simulate what would be published to the NPM registry? Or how the generated release notes would look in GitHub? Or how the generated CHANGELOG.md would look like? Keep reading to see how to safely test that.
 
 However, bear in mind that it won't be a dry run (hence the quotes). Semantic Release will be called as if actually performing a release, but with a different registry and repository. There's [no way of dry running a release with semantic release that includes prepare, publish, success or failure steps](https://github.com/semantic-release/semantic-release/blob/v23.1.1/lib/definitions/plugins.js#L72).
 
-###### Private, local registry
+##### Private, local registry
 
 A private registry can be used to simulate packaging and publishing steps. [Verdaccio] is a popular choice at this time.
 
@@ -421,7 +421,7 @@ npm token create
 
 Take note of it. This token will be used by [Semantic Release] to authenticate against the registry as seen in the [minimal dry run](#dry-run-minimal)
 
-###### Different repository
+##### Different repository
 
 Unfortunately [Semantic Release] [hardcodes pushing to the git repository](https://github.com/semantic-release/semantic-release/blob/v23.1.1/index.js#L207-L212). So there's no way to dry-run that part :(
 
@@ -473,7 +473,7 @@ git notes prune -v # to clear notes about non-existing tags
 
 If using Semantic Release's git plugin (or another that writes to git), you'll need to remove the created commit by it too.
 
-###### Running the release
+##### Running the release
 
 With the private registry setup and the new repository created, you can run the release.
 
@@ -528,13 +528,13 @@ pnpm semantic-release \
 [Semantic Release's NPM plugin]: https://github.com/semantic-release/npm
 [Verdaccio]: https://verdaccio.org/
 
-### Tools
+## Tools
 
-#### IDE
+### IDE
 
 [JetBrains WebStorm](https://www.jetbrains.com/webstorm/) is used to develop this project. The repository contains many run configurations and settings to help you. However, feel free to use whatever tool you prefer :)
 
-#### Git hooks
+### Git hooks
 
 [Git hooks]: #git-hooks
 
@@ -552,9 +552,9 @@ They should be installed by default. If not, do run
 pnpm husky
 ```
 
-### Quirks
+## Quirks
 
-#### Can't run unit tests: `TestBed` error
+### Can't run unit tests: `TestBed` error
 
 If you see this error:
 


### PR DESCRIPTION
# Issue or need

Contributing guide headers are starting to require more space (reaching level 6)

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Main titles to be level 1 -> `#` and not level 2 -> `##`

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
