### PR TITLE
build: add run script for unit tests with coverage

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -19,8 +19,8 @@ lint-gh-actions:
 	ationlint
 
 unit-test:
-	pnpm run test:unit --browsers=ChromeHeadless --no-watch --no-progress \
-		--reporters progress --code-coverage
+	pnpm run test:unit:coverage --browsers=ChromeHeadless --no-watch --no-progress \
+		--reporters progress
 
 format-check:
 	cd .. && pnpm run format-check-all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,10 +186,10 @@ pnpm run test:unit
 
 ##### With coverage
 
-To enable coverage reporting, add `--code-coverage` CLI option:
+To enable coverage reporting, run the following run script
 
 ```sh
-pnpm run test:unit --code-coverage
+pnpm run test:unit:coverage
 ```
 
 Reports will be generated in JSON, `lcov` and HTML format. JSON report file name is `unit-test.json`. See [coverage section](#coverage) for more details.
@@ -220,6 +220,8 @@ Then, you can use the `coverage:report:all` run script in `package.json` to merg
 ```sh
 pnpm run ngx-meta:coverage:report:all
 ```
+
+The global coverage report will be in `lcov`(`.info`) and HTML format.
 
 ### Format
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "ng build && ./postbuild.sh",
     "watch": "ng build --watch --configuration development",
     "test:unit": "ng test",
+    "test:unit:coverage": "pnpm run test:unit --code-coverage",
     "lint": "pnpm run '/lint:.*/'",
     "lint:code": "ng lint",
     "lint:commit-message": "pnpm run commitlint-edit-msg",


### PR DESCRIPTION
# Issue or need

Running tests with code coverage requires typing a manual command with `--code-coverage` arg

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Introduce run script in order to make it a bit easier

Use that run script in CI/CD to provide that same CLI flag

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
