### PR TITLE
ci: configure Codecov to don't wait for CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,9 @@ comment:
   hide_project_coverage: false
 
 codecov:
+  require_ci_to_pass: false
   notify:
+    wait_for_ci: false
     # 👇 Must be in sync with number of uploads needed.
     #    Which now depends on amount of E2E tests run
     #    Plus the unit tests coverage


### PR DESCRIPTION
# Issue or need

In #698, Codecov was configured to wait for all coverage reports to be uploaded before emitting a status check via `after_n_builds` config (as stated in docs).

However, once that's configured, we no longer need to wait for CI/CD as that's a sufficient enough condition.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Don't wait for CI to emit Codecov status check 

Not sure of difference between `require_ci_to_pass` and `notify`. So adding them both.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
