### PR TITLE
build: improve Cypress coverage DX: cache & report renaming

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -72,6 +72,8 @@ jobs:
         working-directory: ${{ env.EXAMPLE_APP_DIR }}
       - name: Cypress run
         uses: cypress-io/github-action@df7484c5ba85def7eef30db301afa688187bc378 # v6.7.2
+        env:
+          COVERAGE_JSON_REPORT_NAME: e2e-${{ matrix.app-name }}.json
         with:
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
@@ -79,9 +81,6 @@ jobs:
           # https://github.com/cypress-io/github-action/tree/v6.6.1?tab=readme-ov-file#pnpm
           # Given we're doing caching manually, installing apart to leverage cache
           install: false
-      - name: Rename coverage report with app name suffix
-        run: mv ${{ env.COVERAGE_DIR }}/*.json ${{ env.COVERAGE_DIR }}/e2e-${{ matrix.app-name }}.json
-        working-directory: .
       - name: Upload coverage report
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         if: failure() || success()

--- a/projects/ngx-meta/e2e/cypress.config.ts
+++ b/projects/ngx-meta/e2e/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import registerCodeCoverageTasks from '@cypress/code-coverage/task'
+import { removeNycTempDir, renameJsonReport } from './cypress/support/coverage'
 
 export default defineConfig({
   e2e: {
@@ -11,6 +12,15 @@ export default defineConfig({
     ) {
       // implement node event listeners here
       registerCodeCoverageTasks(on, config)
+      on('before:run', async () => {
+        console.debug('Running before:run tasks')
+        await removeNycTempDir()
+      })
+      on('after:run', async () => {
+        console.debug('Running after:run tasks')
+        await renameJsonReport()
+        await removeNycTempDir()
+      })
       return config
     },
   },

--- a/projects/ngx-meta/e2e/cypress/support/coverage.ts
+++ b/projects/ngx-meta/e2e/cypress/support/coverage.ts
@@ -1,0 +1,53 @@
+import { rename, rm } from 'fs/promises'
+import { join } from 'path'
+import { loadNycConfig } from '@istanbuljs/load-nyc-config'
+
+export async function removeNycTempDir() {
+  const nycConfig = await loadNycConfig()
+  const nycTempDir = nycConfig.tempDir ?? DEFAULT_NYC_TEMP_DIR
+  const nycTempPath = join(nycConfig.cwd, nycTempDir)
+
+  if (nycTempPath.length === 0) {
+    console.error('Temporary path is not properly defined. Aborting')
+    return
+  }
+
+  console.info('Clearing nyc temp dir "%s"', nycTempPath)
+  await rm(join(nycTempPath), { recursive: true, force: true })
+}
+
+// https://github.com/istanbuljs/nyc/tree/main#common-configuration-options
+
+const DEFAULT_NYC_TEMP_DIR = '.nyc_output'
+
+export async function renameJsonReport() {
+  const nycConfig = await loadNycConfig()
+  if (
+    !nycConfig['reporter']
+      ?.map((reporter) => reporter.toLowerCase())
+      .includes('json')
+  ) {
+    console.debug(
+      'No JSON coverage report emitted as per configuration. Not renaming',
+    )
+    return
+  }
+
+  console.info('Renaming JSON coverage report')
+  const coverageDirectory = join(
+    nycConfig.cwd,
+    nycConfig.reportDir ?? DEFAULT_COVERAGE_DIR,
+  )
+  const jsonReportName =
+    process.env['COVERAGE_JSON_REPORT_NAME'] ?? DEFAULT_RENAMED_JSON_REPORT_NAME
+  const oldPath = join(coverageDirectory, DEFAULT_JSON_REPORT_NAME)
+  const newPath = join(coverageDirectory, jsonReportName)
+  console.info(" Source:      '%s'", oldPath)
+  console.info(" Destination: '%s'", newPath)
+
+  await rename(oldPath, newPath)
+}
+
+const DEFAULT_COVERAGE_DIR = 'coverage'
+const DEFAULT_JSON_REPORT_NAME = 'coverage-final.json'
+const DEFAULT_RENAMED_JSON_REPORT_NAME = 'e2e.json'

--- a/projects/ngx-meta/e2e/cypress/support/coverage.ts
+++ b/projects/ngx-meta/e2e/cypress/support/coverage.ts
@@ -16,8 +16,6 @@ export async function removeNycTempDir() {
   await rm(join(nycTempPath), { recursive: true, force: true })
 }
 
-// https://github.com/istanbuljs/nyc/tree/main#common-configuration-options
-
 const DEFAULT_NYC_TEMP_DIR = '.nyc_output'
 
 export async function renameJsonReport() {

--- a/projects/ngx-meta/e2e/package.json
+++ b/projects/ngx-meta/e2e/package.json
@@ -4,13 +4,14 @@
   "description": "ngx-meta E2E testing infra",
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run",
-    "postcypress:run": "mv -f ../../../coverage/ngx-meta/coverage-final.json ../../../coverage/ngx-meta/e2e.json"
+    "cypress:run": "cypress run"
   },
   "packageManager": "pnpm@9.6.0",
   "private": true,
   "devDependencies": {
     "@cypress/code-coverage": "3.12.44",
+    "@istanbuljs/load-nyc-config": "1.1.0",
+    "@types/node": "22.0.2",
     "cypress": "13.13.1",
     "tslib": "2.6.3",
     "typescript": "5.5.3"

--- a/projects/ngx-meta/e2e/pnpm-lock.yaml
+++ b/projects/ngx-meta/e2e/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@cypress/code-coverage':
         specifier: 3.12.44
         version: 3.12.44(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1))(cypress@13.13.1)(webpack@5.92.1)
+      '@istanbuljs/load-nyc-config':
+        specifier: 1.1.0
+        version: 1.1.0
+      '@types/node':
+        specifier: 22.0.2
+        version: 22.0.2
       cypress:
         specifier: 13.13.1
         version: 13.13.1
@@ -684,8 +690,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@18.18.13':
-    resolution: {integrity: sha512-vXYZGRrSCreZmq1rEjMRLXJhiy8MrIeVasx+PCVlP414N7CJLHnMf+juVvjdprHyH+XRy3zKZLHeNueOpJCn0g==}
+  '@types/node@22.0.2':
+    resolution: {integrity: sha512-yPL6DyFwY5PiMVEwymNeqUTKsDczQBJ/5T7W/46RwLU/VH+AA8aT5TZkvBviLKLbbm0hlfftEkGrNzfRk/fofQ==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -2000,8 +2006,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@6.11.1:
+    resolution: {integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -2202,7 +2208,7 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -3010,9 +3016,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@18.18.13':
+  '@types/node@22.0.2':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.11.1
 
   '@types/sinonjs__fake-timers@8.1.1': {}
 
@@ -3020,7 +3026,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 18.18.13
+      '@types/node': 22.0.2
     optional: true
 
   '@webassemblyjs/ast@1.12.1':
@@ -3807,7 +3813,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.18.13
+      '@types/node': 22.0.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -4344,7 +4350,7 @@ snapshots:
 
   typescript@5.5.3: {}
 
-  undici-types@5.26.5: {}
+  undici-types@6.11.1: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 

--- a/projects/ngx-meta/e2e/tsconfig.json
+++ b/projects/ngx-meta/e2e/tsconfig.json
@@ -3,7 +3,8 @@
   "include": ["cypress/**/*.ts"],
   "compilerOptions": {
     "sourceMap": false,
-    "types": ["cypress"],
+    "types": ["cypress", "node", "istanbuljs__load-nyc-config"],
+    "typeRoots": ["node_modules/@types", "types"],
     // Load JSON fixtures (so we leverage types)
     "resolveJsonModule": true
   }

