### PR TITLE
build: revert dead code elimination hack for coverage

### DIFF
--- a/instrument-for-coverage.sh
+++ b/instrument-for-coverage.sh
@@ -9,9 +9,3 @@ NGX_META_DIST_DIR="projects/ngx-meta/dist/fesm2022"
 echo "ℹ️ Instrumenting for coverage with 'nyc'"
 echo "     - Directory: '$NGX_META_DIST_DIR'"
 nyc instrument "$NGX_META_DIST_DIR" --in-place
-
-echo "ℹ️ Replacing 'ngDevMode' plain usages to avoid tree-shaking"
-BACKUP_EXT=".bak"
-find "$NGX_META_DIST_DIR" -type f -name '*.*js' -exec \
-  sed -i"$BACKUP_EXT" 's/ngDevMode/globalThis.ngDevMode/g' {} \;
-rm -rf "$NGX_META_DIST_DIR"/*"${BACKUP_EXT:?}"

--- a/projects/ngx-meta/e2e/README.md
+++ b/projects/ngx-meta/e2e/README.md
@@ -98,34 +98,6 @@ Links:
 - [End-to-end Testing for Server-Side Rendered Pages](https://glebbahmutov.com/blog/ssr-e2e/)
 - [Cypress and SSR (Server Side Rendering) on Cypress' GitHub Discussions](https://github.com/cypress-io/cypress/discussions/26595)
 
-### Coverage instrumentation tweak
-
-There's some code in the library that may get removed when building an app in production mode due to [dead code elimination](https://en.wikipedia.org/wiki/Dead-code_elimination) optimization technique in the compilation process.
-
-Specifically, uses of `ngDevMode`. So that we can include code that only runs when running apps in development mode and that gets eliminated in app production builds.
-
-This is not very well handled by coverage tooling. And given the code being run is an optimized version from a flattened version from a compiled version from the original source, source maps can lead to misreporting coverage too.
-
-So in order to at least always have the same code for both unit tests (where no dead code elimination happens) and E2E tests, dead code elimination is prevented. Using a hack though. In library's built code, instances of constants that could lead to dead code elimination (right now only `ngDevMode`) are replaced by `globalThis` object accesses. Object accesses are not eliminated by default. This is for safety as you can't anymore be sure it's a constant (it could be a getter, could be modified by some code around, ....).
-
-TL;DR:
-
-```typescript
-if (ngDevMode) {
-  console.log('This whole `if` clause will be eliminated in production builds')
-}
-```
-
-Becomes (when instrumenting code for E2E testing with coverage)
-
-```typescript
-if (globalThis.ngDevMode) {
-  console.log("This whole `if` clause won't be eliminated in production builds")
-}
-```
-
-More info in [PR introducing that change](https://github.com/davidlj95/ngx/pull/732)
-
 ### `tslib` error
 
 When adding code coverage to E2E tests via the `@cypress/code-coverage` import in `cypress.config.ts`, a ~wild~ error appeared in CI logs (worked fine locally):


### PR DESCRIPTION
# Issue or need

In #732, a step was introduced when instrumenting library's code for coverage reporting when running E2E tests. Avoiding dead code elimination by modifying source code to alter the code subject to that. See #732 for more details. However, after working extensively in coverage reporting tooling & DX (+ rabbit hole in #730 ), wondered if actually one of those poor DX issues caused confusion leading to think this could help and actually does nothing.

Seems that's the case, the coverage is properly reported after removing this extra step. 

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove this extra step in instrumentation for coverage to reduce complexity of tooling & also so that example apps run 100% same code as an app would do in production.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
