### PR TITLE
ci: merge API Extractor / Documenter into 1 job

### DIFF
--- a/.github/workflows/reusable-api-extractor.yml
+++ b/.github/workflows/reusable-api-extractor.yml
@@ -5,13 +5,12 @@ on:
 env:
   # 👇 Keep in sync with build workflow
   TSC_ARTIFACT_NAME_SUFFIX: -tsc
-  API_EXTRACTOR_ARTIFACT_NAME_SUFFIX: -api-extractor
   # 👇 Keep in sync with docs workflow
   API_DOCS_ARTIFACT_NAME_SUFFIX: -api-docs
 
 jobs:
   api-extractor:
-    name: API Extractor (report and JSON docs)
+    name: API Extractor
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -26,31 +25,9 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run API Extractor in production mode
         run: cd .ci && make api-extractor
-      - name: Upload API Extractor JSON docs
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
-        with:
-          name: ngx-meta${{ env.API_EXTRACTOR_ARTIFACT_NAME_SUFFIX }}
-          path: projects/ngx-meta/api-extractor/*.api.json
-          retention-days: 5
-
-  api-documenter:
-    needs: api-extractor
-    name: API Documenter (markdown API Ref docs)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Download API Extractor JSON docs
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
-        with:
-          name: ngx-meta${{ env.API_EXTRACTOR_ARTIFACT_NAME_SUFFIX }}
-          path: projects/ngx-meta/api-extractor
-      - name: Setup
-        uses: ./.github/actions/setup
       - name: Run API Documenter
         run: cd .ci && make api-documenter
-      - name: Upload API Documenter generated markdown docs
+      - name: Upload API Documenter generated Markdown docs
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
           name: ngx-meta${{ env.API_DOCS_ARTIFACT_NAME_SUFFIX }}


### PR DESCRIPTION
# Issue or need

API Extractor and API Documenter do very related things. Indeed the latter is an extension to the former. And the latter requires the former. Currently they're separated jobs in CI/CD, but joining them would save time & compute resources

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Join both jobs

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
