### PR TITLE
ci: upload a merged coverage report to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
-    secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml
@@ -34,6 +32,10 @@ jobs:
     needs: example-apps
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
+  coverage:
+    needs: [e2e, test]
+    name: Coverage
+    uses: ./.github/workflows/reusable-coverage.yml
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/reusable-test.yml
-    secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
   lint:
     name: Lint
     uses: ./.github/workflows/reusable-lint.yml
@@ -31,6 +29,10 @@ jobs:
     needs: example-apps
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
+  coverage:
+    needs: [e2e, test]
+    name: Coverage
+    uses: ./.github/workflows/reusable-coverage.yml
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -1,0 +1,37 @@
+name: Coverage
+on:
+  workflow_call:
+    secrets:
+      codecov-token:
+        description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
+        required: true
+
+env:
+  COVERAGE_DIR: coverage/ngx-meta
+  # 👇 Keep in sync with e2e and coverage workflows
+  COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX: -coverage-report
+
+jobs:
+  upload-to-codecov:
+    name: Upload to Codecov
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Download coverage reports
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          pattern: '*${{ env.COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX }}'
+          path: ${{ env.COVERAGE_DIR }}
+          merge-multiple: true
+      - name: Merge coverage reports
+        run: pnpm run ngx-meta:coverage:report:all
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          disable_search: true
+          file: ${{ env.COVERAGE_DIR }}/lcov.info
+          token: ${{ secrets.codecov-token }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -1,10 +1,6 @@
 name: E2E
 on:
   workflow_call:
-    secrets:
-      codecov-token:
-        description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
-        required: false
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
@@ -13,6 +9,8 @@ env:
   COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
   # 👇 Keep in sync with example apps workflow
   EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
+  # 👇 Keep in sync with e2e and coverage workflows
+  COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX: -coverage-report
 
 jobs:
   load-config:
@@ -81,12 +79,13 @@ jobs:
           # https://github.com/cypress-io/github-action/tree/v6.6.1?tab=readme-ov-file#pnpm
           # Given we're doing caching manually, installing apart to leverage cache
           install: false
-      - name: Fix code coverage paths
-        run: pnpm run coverage:relative-path-fix
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+      - name: Rename coverage report with app name suffix
+        run: mv ${{ env.COVERAGE_DIR }}/*.json ${{ env.COVERAGE_DIR }}/e2e-${{ matrix.app-name }}.json
+        working-directory: .
+      - name: Upload coverage report
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         if: failure() || success()
         with:
-          disable_search: true
-          file: ${{ env.COVERAGE_DIR }}/lcov.info
-          token: ${{ secrets.codecov-token }}
+          name: ngx-meta-e2e-${{ matrix.app-name }}${{ env.COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX }}
+          path: ${{ env.COVERAGE_DIR }}/*.json
+          retention-days: 5

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,13 +1,11 @@
 name: Test
 on:
   workflow_call:
-    secrets:
-      codecov-token:
-        description: Token to use to upload coverage to Codecov. Can be empty for forks https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/
-        required: true
 
 env:
   COVERAGE_DIR: coverage/ngx-meta
+  # 👇 Keep in sync with e2e and coverage workflows
+  COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX: -coverage-report
 
 jobs:
   unit-test:
@@ -21,9 +19,10 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run unit tests
         run: cd .ci && make unit-test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+      - name: Upload coverage report
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
+        if: failure() || success()
         with:
-          disable_search: true
-          file: ${{ env.COVERAGE_DIR }}/lcov.info
-          token: ${{ secrets.codecov-token }}
+          name: ngx-meta-unit-test${{ env.COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX }}
+          path: ${{ env.COVERAGE_DIR }}/*.json
+          retention-days: 5

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,3 @@ codecov:
   require_ci_to_pass: false
   notify:
     wait_for_ci: false
-    # 👇 Must be in sync with number of uploads needed.
-    #    Which now depends on amount of E2E tests run
-    #    Plus the unit tests coverage
-    after_n_builds: 5

--- a/projects/ngx-meta/e2e/package.json
+++ b/projects/ngx-meta/e2e/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "postcypress:run": "mv -f ../../../coverage/ngx-meta/coverage-final.json ../../../coverage/ngx-meta/e2e.json",
-    "//1": "👇 Coverage reporting tools like Codecov usually require paths relative to repo root",
-    "coverage:relative-path-fix": "sed -i.bak 's|SF:..|SF:projects/ngx-meta|' ../../../coverage/ngx-meta/lcov.info"
+    "postcypress:run": "mv -f ../../../coverage/ngx-meta/coverage-final.json ../../../coverage/ngx-meta/e2e.json"
   },
   "packageManager": "pnpm@9.6.0",
   "private": true,


### PR DESCRIPTION
# Issue or need

Currently if you check Codecov status on `main` and just the unit test coverage report has been uploaded, the status will be reported as if other coverage reports aren't to come. This also means the coverage status badge may report a lower coverage than the actual one if that scenario is in place.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Merge all coverage reports as part of CI/CD. Then just upload one to Codecov. This way coverage updates will be atomic

Also adds that new job as a required status check to pass in order to merge to `main` branch in GitHub configuration of this repository

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
