### PR TITLE
ci: reduce complexity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,6 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
-    with:
-      dist-artifact-name: ngx-meta-dist
-      dist-artifact-name-coverage-suffix: -coverage
-      tsc-artifact-name: ngx-meta-tsc
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -30,42 +26,26 @@ jobs:
     needs: build
     name: API Extractor
     uses: ./.github/workflows/reusable-api-extractor.yml
-    with:
-      tsc-artifact-name: ngx-meta-tsc
-      api-docs-artifact-name: ngx-meta-api-docs
   example-apps:
     needs: build
     name: Example apps
     uses: ./.github/workflows/reusable-example-apps.yml
-    with:
-      dist-artifact-name: ngx-meta-dist
-      dist-artifact-name-coverage-suffix: -coverage
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      example-app-artifact-name-coverage-suffix: -coverage
   e2e:
     needs: example-apps
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
-    with:
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      example-app-artifact-name-coverage-suffix: -coverage
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:
     needs: example-apps
     name: Bundle size
     uses: ./.github/workflows/reusable-bundle-size.yml
-    with:
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      bundle-size-artifact-name-prefix: ngx-meta-bundle-size-
     permissions:
       checks: write
   release:
     name: Release
     needs: e2e
     uses: ./.github/workflows/reusable-release.yml
-    with:
-      dist-artifact-name: ngx-meta-dist
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
       github-token-pr: ${{ secrets.PR_GH_TOKEN }}
@@ -78,9 +58,6 @@ jobs:
     name: Docs
     needs: [api-extractor, bundle-size]
     uses: ./.github/workflows/reusable-docs.yml
-    with:
-      api-docs-artifact-name: ngx-meta-api-docs
-      bundle-size-artifact-name-prefix: ngx-meta-bundle-size-
     secrets:
       cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -15,9 +15,9 @@ permissions:
   pull-requests: write
 
 env:
-  #👇 Keep in sync with pull request workflow
-  BUNDLE_SIZE_ARTIFACT_NAME_PREFIX: ngx-meta-bundle-size-
-  #👇 Keep in sync with bundle size reusable workflow
+  #👇 Keep in sync with bundle size workflow
+  BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX: -bundle-size
+  #👇 Keep in sync with bundle size workflow
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
       - name: Download bundle size analysis results
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ env.BUNDLE_SIZE_ARTIFACT_NAME_PREFIX }}${{ matrix.app-name }}
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}
           #👇 Need to specify it, otherwise, `run-id` argument won't be taken into account
           # https://github.com/actions/download-artifact/tree/v4.1.4#:~:text=current%20workflow%20run.-,github%2Dtoken%3A,-%23%20The%20repository
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,10 +8,6 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
-    with:
-      dist-artifact-name: ngx-meta-dist
-      dist-artifact-name-coverage-suffix: -coverage
-      tsc-artifact-name: ngx-meta-tsc
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
@@ -27,41 +23,24 @@ jobs:
     needs: build
     name: API Extractor
     uses: ./.github/workflows/reusable-api-extractor.yml
-    with:
-      tsc-artifact-name: ngx-meta-tsc
-      api-docs-artifact-name: ngx-meta-api-docs
   example-apps:
     needs: build
     name: Example apps
     uses: ./.github/workflows/reusable-example-apps.yml
-    with:
-      dist-artifact-name: ngx-meta-dist
-      dist-artifact-name-coverage-suffix: -coverage
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      example-app-artifact-name-coverage-suffix: -coverage
   e2e:
     needs: example-apps
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
-    with:
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      example-app-artifact-name-coverage-suffix: -coverage
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:
     needs: example-apps
     name: Bundle size
     uses: ./.github/workflows/reusable-bundle-size.yml
-    with:
-      example-app-artifact-name-prefix: ngx-meta-example-app-
-      bundle-size-artifact-name-prefix: ngx-meta-bundle-size-
   docs:
     needs: [api-extractor, bundle-size]
     name: Docs
     uses: ./.github/workflows/reusable-docs.yml
-    with:
-      api-docs-artifact-name: ngx-meta-api-docs
-      bundle-size-artifact-name-prefix: ngx-meta-bundle-size-
     secrets:
       cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/reusable-api-extractor.yml
