### PR TITLE
test: add unit test for `clear` method

### DIFF
--- a/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
@@ -10,22 +10,19 @@ describe('NgxMeta service', () => {
   enableAutoSpy()
   let sut: NgxMetaService
   let metadataRegistry: jasmine.SpyObj<MetadataRegistry>
+  const firstMetadata = makeMetadataManagerSpy({ id: 'first' })
+  const secondMetadata = makeMetadataManagerSpy({ id: 'second' })
 
   beforeEach(() => {
     sut = makeSut()
     metadataRegistry = TestBed.inject(
       MetadataRegistry,
     ) as jasmine.SpyObj<MetadataRegistry>
+    metadataRegistry.getAll.and.returnValue([firstMetadata, secondMetadata])
   })
 
   describe('set', () => {
-    const firstMetadata = makeMetadataManagerSpy({ id: 'first' })
-    const secondMetadata = makeMetadataManagerSpy({ id: 'second' })
     const dummyValues = {}
-
-    beforeEach(() => {
-      metadataRegistry.getAll.and.returnValue([firstMetadata, secondMetadata])
-    })
 
     it('should set each metadata using resolved values', () => {
       const resolver = TestBed.inject(
@@ -57,6 +54,15 @@ describe('NgxMeta service', () => {
         secondMetadata.resolverOptions,
       )
       expect(secondMetadata.set).toHaveBeenCalledWith(dummySecondMetadataValue)
+    })
+  })
+
+  describe('clear', () => {
+    it('should set each metadata to undefined so they get removed from page', () => {
+      sut.clear()
+
+      expect(firstMetadata.set).toHaveBeenCalledWith(undefined)
+      expect(secondMetadata.set).toHaveBeenCalledWith(undefined)
     })
   })
 })


### PR DESCRIPTION
# Issue or need

`NgxMetaService.clear` doesn't have tests

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a unit one

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