--- a/projects/ngx-meta/e2e/types/istanbuljs__load-nyc-config.d.ts
+++ b/projects/ngx-meta/e2e/types/istanbuljs__load-nyc-config.d.ts
@@ -1,6 +1,9 @@
 declare module '@istanbuljs/load-nyc-config' {
+  // https://github.com/istanbuljs/load-nyc-config
   export function loadNycConfig(): Promise<NycConfig>
 
+  // https://github.com/istanbuljs/nyc/tree/main#common-configuration-options
+  // https://github.com/istanbuljs/load-nyc-config/blob/v1.1.0/index.js#L100
   export interface NycConfig {
     cwd: string
     reportDir?: string

--- a/projects/ngx-meta/e2e/types/istanbuljs__load-nyc-config.d.ts
+++ b/projects/ngx-meta/e2e/types/istanbuljs__load-nyc-config.d.ts
@@ -1,0 +1,10 @@
+declare module '@istanbuljs/load-nyc-config' {
+  export function loadNycConfig(): Promise<NycConfig>
+
+  export interface NycConfig {
+    cwd: string
+    reportDir?: string
+    reporter?: ReadonlyArray<string>
+    tempDir?: string
+  }
+}


### PR DESCRIPTION
# Issue or need

After playing a bit with code coverage using Cypress, learned that:
 - Removing `nyc` temporary directory (`.nyc_output` in the `e2e` dir) after running Cypress is important. Otherwise every Cypress run will take into account previous runs' coverage. Leading sometimes to inconsistencies
 - When using WebStorm, the `post` hook to achieve the previous point doesn't run. Also that script renames the Cypress output coverage report JSON file. So the output file is not renamed either. Therefore you're used to either take that into account (and remove the temporary directory manually if using WebStorm to run Cypress tests) or use the CLI so the hook is taken into account

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

In order to improve the development experience when dealing with code coverage in Cypress, moving those hooks to Cypress hooks. This way, no matter how you run Cypress, those will run.

Adds two hooks:
 - Before running tests in a project: to remove the `nyc` temporary directory and start fresh. If using Cypress interactively, the code coverage plugin will automatically clear that directory for each run.
 - After running tests in a project: to remove the `nyc` temporary directory just in case the before hook doesn't run or something. And also does the file renaming

Extra point: allows to customize the name of the renamed JSON code coverage report via env vars. So the CI can specify it as an env var and no `mv` step is needed.

Those can be useful, so proposing them to Cypress community could be nice. After reading many code of the Cypress code coverage plugin, I could even implement those myself pretty quickly.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
