### PR TITLE
style: remove unneeded `setter` describe block in tests

### DIFF
--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.spec.ts
@@ -27,50 +27,48 @@ describe('Open Graph image metadata', () => {
     height: 875,
   } satisfies OpenGraphImage
 
-  describe('setter', () => {
-    describe('when url is provided', () => {
-      it('should set all meta properties', () => {
-        sut(image)
+  describe('when url is provided', () => {
+    it('should set all meta properties', () => {
+      sut(image)
 
-        const props = Object.keys(image).length
-        expect(metaService.set).toHaveBeenCalledTimes(props)
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.url,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.alt,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.secureUrl,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.type,
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.width.toString(),
-        )
-        expect(metaService.set).toHaveBeenCalledWith(
-          jasmine.anything(),
-          image.height.toString(),
-        )
-      })
+      const props = Object.keys(image).length
+      expect(metaService.set).toHaveBeenCalledTimes(props)
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.url,
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.alt,
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.secureUrl,
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.type,
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.width.toString(),
+      )
+      expect(metaService.set).toHaveBeenCalledWith(
+        jasmine.anything(),
+        image.height.toString(),
+      )
     })
+  })
 
-    describe('when no url is defined', () => {
-      it('should remove all meta properties', () => {
-        sut({ ...image, url: undefined })
+  describe('when no url is defined', () => {
+    it('should remove all meta properties', () => {
+      sut({ ...image, url: undefined })
 
-        const props = Object.keys(image).length
-        expect(metaService.set).toHaveBeenCalledTimes(props)
-        for (let i = 0; i < props; i++) {
-          expect(metaService.set).toHaveBeenCalledWith(jasmine.anything(), null)
-        }
-      })
+      const props = Object.keys(image).length
+      expect(metaService.set).toHaveBeenCalledTimes(props)
+      for (let i = 0; i < props; i++) {
+        expect(metaService.set).toHaveBeenCalledWith(jasmine.anything(), null)
+      }
     })
   })
 })

--- a/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-generator-metadata-provider.spec.ts
@@ -18,28 +18,26 @@ describe('Standard generator metadata', () => {
     ) as jasmine.SpyObj<NgxMetaMetaService>
   })
 
-  describe('setter', () => {
-    it('when not provided should call meta service with nothing value', () => {
-      sut(undefined)
+  it('when not provided should call meta service with nothing value', () => {
+    sut(undefined)
 
-      expect(metaService.set).toHaveBeenCalledOnceWith(
-        jasmine.anything(),
-        undefined,
-      )
-    })
-    it('when null should call meta service with null value', () => {
-      sut(null)
+    expect(metaService.set).toHaveBeenCalledOnceWith(
+      jasmine.anything(),
+      undefined,
+    )
+  })
+  it('when null should call meta service with null value', () => {
+    sut(null)
 
-      expect(metaService.set).toHaveBeenCalledOnceWith(jasmine.anything(), null)
-    })
-    it('when true should call meta service with Angular version as value', () => {
-      sut(true)
+    expect(metaService.set).toHaveBeenCalledOnceWith(jasmine.anything(), null)
+  })
+  it('when true should call meta service with Angular version as value', () => {
+    sut(true)
 
-      expect(metaService.set).toHaveBeenCalledOnceWith(
-        jasmine.anything(),
-        `Angular v${VERSION.full}`,
-      )
-    })
+    expect(metaService.set).toHaveBeenCalledOnceWith(
+      jasmine.anything(),
+      `Angular v${VERSION.full}`,
+    )
   })
 })
 

--- a/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-keywords-metadata-provider.spec.ts
@@ -17,19 +17,17 @@ describe('Standard keywords metadata', () => {
     ) as jasmine.SpyObj<NgxMetaMetaService>
   })
 
-  describe('setter', () => {
-    it('when keywords are provided should set them separated by comma', () => {
-      const firstKeyword = 'first'
-      const secondKeyword = 'second'
-      const thirdKeyword = 'third'
+  it('should set keywords separated by comma', () => {
+    const firstKeyword = 'first'
+    const secondKeyword = 'second'
+    const thirdKeyword = 'third'
 
-      sut([firstKeyword, secondKeyword, thirdKeyword])
+    sut([firstKeyword, secondKeyword, thirdKeyword])
 
-      expect(metaService.set).toHaveBeenCalledOnceWith(
-        jasmine.anything(),
-        `${firstKeyword},${secondKeyword},${thirdKeyword}`,
-      )
-    })
+    expect(metaService.set).toHaveBeenCalledOnceWith(
+      jasmine.anything(),
+      `${firstKeyword},${secondKeyword},${thirdKeyword}`,
+    )
   })
 })
 

--- a/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-locale-metadata-provider.spec.ts
@@ -21,43 +21,41 @@ describe('Standard locale metadata', () => {
     htmlLangAttributeHarness.remove()
   })
 
-  describe('setter', () => {
-    describe('when locale is not provided', () => {
-      const locale = undefined
+  describe('when locale is not provided', () => {
+    const locale = undefined
 
-      it('should remove HTML element lang attribute', () => {
-        htmlLangAttributeHarness.set('es')
-        expect(htmlLangAttributeHarness.get()).toBeTruthy()
+    it('should remove HTML element lang attribute', () => {
+      htmlLangAttributeHarness.set('es')
+      expect(htmlLangAttributeHarness.get()).toBeTruthy()
 
-        sut(locale)
+      sut(locale)
 
-        expect(htmlLangAttributeHarness.get()).toBeNull()
-      })
+      expect(htmlLangAttributeHarness.get()).toBeNull()
     })
+  })
 
-    describe('when locale is provided', () => {
-      const locale = 'es-ES'
+  describe('when locale is provided', () => {
+    const locale = 'es-ES'
 
-      it('should update HTML element lang attribute', () => {
-        sut(locale)
+    it('should update HTML element lang attribute', () => {
+      sut(locale)
 
-        const htmlTagLangAttribute = htmlLangAttributeHarness.get()
-        expect(htmlTagLangAttribute).not.toBeNull()
-        expect(htmlTagLangAttribute?.value).toEqual(locale)
-      })
+      const htmlTagLangAttribute = htmlLangAttributeHarness.get()
+      expect(htmlTagLangAttribute).not.toBeNull()
+      expect(htmlTagLangAttribute?.value).toEqual(locale)
     })
+  })
 
-    describe('when locale is null', () => {
-      const locale = null
+  describe('when locale is null', () => {
+    const locale = null
 
-      it('should remove HTML element lang attribute', () => {
-        htmlLangAttributeHarness.set('es')
-        expect(htmlLangAttributeHarness.get()).toBeTruthy()
+    it('should remove HTML element lang attribute', () => {
+      htmlLangAttributeHarness.set('es')
+      expect(htmlLangAttributeHarness.get()).toBeTruthy()
 
-        sut(locale)
+      sut(locale)
 
-        expect(htmlLangAttributeHarness.get()).toBeNull()
-      })
+      expect(htmlLangAttributeHarness.get()).toBeNull()
     })
   })
 })

--- a/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/standard-title-metadata-provider.spec.ts
@@ -16,28 +16,26 @@ describe('Standard title metadata', () => {
     titleService = TestBed.inject(Title) as jasmine.SpyObj<Title>
   })
 
-  describe('setter', () => {
-    it('when title is not provided should not update title', () => {
-      sut(undefined)
+  it('should not update title when title is not provided ', () => {
+    sut(undefined)
 
-      expect(titleService.setTitle).not.toHaveBeenCalled()
-    })
+    expect(titleService.setTitle).not.toHaveBeenCalled()
+  })
 
-    it('when title is empty should update title', () => {
-      const pageTitle = ''
+  it('should update title when title is empty ', () => {
+    const pageTitle = ''
 
-      sut(pageTitle)
+    sut(pageTitle)
 
-      expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
-    })
+    expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
+  })
 
-    it('when title is provided should update title', () => {
-      const pageTitle = 'Page title'
+  it('should update title when title is provided', () => {
+    const pageTitle = 'Page title'
 
-      sut(pageTitle)
+    sut(pageTitle)
 
-      expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
-    })
+    expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
   })
 })
 


### PR DESCRIPTION
# Issue or need

Some tests contain a `describe` block that it's not needed. That comes from initial versions when metadata setters were a class

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove them

Also ensures tests starts with `should` by convention

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
