### PR TITLE
build: ignore __tests__ dirs in coverage reports

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,8 @@
           "options": {
             "tsConfig": "projects/ngx-meta/src/tsconfig.spec.json",
             "polyfills": ["zone.js", "zone.js/testing"],
-            "karmaConfig": "projects/ngx-meta/src/karma.conf.js"
+            "karmaConfig": "projects/ngx-meta/src/karma.conf.js",
+            "codeCoverageExclude": ["**/__tests__/**"]
           }
         },
         "lint": {

--- a/projects/ngx-meta/e2e/.nycrc.json
+++ b/projects/ngx-meta/e2e/.nycrc.json
@@ -1,4 +1,5 @@
 {
   "reporter": ["lcov", "json"],
-  "report-dir": "../../../coverage/ngx-meta"
+  "report-dir": "../../../coverage/ngx-meta",
+  "exclude": ["**/__tests__/**"]
 }


### PR DESCRIPTION
# Issue or need

Current coverage reports take into account coverage of files inside `__tests__` directories

Those shouldn't be taken into account, as they're used for test purposes only, it's not actual source code that will run in production

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Exclude `__tests__` directories from coverage reports:
 - In unit tests, via Angular CLI config (`angular.json`)
 - In Cypress E2E tests, via `nyc` report configuration (`.nyrcrc.json`)

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
