### PR TITLE
docs: add recent coverage tooling changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,13 +199,13 @@ Reports will be generated in JSON, `lcov` and HTML format. JSON report file name
 
 #### E2E tests
 
-Refer to [`ngx-meta`'s E2E `README` for more information](projects/ngx-meta/e2e/README.md)
+Refer to [`ngx-meta`'s E2E infra for more information](projects/ngx-meta/e2e/README.md)
 
 #### Coverage
 
 Tests are configured to output coverage reports to the `coverage/<projectName>` directory. See each kind of tests to see which formats will be output there.
 
-[Codecov](https://codecov.io) is used to keep track of code coverage over time. It is configured in CI/CD to ensure each PR introduces tests for new code introduced and to maintain a good overall project coverage. It will also merge coverage reports from different tests (unit, E2E) to have a holistic code coverage view.
+[Codecov](https://codecov.io) is used to keep track of code coverage over time. It is configured in CI/CD to ensure each PR introduces tests for new code introduced and to maintain a good overall project coverage. All coverage results from different tests (unit, E2E) are uploaded there to have a holistic code coverage view.
 
 In local, beware that reports may overwrite each other. Except for JSON reports. For instance if running unit tests coverage and then E2E tests coverage, the `lcov` and HTML report will take int account E2E tests only.
 


### PR DESCRIPTION
# Issue or need

Coverage tooling has been improved recently:
 - #729
 - #732
 - #733
 - #734

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Update developer's documentation to reflect changes. Mainly additions

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
