### PR TITLE
build: tell ng-lint-staged to just lint code [skip ci]

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm run lint-staged
+lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*": ["pnpm run format"],
-  "projects/ngx-meta/src/**/*.ts": ["pnpm run ng-lint-staged"],
+  "projects/ngx-meta/src/**/*.ts": ["ng-lint-staged lint:code --fix --"],
   ".github/**/*.{yml,yaml}": ["pnpm run lint:gh-actions"]
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "format": "prettier --ignore-unknown --write",
     "format-all": "npm run format -- .",
     "prepare": "husky",
-    "lint-staged": "lint-staged",
     "commitlint-edit-msg": "commitlint --verbose --edit",
     "commitlint-last": "commitlint --verbose --from HEAD~1",
     "ng-lint-staged": "ng-lint-staged lint --max-warnings 0 --fix --",


### PR DESCRIPTION
# Issue or need

When about to commit some changes to `*.ts` files, turns out the `git` `pre-commit` hook failed. Seems `lint-staged` errored after running the task for `*.ts` files via `ng-lint-staged`. Seems that what happens is that `ng-lint-staged` was running `lint` script, which now lints everything (code, commit message & GH Actions). And if a Typescript file was changed, it was added as argument to the commit message linter, which didn't know what that was and failed

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Tell `ng-lint-staged` to use `lint:code` as the run script to use for `*.ts` files linting

Also: 
 - Remove unneeded run script `lint-staged` in `package.json`. Can be ran directly with `pnpm lint-staged`
 - Remove `pnpm` prefix in `pre-commit` to run `lint-staged`. If properly configured, that should be there already

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
