### PR TITLE
docs: add coverage section to contributing guide [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ To build all libraries
 
 #### Unit tests
 
-Unit tests are run with Angular's default test runner [Karma](https://karma-runner.github.io) and written in [Jasmine](https://jasmine.github.io/)
+Unit tests are run with Angular's default test runner [Karma](https://karma-runner.github.io) and default framework [Jasmine](https://jasmine.github.io/)
 
 To run them all
 
@@ -184,9 +184,42 @@ pnpm run test:unit
 > [!TIP]
 > There's also a WebStorm run configuration (`Unit tests: all`) to run all unit tests and report the results inside the IDE
 
+##### With coverage
+
+To enable coverage reporting, add `--code-coverage` CLI option:
+
+```sh
+pnpm run test:unit --code-coverage
+```
+
+Reports will be generated in JSON, `lcov` and HTML format. JSON report file name is `unit-test.json`. See [coverage section](#coverage) for more details.
+
+> [!NOTE]
+> You can also use WebStorm's [`Run with coverage` option](https://www.jetbrains.com/help/webstorm/code-coverage.html). However, seems that it will use a custom Karma config. So the coverage report configuration may be different. At the moment of writing this document, for instance, the report directory and format is not the same.
+
 #### E2E tests
 
 Refer to [`ngx-meta`'s E2E `README` for more information](projects/ngx-meta/e2e/README.md)
+
+#### Coverage
+
+Tests are configured to output coverage reports to the `coverage/<projectName>` directory. See each kind of tests to see which formats will be output there.
+
+[Codecov](https://codecov.io) is used to keep track of code coverage over time. It is configured in CI/CD to ensure each PR introduces tests for new code introduced and to maintain a good overall project coverage. It will also merge coverage reports from different tests (unit, E2E) to have a holistic code coverage view.
+
+In local, beware that reports may overwrite each other. Except for JSON reports. For instance if running unit tests coverage and then E2E tests coverage, the `lcov` and HTML report will take int account E2E tests only.
+
+##### Global coverage
+
+In order to get the coverage for all kinds of tests, [`nyc` CLI](https://github.com/istanbuljs/nyc) can be used to merge several JSON code coverage reports.
+
+First, run all tests with coverage you want to merge to emit those JSON code coverage reports.
+
+Then, you can use the `coverage:report:all` run script in `package.json` to merge reports. For instance, for `ngx-meta`:
+
+```sh
+pnpm run ngx-meta:coverage:report:all
+```
 
 ### Format
 

--- a/projects/ngx-meta/e2e/README.md
+++ b/projects/ngx-meta/e2e/README.md
@@ -24,7 +24,11 @@ pnpm install
 
 [Cypress can be configured to perform code coverage reporting](https://docs.cypress.io/guides/tooling/code-coverage#What-youll-learn). Essentially two steps are needed: instrument the JS code to track lines being hit and later report the results.
 
-Run the `ngx-meta:instrument-for-coverage` script in root repo to instrument the `ngx-meta` library for coverage reporting before running Cypress tests. Then, Cypress is already configured via the [`@cypress/code-coverage` plugin](https://github.com/cypress-io/code-coverage) to report results (to the `coverage` subdirectory).
+Run the `ngx-meta:instrument-for-coverage` script in root repo to instrument the `ngx-meta` library for coverage reporting before running Cypress tests. Now, create an example app and serve it (as usual to run E2E tests). Cypress is configured via the [`@cypress/code-coverage` plugin](https://github.com/cypress-io/code-coverage) to report results. A report will be generated in JSON, `lcov` and HTML formats.
+
+Take look into [`package.json`](package.json)'s `postcypress:run` script for the name of the JSON report generated inside the report directory.
+
+See more details on coverage in [contributing guide](../../../CONTRIBUTING.md#coverage)
 
 ### Run tests
 


### PR DESCRIPTION
# Issue or need

Changes introduced in #705 to merge code coverage reports are not documented

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Document them in contributing guide

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
