### PR TITLE
feat: add dev error 4 non http(s) Open Graph image URLs

### DIFF
--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
@@ -29,38 +29,69 @@ describe('Open Graph image metadata', () => {
 
   describe('setter', () => {
     describe('when url is provided', () => {
-      it('should set all meta properties', () => {
-        sut(image)
+      describe('when the url does not start with http or https', () => {
+        it('should log an error to the console', () => {
+          spyOn(console, 'error')
 
-        const props = Object.keys(image).length
-        expect(metaService.set).toHaveBeenCalledTimes(props)
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.url,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.alt,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.secureUrl,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.type,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.width.toString(),
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.height.toString(),
-        )
+          const invalidImageUrl = 'ftp://ftp.example.com/images/og.jpg'
+          sut({ ...image, url: invalidImageUrl })
+
+          expect(console.error).toHaveBeenCalledWith(
+            jasmine.stringMatching(/http or https/),
+            invalidImageUrl,
+          )
+        })
+      })
+
+      describe('when the url is valid', () => {
+        it('should not error', () => {
+          spyOn(console, 'error')
+
+          sut(image)
+
+          expect(console.error).not.toHaveBeenCalled()
+        })
+        it('should set all meta properties', () => {
+          sut(image)
+
+          const props = Object.keys(image).length
+          expect(metaService.set).toHaveBeenCalledTimes(props)
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.url,
+          )
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.alt,
+          )
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.secureUrl,
+          )
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.type,
+          )
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.width.toString(),
+          )
+          expect(metaService.set).toHaveBeenCalledWith(
+            jasmine.anything(),
+            image.height.toString(),
+          )
+        })
       })
     })
     describe('when no url is defined', () => {
+      it('should not log any error', () => {
+        spyOn(console, 'error')
+
+        sut({ ...image, url: undefined })
+
+        expect(console.error).not.toHaveBeenCalled()
+      })
+
       it('should remove all meta properties', () => {
         sut({ ...image, url: undefined })
 

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -21,6 +21,18 @@ export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
     const imageUrl = value?.url?.toString()
     const effectiveValue: OpenGraph[typeof _GLOBAL_IMAGE] =
       imageUrl !== undefined && imageUrl !== null ? value : NO_KEY_VALUE
+    //👇 What the f*ck? You may wonder (and with good cause https://youtu.be/U58IdBjMeS4?si=MT89dCrptOIS98Q9&t=27)
+    //   Checkout https://github.com/davidlj95/ngx/pull/731 for an interesting rabbit hole about coverage reporting
+    //   with `istanbul.js``, source maps & more fun
+    // noinspection HttpUrlsUsage
+    ngDevMode &&
+      imageUrl &&
+      !(imageUrl?.startsWith('http://') || imageUrl?.startsWith('https://')) &&
+      // prettier-ignore
+      console.error(
+        "ngx-meta/open-graph: an image URL must use either http or https.\n" +
+        "-> Invalid image URL: %s\n" +
+        "For more info, checkout https://stackoverflow.com/a/9858694/3263250", imageUrl)
     metaService.set(makeOpenGraphMetaDefinition(_GLOBAL_IMAGE), imageUrl)
     metaService.set(
       makeOpenGraphMetaDefinition(_GLOBAL_IMAGE, 'alt'),


### PR DESCRIPTION
# Issue or need

Using a non `http://` or `https://` image URL for Open Graph images will result in unexpected behaviour

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add an error when running in development mode to warn the developer about it

## 🐇 A coverage rabbit hole
### Preamble / context
To get started going down the rabbit hole, you need to know that [Istanbul / `istanbul.js`](https://istanbul.js.org/) is a very popular tooling for measuring tests code coverage in JavaScript. 

In unit tests code coverage, Angular CLI and Karma (default test runner recommended by Angular CLI) use it for measuring code coverage

Angular CLI [instruments code for you to measure coverage when building for unit tests via `istanbul-lib-instrument`](https://github.com/angular/angular-cli/blob/18.1.3/packages/angular_devkit/build_angular/src/tools/babel/plugins/add-code-coverage.ts#L25-L28).

> Implementation [was changed recently though](https://github.com/angular/angular-cli/pull/27857). Before the `babel-plugin-istanbul` was added to the babel transformations part of the build. Now, the `istanbul-lib-instrument` is called directly to remove this extra dependency chain ([`babel-plugin-istanbul`] uses `istanbul-lib-instrument` under the hood).

[`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul

Then, it is used in the default test runner Karma for reporting coverage via [`karma-coverage` plugin](https://www.npmjs.com/package/karma-coverage)

For E2E tests code coverage, [Cypress instructs you to use Istanbul to first instrument the application code to measure coverage](https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code). Either via [`babel-plugin-istanbul`] or [`nyc`] which is the CLI to run Istanbul. Then, [Cypress code coverage plugin](https://github.com/cypress-io/code-coverage) grabs the `__coverage__` object created in the running app's [`window` object](https://developer.mozilla.org/en-US/docs/Web/API/Window) and [reports results using `nyc`](https://github.com/cypress-io/code-coverage/blob/v3.12.44/task.js#L223)

[`nyc`]: https://github.com/istanbuljs/nyc

Finally to provide a holistic view of code coverage from both unit tests and E2E tests, both reports are merged via [`nyc`]. Specifically `nyc report`. Though `nyc merge` also works. The only benefit is that `nyc report` does the merge + outputs a merged report in whatever format you want, not just JSON. `nyc merge` output is a JSON report.

### Looking for the issue
When adding the `if` clause to report the message just for development purposes, code coverage was not accurate. However, when running unit tests code coverage was in fact correct. And also for the E2E code coverage report. So seems the issue is when merging both.

Hence started to see how JSON reports are merged. Recalled that Cypress code coverage plugin supported merging coverage reports, so went there to see how it did so. Seems it [calls `merge` on a coverage map object that `istanbul-lib-coverage` creates](https://github.com/cypress-io/code-coverage/blob/v3.12.44/task.js#L162-L164). 

However, we are doing the report merging by calling `nyc report` with a bunch of JSON reports in the `.nyc_output` temporary dir. How does that merges reports? Turns out the [`report` method](https://github.com/istanbuljs/nyc/blob/main/index.js#L428) first [calls `getCoverageMapFromAllFiles` method](https://github.com/istanbuljs/nyc/blob/v15.1.0/index.js#L458) to do so. Which then [calls the same coverage map `merge` method](https://github.com/istanbuljs/nyc/blob/v15.1.0/index.js#L433) after creating a coverage map object from every file. Same as Cypress is doing then. 

> [!NOTE]
> Actually we're calling `nyc report` to merge several reports and emit a merged report in different formats. However you can also call `nyc merge` to just merge coverage reports. Turns out that command also [calls the same `getCoverageMapFromAllFiles` method](https://github.com/istanbuljs/nyc/blob/v15.1.0/lib/commands/merge.js#L43). So seems we've found the main bit.

> [!NOTE]
> This `getCoverageMapFromAllFiles` method has an interesting part that we skip here, but will come back later 

Let's see what that magic `merge` does then. So seems that first [each file coverage (keys of the report object) is merged](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-coverage/lib/coverage-map.js#L52). To do so looks like [`merge` method of a `FileCoverage` object is called](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-coverage/lib/coverage-map.js#L112). Then we see an interesting bit in the `merge` method comment:

> _Note that the other object should have the same structure as this one (same file)_
> https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-coverage/lib/file-coverage.js#L290-L294

Hence #732 was implemented in order to avoid dead code elimination which could make the coverage report file structure different given the code ran is not the same (unit tests do not do dead code elimination while app production builds do). After doing some tests, weird things happened, so Cypress DX was improved to ensure consistent results when running tests with coverage (#733 )

Finally, seems the [`mergeProp` method is doing the hard work](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-coverage/lib/file-coverage.js#L133). For the branches map, the one that differs from unit tests vs E2E test seems that `mergeProp` is called with both maps & hits and with `const keyFromLocationsProp = x => keyFromLoc(x.locations[0]);` as the `itemKey` finder method. Here my mind exploded a bit tbh 🤯 However essentially seems that it is merging JSON report objects smartly so let's take a look and see how those JSON reports look.

Aaaaand found a smell! `branchMap` section of the JSON coverage report wasn't the same for unit tests and E2E tests for the same file. In unit tests JSON coverage report, the start and end line & columns were defined. In E2E tests JSON coverage report however, the end column was `null`. 

Here's an example excerpt of the JSON coverage report:
```json
{
  "/Users/davidlj95/Code/git/davidlj95/ngx/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts": {
    "path": "/Users/davidlj95/Code/git/davidlj95/ngx/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts",
    "branchMap": {
      "3": {
        "loc": {
          "start": {
            "line": 23,
            "column": 6
          },
          "end": {
            "line": 23,
            "column": 72
          }
        }
      }
    }
  }
}
```
Issue was that in unit tests it was like the example. However same branch in E2E tests code coverage JSON report. `branchMap.3.loc.end.column` was `null`. This seems the faulty one as the closing bracket of the `if` (whose position is determined by line + column) definitely exists 😛 

> Actually the merging function uses `locations` instead of `loc`. But `loc` is calculated from the earliest `location` until the latest `location`. And the latest `location` has the column as `null`. So the issue is there anyway

So the merge method then added an extra, non-covered branch (E2E tests don't print messages as apps are built in prod mode). Despite that branch was the same that was actually covered in unit tests.

So started to see where this is generated. First, ensured that Istanbul dependencies were the same ones for unit tests and for E2E tests with `pnpm why 'istanbul*'` inside root and `e2e` dir. They're almost the same ones. 

> Did that cause after researching a bit seems some issues could be due to that reason (makes sense: different versions generate different coverage files structures hence the merge method doesn't work properly). 

So went ahead and traced where those lines are generated. They're not in the JSON reporter, given the [JSON reporter just writes in JSON format the actual raw coverage data](https://github.com/istanbuljs/istanbuljs/blob/istanbul-reports-v3.1.7/packages/istanbul-reports/lib/json/index.js#L8). 

So opened and instrumented example app for E2E tests and ran `__coverage__` on the Chrome DevTools console. Maybe in there the coverage report structure was already wrong. In there I found that keys in the object were the `dist/fesm2022/*.mjs` files. Which makes sense as those `* are the ones being instrumented. So the `branchMap`s were totally different from the final report. This means at some point those are mapped to the original files. Maybe the issue was in that remap?

After investigating Cypress code coverage plugin, found out it's not the one doing that remap . Which makes sense as it's something more related to Istanbul / JS coverage specific tooling and we've seen that Cypress calls `report` with whatever it grabs from the `__coverage__` object in the `window`. 

Here is where I looked again at the `report` method. But now looking at where the files are mapped using source maps. Given the E2E code coverage report output has the `*.ts` source files in it. But in the browser `*.mjs` files are in the `__coverage__` report object. So it must happen in there. Aaaaand back to the previous `getCoverageMapFromAllFiles` method again. 

In there, noticed that the remap coverage happens after merging all coverage reports:

```typescript
map.data = await this.sourceMaps.remapCoverage(map.data)
```
https://github.com/istanbuljs/nyc/blob/v15.1.0/index.js#L438

Source maps are handled by `istanbul-lib-source-maps`. After following a bit more the rabbit hole, seems the function that looks for the end position of a block of code is the [`originalEndPositionFor`](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-source-maps/lib/get-mapping.js#L31). Which in turn calls [`originalPositionTryBoth` method](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-coverage-v3.2.2/packages/istanbul-lib-source-maps/lib/get-mapping.js#L83). 

That eventually [uses the `originalPositionFor` API method](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-source-maps-v4.0.1/packages/istanbul-lib-source-maps/lib/get-mapping.js#L83-L98) provided by [`source-map` package](https://www.npmjs.com/package/source-map)

And too much time already spent on this, so stopped here. And tried several ways to alter the code to achieve same functionality but with another shape so that source map mapping works properly and therefore code coverage reports can be merged properly too. Found out that removing the `if` and ending the `console.error` without adding a new line works. Leaving there then with the comment pointing to this beautiful rabbit hole.

> [!NOTE]
> In `istanbul-lib-source-maps` next major version `v5`, [that same `originalPositionFor` API is now coming from a new library](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-source-maps-v5.0.0/packages/istanbul-lib-source-maps/lib/get-mapping.js#L9). This new package is [`@jridgewell/trace-mapping`](https://www.npmjs.com/package/@jridgewell/trace-mapping). 
>
> Current `nyc` latest version v17 still uses `v4` of `istanbul-lib-source-maps` (seen by doing `pnpm why 'istanbul*')`. So maybe when they update to use `v5` the issue goes away. 
>
> Indeed [latest version of `source-map` is `0.7.4` at the moment of writing this. However, [`istanbul-lib-source-maps` uses `0.6.1`](https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-source-maps-v4.0.1/packages/istanbul-lib-source-maps/package.json#L17). So if `istanbul-lib-source-maps` updates to `0.7.4` in a `v4` patch / minor and then `nyc` updates to that version, this could get fixed sooner. However in version [`0.7.0`, Web Assembly is needed](https://github.com/mozilla/source-map/blob/v0.7.4/CHANGELOG.md#070). Which is probably the reason to switch to the new package for the same API. Hence `istanbul-lib-source-maps` won't probably use `0.7.x`.

> Anyways, just guessing here. Not sure the fix is in a new version of `source-map` package or by moving to the `@jridgewell/trace-mapping` package 🤷  

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
