### PR TITLE
build: consider tree shaking for code coverage reporting

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -34,7 +34,7 @@ jobs:
           path: projects/ngx-meta/dist
           retention-days: 5
       - name: Instrument for coverage
-        run: pnpm run ngx-meta:instrument-for-coverage
+        run: pnpm run instrument-for-coverage
       - name: Upload distribution files with coverage instrumentation
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:

--- a/instrument-for-coverage.sh
+++ b/instrument-for-coverage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eu
+
+# Change cwd to this script's directory
+cd "$(dirname "$0")"
+
+NGX_META_DIST_DIR="projects/ngx-meta/dist/fesm2022"
+
+echo "ℹ️ Instrumenting for coverage with 'nyc'"
+echo "     - Directory: '$NGX_META_DIST_DIR'"
+nyc instrument "$NGX_META_DIST_DIR" --in-place
+
+echo "ℹ️ Replacing 'ngDevMode' plain usages to avoid tree-shaking"
+BACKUP_EXT=".bak"
+find "$NGX_META_DIST_DIR" -type f -name '*.*js' -exec \
+  sed -i"$BACKUP_EXT" 's/ngDevMode/globalThis.ngDevMode/g' {} \;
+rm -rf "$NGX_META_DIST_DIR"/*"${BACKUP_EXT:?}"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "ngx-meta:api-extractor": "api-extractor run -c ./projects/ngx-meta/src/api-extractor.json",
     "ngx-meta:api-extractor:local": "pnpm run ngx-meta:tsc:lib && pnpm run ngx-meta:api-extractor --local",
     "ngx-meta:api-documenter": "api-documenter markdown -i ./projects/ngx-meta/api-extractor -o ./projects/ngx-meta/docs/content/api",
-    "ngx-meta:instrument-for-coverage": "nyc instrument projects/ngx-meta/dist/fesm2022 --in-place",
     "ngx-meta:coverage:report:all": "pnpm run ngx-meta:coverage:move-to-nyc-output && nyc report --reporter lcov --report-dir coverage/ngx-meta",
     "ngx-meta:coverage:move-to-nyc-output": "rm -rf .nyc_output && mkdir .nyc_output && cp -f coverage/ngx-meta/*.json .nyc_output",
     "format-check": "prettier --check",
@@ -33,7 +32,8 @@
     "ng-lint-staged": "ng-lint-staged lint --max-warnings 0 --fix --",
     "cache-clean": "ng cache clean",
     "commit": "pnpx @commitlint/prompt-cli",
-    "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate"
+    "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate",
+    "instrument-for-coverage": "./instrument-for-coverage.sh"
   },
   "private": true,
   "packageManager": "pnpm@9.6.0",

--- a/postbuild.sh
+++ b/postbuild.sh
@@ -2,6 +2,9 @@
 # Commands to run after building
 set -eu
 
+# Change cwd to this script's directory
+cd "$(dirname "$0")"
+
 # ngx-meta Typescript definitions rollup
 echo "ℹ️ Bundling Typescript definitions"
 dts-bundle-generator --config dts-config.js


### PR DESCRIPTION
# Issue or need

In #731 a coverage mistery was born. In there an `if` clause was introduced to log a message when `ngDevMode` & some other condition for the message. The issue is that branches reported by unit tests code coverage don't match E2E coverage ones. Which kinda makes sense, because due to tree shaking of `ngDevMode`, the whole `if` clause code gets tree shaken when building the example apps that E2E tests are ran against. So that messes up coverage reporting.

Indeed messes up coverage reporting merging. If not, each of those make sense. However when merging it introduces issues and there's a bit of poor support when merging reports soo better keep things simple

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

In order to have the same code both in unit tests and E2E tests so code coverage reporting is about the same code hence the branches match, here an extra step is added when instrumenting for code coverage: avoiding `ngDevMode` tree shaking. So that the code is (almost, see below) the same for all test scenarios. This is a bit of a trade-off as from now on E2E tests aren't running the same code that an app would. But it's worth the trade-off IMO.

The trick done here is to replace `ngDevMode` by `globalThis.ngDevMode` (`globalThis` instead of `window` so that works in the server side too). This way, dead code elimination isn't clever enough to detect that it's a constant. Hence the `if` condition is still there and not tree shaken because of that. In order to do so, using a simple `sed` search and replace. Given it's not a very common string anyway (`ngDevMode`). So the less complexity the better

## Other alternatives considered

### Setting `ngDevMode` to `true` manually
With a `polyfill` for instance. It's messy though. Indeed triggers an error to the console regarding `zone.js` or something like that. And it's messing with Angular thingies sooo not a good idea anyway.

### Disabling Angular optimizations
When building example apps. This way no code is tree shaken. But also many other optimizations are turned off. Hence the E2E tests would greatly differ from a real production scenario. Noooot good. Also if disabling optimizations, budgets are exceeded and should be incremented in order to avoid example apps' build process to fail

### Using `babel`
To transform those `ngDevMode` into `globalThis.ngDevMode`. Didn't go for that as the main purpose of `babel` is to transform JS so it's compatible with older EcmaScript versions. Therefore by default it transforms code to `ES2015`. And we don't want to do more transformations, otherwise code would be more different hence unit code coverage and E2E code coverage won't be more close to be same code. Probably there's a way to tell `babel` to just do the transformation buuuuut didn't want to dig more into that. Also introduces more tooling which is more complexity and things to maintain, sooo... yikes

In the process of adding it considered to run the instrumentation via a babel plugin so all transformations are managed by same tool. But didn't go for it anyway.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
