### PR TITLE
ci: fix docs workflow after refactor

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Download bundle size info
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          pattern: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME-SUFFIX }}*
+          pattern: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}*
       - name: Copy reports into directories
         working-directory: .
         run: |


### PR DESCRIPTION
# Issue or need

After #709 `docs` workflow failed on `main` due to not being able to find bundle size info


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Seems the error is a typo when defining the bundle size artifact name pattern to download those

Fixes the error & trigger a docs preview to ensure all it's ok

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