+++ b/.github/workflows/reusable-api-extractor.yml
@@ -2,11 +2,6 @@ name: API Extractor
 on:
   workflow_call:
     inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
       tsc-artifact-name:
         description: Artifact name containing built lib
         type: string
@@ -27,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Download tsc output files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
@@ -53,8 +46,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Download API Extractor JSON docs
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/reusable-api-extractor.yml
+++ b/.github/workflows/reusable-api-extractor.yml
@@ -14,7 +14,7 @@ on:
       api-docs-artifact-name:
         description: Artifact name containing markdown docs output
         type: string
-        required: false
+        required: true
 
 env:
   API_EXTRACTOR_ARTIFACT_NAME: ngx-meta-api-extractor
@@ -65,7 +65,6 @@ jobs:
       - name: Run API Documenter
         run: cd .ci && make api-documenter
       - name: Upload API Documenter generated markdown docs
-        if: ${{ inputs.api-docs-artifact-name != '' }}
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
           name: ${{ inputs.api-docs-artifact-name }}

--- a/.github/workflows/reusable-api-extractor.yml
+++ b/.github/workflows/reusable-api-extractor.yml
@@ -1,18 +1,13 @@
 name: API Extractor
 on:
   workflow_call:
-    inputs:
-      tsc-artifact-name:
-        description: Artifact name containing built lib
-        type: string
-        required: false
-      api-docs-artifact-name:
-        description: Artifact name containing markdown docs output
-        type: string
-        required: true
 
 env:
-  API_EXTRACTOR_ARTIFACT_NAME: ngx-meta-api-extractor
+  # 👇 Keep in sync with build workflow
+  TSC_ARTIFACT_NAME_SUFFIX: -tsc
+  API_EXTRACTOR_ARTIFACT_NAME_SUFFIX: -api-extractor
+  # 👇 Keep in sync with docs workflow
+  API_DOCS_ARTIFACT_NAME_SUFFIX: -api-docs
 
 jobs:
   api-extractor:
@@ -25,7 +20,7 @@ jobs:
       - name: Download tsc output files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.tsc-artifact-name }}
