### PR TITLE
feat: add dev error 4 non http(s) Twitter Card image URLs

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -150,6 +150,13 @@ export const makeMetadataManagerProviderFromSetterFactory: <T>(setterFactory: Me
 // @internal (undocumented)
 export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global'], objectMerge?: MetadataResolverOptions['objectMerge']) => MetadataResolverOptions;
 
+// @internal
+export const _maybeNonHttpUrlDevMessage: (url?: string | URL, opts?: {
+    module?: string;
+    property?: string;
+    link?: string;
+}) => void;
+
 // @internal (undocumented)
 class MetadataRegistry {
     constructor(managers: ReadonlyArray<NgxMetaMetadataManager> | null);
@@ -266,6 +273,9 @@ export class NgxMetaStandardModule {
 // @public
 export class NgxMetaTwitterCardModule {
 }
+
+// @internal (undocumented)
+export const _NO_OP: () => void;
 
 // @public
 export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER: FactoryProvider;

--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -44,6 +44,9 @@ export const __STANDARD_LOCALE_METADATA_SETTER_FACTORY: MetadataSetterFactory<St
 export const __STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<Standard[typeof _GLOBAL_TITLE]>;
 
 // @internal (undocumented)
+export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY: (metaService: NgxMetaMetaService) => (image: TwitterCard['image']) => void;
+
+// @internal (undocumented)
 export const _COMPOSED_KEY_VAL_META_DEFINITION_DEFAULT_SEPARATOR = ":";
 
 // Warning: (ae-forgotten-export) The symbol "CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts

--- a/projects/ngx-meta/src/core/index.ts
+++ b/projects/ngx-meta/src/core/index.ts
@@ -15,3 +15,6 @@ export * from './src/ngx-meta-metadata-manager'
 export * from './src/metadata-values'
 export * from './src/ngx-meta.service'
 export * from './src/ngx-meta-route-values.service'
+// Internal utils
+export * from './src/maybe-non-http-url-dev-message'
+export * from './src/no-op'

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
@@ -1,0 +1,48 @@
+import { _maybeNonHttpUrlDevMessage } from './maybe-non-http-url-dev-message'
+
+describe('maybeNonHttpUrlDevMessage', () => {
+  const sut = _maybeNonHttpUrlDevMessage
+
+  beforeEach(() => {
+    spyOn(console, 'error')
+  })
+
+  // noinspection HttpUrlsUsage
+  const NO_MSG_TEST_CASES = [
+    { url: undefined, case: 'is not defined' },
+    { url: 'http://example.com/image.jpg', case: 'uses HTTP protocol' },
+    { url: 'https://example.com/image.jpg', case: 'uses HTTPS protocol' },
+  ] as const
+  for (const testCase of NO_MSG_TEST_CASES) {
+    describe(`when URL ${testCase.case}`, () => {
+      it('should not emit any message', () => {
+        sut(testCase.url)
+
+        expect(console.error).not.toHaveBeenCalled()
+      })
+    })
+  }
+
+  describe('when URL does not use HTTP or HTTPS protocol', () => {
+    it('should emit a message about it', () => {
+      let receivedMessage: string
+      ;(console.error as jasmine.Spy).and.callFake(
+        (message) => (receivedMessage = message),
+      )
+      const invalidUrl = 'ftp://example.com/image.jpg'
+      const opts = {
+        module: 'graphTweet',
+        property: 'profile image',
+        link: 'https://example.com/url-error',
+      } satisfies Parameters<typeof sut>[1]
+
+      sut(invalidUrl, opts)
+
+      expect(console.error).toHaveBeenCalled()
+      expect(receivedMessage!).toContain(invalidUrl)
+      expect(receivedMessage!).toContain(opts.module)
+      expect(receivedMessage!).toContain(opts.property)
+      expect(receivedMessage!).toContain(opts.link)
+    })
+  })
+})

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
@@ -1,0 +1,26 @@
+/**
+ * Logs an error message about a URL not being HTTP or HTTPs
+ *
+ * Useful to warn developers about some metadata that requires absolute HTTP
+ * or HTTPs URLs
+ *
+ * MUST be used with `ngDevMode` so that this message only runs in development
+ *
+ * @internal
+ */
+export const _maybeNonHttpUrlDevMessage = (
+  url?: string | URL,
+  opts: { module?: string; property?: string; link?: string } = {},
+) => {
+  const urlStr = url?.toString()
+  if (!urlStr || urlStr.startsWith('http') || urlStr.startsWith('https')) {
+    return
+  }
+  const moduleStr = opts.module ? `/${opts.module}` : ''
+  const propertyStr = opts.property ? `${opts.property} ` : ''
+  const linkStr = opts.link ? `For more information, see ${opts.link}` : ''
+  console.error(
+    `ngx-meta${moduleStr}: ${propertyStr}URL must use either http or https.\n` +
+      ` -> Invalid ${propertyStr}URL: ${urlStr}\n${linkStr}`,
+  )
+}

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
@@ -20,7 +20,7 @@ export const _maybeNonHttpUrlDevMessage = (
   const propertyStr = opts.property ? `${opts.property} ` : ''
   const linkStr = opts.link ? `For more information, see ${opts.link}` : ''
   console.error(
-    `ngx-meta${moduleStr}: ${propertyStr}URL must use either http or https.\n` +
+    `ngx-meta${moduleStr}: ${propertyStr}URL must be absolute and use either http or https.\n` +
       ` -> Invalid ${propertyStr}URL: ${urlStr}\n${linkStr}`,
   )
 }

--- a/projects/ngx-meta/src/core/src/no-op.ts
+++ b/projects/ngx-meta/src/core/src/no-op.ts
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export const _NO_OP = () => {}

--- a/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
@@ -11,6 +11,7 @@ import { OpenGraphMetadata } from './open-graph-metadata'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
 
 export const OPEN_GRAPH_KEY: keyof OpenGraphMetadata = 'openGraph'
+export const OPEN_GRAPH_KEBAB_CASE_KEY = 'open-graph'
 
 export const makeOpenGraphMetadataProvider = <Key extends keyof OpenGraph>(
   key: Key,

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
@@ -29,70 +29,39 @@ describe('Open Graph image metadata', () => {
 
   describe('setter', () => {
     describe('when url is provided', () => {
-      describe('when the url does not start with http or https', () => {
-        it('should log an error to the console', () => {
-          spyOn(console, 'error')
+      it('should set all meta properties', () => {
+        sut(image)
 
-          const invalidImageUrl = 'ftp://ftp.example.com/images/og.jpg'
-          sut({ ...image, url: invalidImageUrl })
-
-          expect(console.error).toHaveBeenCalledWith(
-            jasmine.stringMatching(/http or https/),
-            invalidImageUrl,
-          )
-        })
-      })
-
-      describe('when the url is valid', () => {
-        it('should not error', () => {
-          spyOn(console, 'error')
-
-          sut(image)
-
-          expect(console.error).not.toHaveBeenCalled()
-        })
-        it('should set all meta properties', () => {
-          sut(image)
-
-          const props = Object.keys(image).length
-          expect(metaService.set).toHaveBeenCalledTimes(props)
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.url,
-          )
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.alt,
-          )
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.secureUrl,
-          )
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.type,
-          )
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.width.toString(),
-          )
-          expect(metaService.set).toHaveBeenCalledWith(
-            jasmine.anything(),
-            image.height.toString(),
-          )
-        })
+        const props = Object.keys(image).length
+        expect(metaService.set).toHaveBeenCalledTimes(props)
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.url,
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.alt,
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.secureUrl,
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.type,
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.width.toString(),
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.height.toString(),
+        )
       })
     })
 
     describe('when no url is defined', () => {
-      it('should not log any error', () => {
-        spyOn(console, 'error')
-
-        sut({ ...image, url: undefined })
-
-        expect(console.error).not.toHaveBeenCalled()
-      })
-
       it('should remove all meta properties', () => {
         sut({ ...image, url: undefined })
 

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
@@ -83,6 +83,7 @@ describe('Open Graph image metadata', () => {
         })
       })
     })
+
     describe('when no url is defined', () => {
       it('should not log any error', () => {
         spyOn(console, 'error')

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -1,6 +1,13 @@
 import { OpenGraph } from './open-graph'
-import { _GLOBAL_IMAGE, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
-import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
+import {
+  _GLOBAL_IMAGE,
+  _maybeNonHttpUrlDevMessage,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
+import {
+  makeOpenGraphMetadataProvider,
+  OPEN_GRAPH_KEBAB_CASE_KEY,
+} from './make-open-graph-metadata-provider'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
 
 const NO_KEY_VALUE: OpenGraph[typeof _GLOBAL_IMAGE] = {
@@ -21,18 +28,13 @@ export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
     const imageUrl = value?.url?.toString()
     const effectiveValue: OpenGraph[typeof _GLOBAL_IMAGE] =
       imageUrl !== undefined && imageUrl !== null ? value : NO_KEY_VALUE
-    //👇 What the f*ck? You may wonder (and with good cause https://youtu.be/U58IdBjMeS4?si=MT89dCrptOIS98Q9&t=27)
-    //   Checkout https://github.com/davidlj95/ngx/pull/731 for an interesting rabbit hole about coverage reporting
-    //   with `istanbul.js``, source maps & more fun
-    // noinspection HttpUrlsUsage
+    // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
-      imageUrl &&
-      !(imageUrl?.startsWith('http://') || imageUrl?.startsWith('https://')) &&
-      // prettier-ignore
-      console.error(
-        "ngx-meta/open-graph: an image URL must use either http or https.\n" +
-        "-> Invalid image URL: %s\n" +
-        "For more info, checkout https://stackoverflow.com/a/9858694/3263250", imageUrl)
+      _maybeNonHttpUrlDevMessage(imageUrl, {
+        module: OPEN_GRAPH_KEBAB_CASE_KEY,
+        property: _GLOBAL_IMAGE,
+        link: 'https://stackoverflow.com/a/9858694/3263250',
+      })
     metaService.set(makeOpenGraphMetaDefinition(_GLOBAL_IMAGE), imageUrl)
     metaService.set(
       makeOpenGraphMetaDefinition(_GLOBAL_IMAGE, 'alt'),

--- a/projects/ngx-meta/src/twitter-card/src/make-twitter-card-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/make-twitter-card-metadata-provider.ts
@@ -11,6 +11,7 @@ import { TwitterCardMetadata } from './twitter-card-metadata'
 import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
 
 const TWITTER_KEY: keyof TwitterCardMetadata = `twitterCard`
+export const TWITTER_KEY_KEBAB_CASE = 'twitter-card'
 
 export const makeTwitterCardMetadataProvider = <Key extends keyof TwitterCard>(
   key: Key,

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.spec.ts
@@ -1,0 +1,104 @@
+import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
+import { MetadataSetter, NgxMetaMetaService } from '../../core'
+import { TestBed } from '@angular/core/testing'
+import { MockProviders } from 'ng-mocks'
+import { TwitterCard } from './twitter-card'
+import {
+  __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY,
+  TWITTER_CARD_IMAGE_METADATA_PROVIDER,
+} from './twitter-card-image-metadata-provider'
+import { TwitterCardImage } from './twitter-card-image'
+
+describe('Twitter Card image metadata', () => {
+  enableAutoSpy()
+  let sut: MetadataSetter<TwitterCard['image']>
+  let metaService: jasmine.SpyObj<NgxMetaMetaService>
+
+  beforeEach(() => {
+    sut = makeSut()
+    metaService = TestBed.inject(
+      NgxMetaMetaService,
+    ) as jasmine.SpyObj<NgxMetaMetaService>
+  })
+
+  const image = {
+    url: 'https://example.com/foo.png',
+    alt: 'Alternative text',
+  } satisfies TwitterCardImage
+
+  describe('when image is provided', () => {
+    describe('when its url does not start with http or https', () => {
+      it('should log an error to the console', () => {
+        spyOn(console, 'error')
+
+        const invalidImageUrl = 'ftp://ftp.example.com/images/og.jpg'
+        sut({ ...image, url: invalidImageUrl })
+
+        expect(console.error).toHaveBeenCalledWith(
+          jasmine.stringMatching(/http or https/),
+          invalidImageUrl,
+        )
+      })
+    })
+
+    describe('when the url is valid', () => {
+      it('should not error', () => {
+        spyOn(console, 'error')
+
+        sut(image)
+
+        expect(console.error).not.toHaveBeenCalled()
+      })
+      it('should set all meta properties', () => {
+        // noinspection DuplicatedCode
+        sut(image)
+
+        const props = Object.keys(image).length
+        expect(metaService.set).toHaveBeenCalledTimes(props)
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.url,
+        )
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          image.alt,
+        )
+      })
+    })
+  })
+
+  describe('when no image provided', () => {
+    it('should not log any error', () => {
+      spyOn(console, 'error')
+
+      sut(undefined)
+
+      expect(console.error).not.toHaveBeenCalled()
+    })
+
+    it('should remove all meta properties', () => {
+      sut(undefined)
+
+      const props = Object.keys(image).length
+      expect(metaService.set).toHaveBeenCalledTimes(props)
+      for (let i = 0; i < props; i++) {
+        expect(metaService.set).toHaveBeenCalledWith(
+          jasmine.anything(),
+          undefined,
+        )
+      }
+    })
+  })
+})
+
+function makeSut(): MetadataSetter<TwitterCard['image']> {
+  TestBed.configureTestingModule({
+    providers: [
+      MockProviders(NgxMetaMetaService),
+      TWITTER_CARD_IMAGE_METADATA_PROVIDER,
+    ],
+  })
+  return __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY(
+    TestBed.inject(NgxMetaMetaService),
+  )
+}

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.spec.ts
@@ -27,55 +27,24 @@ describe('Twitter Card image metadata', () => {
   } satisfies TwitterCardImage
 
   describe('when image is provided', () => {
-    describe('when its url does not start with http or https', () => {
-      it('should log an error to the console', () => {
-        spyOn(console, 'error')
+    it('should set all meta properties', () => {
+      // noinspection DuplicatedCode
+      sut(image)
 
-        const invalidImageUrl = 'ftp://ftp.example.com/images/og.jpg'
-        sut({ ...image, url: invalidImageUrl })
-
-        expect(console.error).toHaveBeenCalledWith(
-          jasmine.stringMatching(/http or https/),
-          invalidImageUrl,
-        )
-      })
-    })
-
-    describe('when the url is valid', () => {
-      it('should not error', () => {
-        spyOn(console, 'error')
-
-        sut(image)
-
-        expect(console.error).not.toHaveBeenCalled()
-      })
-      it('should set all meta properties', () => {
-        // noinspection DuplicatedCode
-        sut(image)
-
-        const props = Object.keys(image).length
-        expect(metaService.set).toHaveBeenCalledTimes(props)
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.url,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.alt,
-        )
-      })
+      const props = Object.keys(image).length
+      expect(metaService.set).toHaveBeenCalledTimes(props)
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.url,
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.alt,
+      )
     })
   })
 
   describe('when no image provided', () => {
-    it('should not log any error', () => {
-      spyOn(console, 'error')
-
-      sut(undefined)
-
-      expect(console.error).not.toHaveBeenCalled()
-    })
-
     it('should remove all meta properties', () => {
       sut(undefined)
 

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
@@ -1,7 +1,33 @@
 import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
 import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
-import { _GLOBAL_IMAGE } from '@davidlj95/ngx-meta/core'
+import { _GLOBAL_IMAGE, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import { TwitterCard } from './twitter-card'
 
+/**
+ * @internal
+ */
+export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
+  (metaService: NgxMetaMetaService) => (image: TwitterCard['image']) => {
+    const imageUrl = image?.url.toString()
+    // 👇 See Open Graph image metadata provider to answer your: WTF?
+    // noinspection HttpUrlsUsage
+    ngDevMode &&
+      imageUrl &&
+      !(imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) &&
+      // prettier-ignore
+      console.error(
+        'ngx-meta/twitter-card: an image URL must use either http or https.\n' +
+          '-> Invalid image URL: %s\n' +
+          'For more info, checkout https://stackoverflow.com/a/9858694/3263250', imageUrl)
+    metaService.set(
+      makeTwitterCardMetaDefinition(_GLOBAL_IMAGE),
+      image?.url?.toString(),
+    )
+    metaService.set(
+      makeTwitterCardMetaDefinition(_GLOBAL_IMAGE, 'alt'),
+      image?.alt,
+    )
+  }
 /**
  * Manages the {@link TwitterCard.image} metadata
  * @public
@@ -9,15 +35,6 @@ import { _GLOBAL_IMAGE } from '@davidlj95/ngx-meta/core'
 export const TWITTER_CARD_IMAGE_METADATA_PROVIDER =
   makeTwitterCardMetadataProvider(_GLOBAL_IMAGE, {
     g: _GLOBAL_IMAGE,
-    s: (metaService) => (value) => {
-      metaService.set(
-        makeTwitterCardMetaDefinition(_GLOBAL_IMAGE),
-        value?.url?.toString(),
-      )
-      metaService.set(
-        makeTwitterCardMetaDefinition(_GLOBAL_IMAGE, 'alt'),
-        value?.alt,
-      )
-    },
+    s: __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY,
     m: true,
   })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
@@ -1,6 +1,13 @@
-import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
+import {
+  makeTwitterCardMetadataProvider,
+  TWITTER_KEY_KEBAB_CASE,
+} from './make-twitter-card-metadata-provider'
 import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
-import { _GLOBAL_IMAGE, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import {
+  _GLOBAL_IMAGE,
+  _maybeNonHttpUrlDevMessage,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { TwitterCard } from './twitter-card'
 
 /**
@@ -8,17 +15,13 @@ import { TwitterCard } from './twitter-card'
  */
 export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
   (metaService: NgxMetaMetaService) => (image: TwitterCard['image']) => {
-    const imageUrl = image?.url.toString()
-    // 👇 See Open Graph image metadata provider to answer your: WTF?
-    // noinspection HttpUrlsUsage
+    // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
-      imageUrl &&
-      !(imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) &&
-      // prettier-ignore
-      console.error(
-        'ngx-meta/twitter-card: an image URL must use either http or https.\n' +
-          '-> Invalid image URL: %s\n' +
-          'For more info, checkout https://stackoverflow.com/a/9858694/3263250', imageUrl)
+      _maybeNonHttpUrlDevMessage(image?.url, {
+        module: TWITTER_KEY_KEBAB_CASE,
+        property: 'image',
+        link: 'https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736',
+      })
     metaService.set(
       makeTwitterCardMetaDefinition(_GLOBAL_IMAGE),
       image?.url?.toString(),


### PR DESCRIPTION
# Issue or need

Same as #731 but for Twitter Card

Closes #730

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Same as #731 but for Twitter Card

Refactors to export a function to perform this task around

The function is not injected in order to be able to tree shake it when building for production. However this means we can't test that bit as there's no way to spy on that. 

Well actually [could use a Typescript trick](https://stackoverflow.com/a/43532075/3263250). But I think it's not worth the effort anyway, it's a very simple clause anyway

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