+          name: ngx-meta${{ env.TSC_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/out
       - name: Setup
         uses: ./.github/actions/setup
@@ -34,7 +29,7 @@ jobs:
       - name: Upload API Extractor JSON docs
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ env.API_EXTRACTOR_ARTIFACT_NAME }}
+          name: ngx-meta${{ env.API_EXTRACTOR_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/api-extractor/*.api.json
           retention-days: 5
 
@@ -49,7 +44,7 @@ jobs:
       - name: Download API Extractor JSON docs
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ env.API_EXTRACTOR_ARTIFACT_NAME }}
+          name: ngx-meta${{ env.API_EXTRACTOR_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/api-extractor
       - name: Setup
         uses: ./.github/actions/setup
@@ -58,6 +53,6 @@ jobs:
       - name: Upload API Documenter generated markdown docs
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ inputs.api-docs-artifact-name }}
+          name: ngx-meta${{ env.API_DOCS_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/docs/content/api
           retention-days: 5

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -18,7 +18,7 @@ on:
       tsc-artifact-name:
         description: Name for artifact containing lib tsc output files
         type: string
-        required: false
+        required: true
 
 jobs:
   build:
@@ -68,7 +68,6 @@ jobs:
       - name: Run tsc
         run: cd .ci && make tsc
       - name: Upload compiled JS files
-        if: ${{ inputs.tsc-artifact-name != '' }}
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
           name: ${{ inputs.tsc-artifact-name }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -2,11 +2,6 @@ name: Build
 on:
   workflow_call:
     inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
       dist-artifact-name:
         description: Name for artifact containing lib dist files
         type: string
@@ -28,8 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Cache Angular build
@@ -61,8 +54,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run tsc

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,19 +1,14 @@
 name: Build
 on:
   workflow_call:
-    inputs:
-      dist-artifact-name:
-        description: Name for artifact containing lib dist files
-        type: string
-        required: true
-      dist-artifact-name-coverage-suffix:
-        description: Name suffix for artifact containing lib dist files instrumented for code coverage tracking
-        type: string
-        required: true
-      tsc-artifact-name:
-        description: Name for artifact containing lib tsc output files
-        type: string
-        required: true
+
+env:
+  # 👇 Keep in sync with release and example apps workflow
+  DIST_ARTIFACT_NAME_SUFFIX: -dist
+  # 👇 Keep in sync with example apps workflow
+  COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
+  # 👇 Keep in sync with API Extractor workflow
+  TSC_ARTIFACT_NAME_SUFFIX: -tsc
 
 jobs:
   build:
@@ -35,7 +30,7 @@ jobs:
       - name: Upload distribution files
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ inputs.dist-artifact-name }}
+          name: ngx-meta${{ env.DIST_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/dist
           retention-days: 5
       - name: Instrument for coverage
@@ -43,7 +38,7 @@ jobs:
       - name: Upload distribution files with coverage instrumentation
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ inputs.dist-artifact-name }}${{ inputs.dist-artifact-name-coverage-suffix }}
+          name: ngx-meta${{ env.DIST_ARTIFACT_NAME_SUFFIX }}${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/dist
           retention-days: 5
 
@@ -61,6 +56,6 @@ jobs:
       - name: Upload compiled JS files
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ inputs.tsc-artifact-name }}
+          name: ngx-meta${{ env.TSC_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/out
           retention-days: 5

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -1,25 +1,20 @@
 name: Bundle size
 on:
   workflow_call:
-    inputs:
-      example-app-artifact-name-prefix:
-        description: Artifact name prefix containing built example apps
-        required: true
-        type: string
-      bundle-size-artifact-name-prefix:
-        description: Artifact name prefix where bundle size info is stored
-        required: true
-        type: string
 
 #permissions:
 #  👇 Needed for main bundle size check store only
 #  checks: write
 
 env:
-  # 👇 Keep in sync with on bundle size completed workflow
+  # 👇 Keep in sync with pull request completed workflow
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-
   BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX: ngx-meta-bundle-size-
   BUNDLE_SIZE_DIR: projects/ngx-meta/bundle-size
+  # 👇 Keep in sync with example apps workflow
+  EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
+  # 👇 Keep in sync with pull request completed and docs workflow
+  BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX: -bundle-size
 
 jobs:
   analysis:
@@ -41,7 +36,7 @@ jobs:
       - name: Download example app distribution files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app-name }}
+          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}
           path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
@@ -92,7 +87,7 @@ jobs:
       - name: Upload bundle size analysis results
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
-          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.app-name }}
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}
           path: ${{ env.BUNDLE_SIZE_DIR }}/${{ env.OUTPUT_DIR }}
           retention-days: 5
 
@@ -109,7 +104,7 @@ jobs:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.bundle-size-artifact-name-prefix }}${{ matrix.app-name }}
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}
       - name: Create check run
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -10,11 +10,6 @@ on:
         description: Artifact name prefix where bundle size info is stored
         required: true
         type: string
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
 
 #permissions:
 #  👇 Needed for main bundle size check store only
@@ -43,8 +38,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Download example app distribution files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,15 +1,6 @@
 name: Docs
 on:
   workflow_call:
-    inputs:
-      api-docs-artifact-name:
-        description: Artifact name containing API reference markdown docs
-        type: string
-        required: true
-      bundle-size-artifact-name-prefix:
-        description: Artifact name prefix containing bundle size info
-        type: string
-        required: true
     secrets:
       cloudflare-account-id:
         required: true
@@ -18,6 +9,10 @@ on:
 
 env:
   DOCS_DIR: projects/ngx-meta/docs
+  # 👇 Keep in sync with API Extractor workflow
+  API_DOCS_ARTIFACT_NAME_SUFFIX: -api-docs
+  # 👇 Keep in sync with pull request completed workflow
+  BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX: -bundle-size
 
 permissions:
   deployments: write
@@ -42,18 +37,18 @@ jobs:
       - name: Download API reference docs
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.api-docs-artifact-name }}
+          name: ngx-meta${{ env.API_DOCS_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/docs/content/api
       - name: Download bundle size info
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          pattern: ${{ inputs.bundle-size-artifact-name-prefix }}*
+          pattern: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME-SUFFIX }}*
       - name: Copy reports into directories
         working-directory: .
         run: |
           # shellcheck disable=SC2001
-          for artifact_dir in "${{ inputs.bundle-size-artifact-name-prefix }}"*; do
-            app_name="$(echo "$artifact_dir" | sed "s/^${{ inputs.bundle-size-artifact-name-prefix }}//")"
+          for artifact_dir in "ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_PREFIX }}"*; do
+            app_name="$(echo "$artifact_dir" | sed "s/^ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-//")"
             bundle_size_app_dir="projects/ngx-meta/bundle-size/out/$app_name"
             mkdir -p "$bundle_size_app_dir"
             cp "$artifact_dir/bundle-size-report.md" "$bundle_size_app_dir"

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -10,11 +10,11 @@ on:
       api-docs-artifact-name:
         description: Artifact name containing API reference markdown docs
         type: string
-        required: false
+        required: true
       bundle-size-artifact-name-prefix:
         description: Artifact name prefix containing bundle size info
         type: string
-        required: false
+        required: true
     secrets:
       cloudflare-account-id:
         required: true
@@ -47,18 +47,15 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Download API reference docs
-        if: ${{ inputs.api-docs-artifact-name != '' }}
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: ${{ inputs.api-docs-artifact-name }}
           path: projects/ngx-meta/docs/content/api
       - name: Download bundle size info
-        if: ${{ inputs.bundle-size-artifact-name-prefix != '' }}
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           pattern: ${{ inputs.bundle-size-artifact-name-prefix }}*
       - name: Copy reports into directories
-        if: ${{ inputs.bundle-size-artifact-name-prefix != '' }}
         working-directory: .
         run: |
           # shellcheck disable=SC2001

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -2,11 +2,6 @@ name: Docs
 on:
   workflow_call:
     inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
       api-docs-artifact-name:
         description: Artifact name containing API reference markdown docs
         type: string
@@ -44,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Download API reference docs
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -10,11 +10,6 @@ on:
         description: Artifact name suffix used to indicate example app is instrumented to track for coverage
         required: true
         type: string
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
     secrets:
       codecov-token:
         description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
@@ -40,8 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Download example app with coverage instrumentation
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -1,15 +1,6 @@
 name: E2E
 on:
   workflow_call:
-    inputs:
-      example-app-artifact-name-prefix:
-        description: Artifact name prefix containing built example apps
-        required: true
-        type: string
-      example-app-artifact-name-coverage-suffix:
-        description: Artifact name suffix used to indicate example app is instrumented to track for coverage
-        required: true
-        type: string
     secrets:
       codecov-token:
         description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
@@ -18,6 +9,10 @@ on:
 env:
   E2E_DIR: projects/ngx-meta/e2e
   COVERAGE_DIR: coverage/ngx-meta
+  # 👇 Keep in sync with example apps workflow
+  COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
+  # 👇 Keep in sync with example apps workflow
+  EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
 
 jobs:
   e2e:
@@ -38,7 +33,7 @@ jobs:
       - name: Download example app with coverage instrumentation
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app-name }}${{ inputs.example-app-artifact-name-coverage-suffix }}
+          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}
           path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -14,11 +14,6 @@ on:
       example-app-artifact-name-coverage-suffix:
         required: true
         type: string
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
 
 env:
   EXAMPLE_APPS_DIR: projects/ngx-meta/example-apps
@@ -40,8 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Generate artifact names
         run: |
           dist_artifact_name="${{ inputs.dist-artifact-name }}"

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -1,22 +1,15 @@
 name: Example apps
 on:
   workflow_call:
-    inputs:
-      dist-artifact-name:
-        required: true
-        type: string
-      dist-artifact-name-coverage-suffix:
-        required: true
-        type: string
-      example-app-artifact-name-prefix:
-        required: true
-        type: string
-      example-app-artifact-name-coverage-suffix:
-        required: true
-        type: string
 
 env:
   EXAMPLE_APPS_DIR: projects/ngx-meta/example-apps
+  # 👇 Keep in sync with build workflow
+  DIST_ARTIFACT_NAME_SUFFIX: -dist
+  # 👇 Keep in sync with build and E2E tests workflow
+  COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
+  # 👇 Keep in sync with bundle size and E2E tests workflow
+  EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
 
 jobs:
   example-app:
@@ -37,19 +30,17 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Generate artifact names
         run: |
-          dist_artifact_name="${{ inputs.dist-artifact-name }}"
+          dist_artifact_name="ngx-meta${{ env.DIST_ARTIFACT_NAME_SUFFIX }}"
           if [ "${{ matrix.coverage }}" = "enabled" ]; then
-            dist_artifact_name="$dist_artifact_name${{ inputs.dist-artifact-name-coverage-suffix }}"
+            dist_artifact_name="$dist_artifact_name${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}"
           fi
-          echo "$dist_artifact_name"
-          echo "dist_artifact_name=$dist_artifact_name" >> "$GITHUB_ENV"
+          echo "dist_artifact_name=$dist_artifact_name" | tee -a "$GITHUB_ENV"
 
-          example_app_artifact_name="${{ inputs.example-app-artifact-name-prefix }}${{ matrix.app-name }}"
+          example_app_artifact_name="ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.app-name }}"
           if [ "${{ matrix.coverage }}" = "enabled" ]; then
-            example_app_artifact_name="$example_app_artifact_name${{ inputs.example-app-artifact-name-coverage-suffix }}"
+            example_app_artifact_name="$example_app_artifact_name${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}"
           fi
-          echo "$example_app_artifact_name"
-          echo "example_app_artifact_name=$example_app_artifact_name" >> "$GITHUB_ENV"
+          echo "example_app_artifact_name=$example_app_artifact_name" | tee -a "$GITHUB_ENV"
       - name: Download distribution files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -1,12 +1,6 @@
 name: Lint
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
 
 jobs:
   code:
@@ -16,8 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run linter
@@ -30,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Run GitHub Actions linter
         uses: docker://rhysd/actionlint:latest@sha256:435ecdb63b1169e80ca3e136290072548c07fc4d76a044cf5541021712f8f344
         with:
@@ -46,7 +36,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint last commit

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,10 +1,6 @@
 name: Release
 on:
   workflow_call:
-    inputs:
-      dist-artifact-name:
-        required: true
-        type: string
     secrets:
       npm-token:
         required: true
@@ -31,6 +27,10 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # 👇 Keep in sync with build workflow
+  DIST_ARTIFACT_NAME_SUFFIX: -dist
+
 jobs:
   semantic-release:
     name: Semantic Release
@@ -48,7 +48,7 @@ jobs:
       - name: Download distribution files
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: ${{ inputs.dist-artifact-name }}
+          name: ngx-meta${{ env.DIST_ARTIFACT_NAME_SUFFIX }}
           path: projects/ngx-meta/dist
       - name: Release
         env:

--- a/.github/workflows/reusable-style.yml
+++ b/.github/workflows/reusable-style.yml
@@ -1,12 +1,6 @@
 name: Style
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
 
 jobs:
   build:
@@ -16,8 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Format check

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,12 +1,6 @@
 name: Test
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: Git reference to checkout. Defaults to @actions/checkout default.
-        type: string
-        required: false
-        default: ''
     secrets:
       codecov-token:
         description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
@@ -23,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          ref: ${{ inputs.ref }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run unit tests


### PR DESCRIPTION
# Issue or need

CI/CD GitHub Actions workflows are a bit verbose. Some improvement opportunities:
 - `inputs.ref` is defined in every workflow to allow to use it at any `git` ref. However, has never been used.
 - Artifact name constants are defined in many places: inputs of workflows uploading artifacts, inputs of workflows downloading artifacts and in `main` / `pull_request` workflows passing those inputs. This was done to ensure values match. However, that can be done in other ways. It's not expected for those constants to be different depending on the workflow calling the reusable workflows anyway

# Proposed changes

Tackle improvements:
 - Remove `ref` input from reusable workflows
 - Move artifact name constants to `env` in each reusable workflow that needs them
 - Remove useless `if` clauses given artifact names are now always defined
 - Artifact name constants to always be suffixes to allow for more projects in the future (decouple from `ngx-meta` in those names)

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
