### PR TITLE
feat: add dev msg if too long OG/Twitter descriptions

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -66,6 +66,18 @@ const enum CoreFeatureKind {
 }
 
 // @internal (undocumented)
+interface _FormatDevMessageOptions {
+    // (undocumented)
+    link?: string;
+    // (undocumented)
+    module: string;
+    // (undocumented)
+    property?: string;
+    // (undocumented)
+    value?: string | null;
+}
+
+// @internal (undocumented)
 export const _GLOBAL_APPLICATION_NAME = "applicationName";
 
 // @internal (undocumented)
@@ -150,12 +162,13 @@ export const makeMetadataManagerProviderFromSetterFactory: <T>(setterFactory: Me
 // @internal (undocumented)
 export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global'], objectMerge?: MetadataResolverOptions['objectMerge']) => MetadataResolverOptions;
 
+// Warning: (ae-forgotten-export) The symbol "_FormatDevMessageOptions" needs to be exported by the entry point all-entry-points.d.ts
+//
 // @internal
-export const _maybeNonHttpUrlDevMessage: (url?: string | URL, opts?: {
-    module?: string;
-    property?: string;
-    link?: string;
-}) => void;
+export const _maybeNonHttpUrlDevMessage: (url: string | URL | undefined | null, opts: _FormatDevMessageOptions) => void;
+
+// @internal
+export const _maybeTooLongDevMessage: (value: string | undefined | null, maxLength: number, opts: _FormatDevMessageOptions) => void;
 
 // @internal (undocumented)
 class MetadataRegistry {

--- a/projects/ngx-meta/src/core/index.ts
+++ b/projects/ngx-meta/src/core/index.ts
@@ -17,4 +17,5 @@ export * from './src/ngx-meta.service'
 export * from './src/ngx-meta-route-values.service'
 // Internal utils
 export * from './src/maybe-non-http-url-dev-message'
+export * from './src/maybe-too-long-dev-message'
 export * from './src/no-op'

--- a/projects/ngx-meta/src/core/src/__tests__/dummy-format-dev-message-options.ts
+++ b/projects/ngx-meta/src/core/src/__tests__/dummy-format-dev-message-options.ts
@@ -1,0 +1,1 @@
+export const DUMMY_FORMAT_DEV_MESSAGE_OPTIONS = { module: 'module' }

--- a/projects/ngx-meta/src/core/src/format-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/format-dev-message.spec.ts
@@ -1,0 +1,65 @@
+import { _formatDevMessage } from './format-dev-message'
+
+describe('formatDevMessage', () => {
+  const sut = _formatDevMessage
+  const message = 'Hello World'
+  const module = 'core'
+
+  it('should contain message', () => {
+    expect(sut(message, { module })).toContain(message)
+  })
+
+  it('should prefix message with package name and module', () => {
+    expect(sut(message, { module })).toEqual(
+      jasmine.stringMatching(`^ngx-meta/${module}`),
+    )
+  })
+
+  describe('when property name is not provided', () => {
+    it('should start message with given message', () => {
+      const actual = sut(message, { module })
+      const prefixAndMessage = actual.split(':')
+
+      expect(prefixAndMessage[1]).toEqual(
+        jasmine.stringMatching(`^ ${message}`),
+      )
+    })
+  })
+
+  describe('when property name is provided', () => {
+    const property = 'a-bar-prop'
+
+    it('should start message with property name if provided', () => {
+      const actual = sut(message, { module, property })
+      const prefixAndMessage = actual.split(':')
+
+      expect(prefixAndMessage[1]).toEqual(
+        jasmine.stringMatching(`^ ${property}`),
+      )
+    })
+  })
+
+  describe('when value is provided', () => {
+    const value = 'a-foo-value'
+
+    it('should contain referred value in body', () => {
+      const actual = sut(message, { module, value })
+      const body = actual.split('\n')
+
+      expect(body[1]).toEqual(jasmine.stringMatching(`^-> Value: "${value}"`))
+    })
+  })
+
+  describe('when link is provided', () => {
+    const link = 'https://example.com/help/42'
+
+    it('should contain link line', () => {
+      const actual = sut(message, { module, link })
+      const linkLine = actual.split('\n')
+
+      expect(linkLine[1]).toEqual(
+        jasmine.stringMatching(`^For more information, see ${link}`),
+      )
+    })
+  })
+})

--- a/projects/ngx-meta/src/core/src/format-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/format-dev-message.ts
@@ -1,0 +1,26 @@
+/**
+ * @internal
+ */
+export interface _FormatDevMessageOptions {
+  module: string
+  property?: string
+  value?: string | null
+  link?: string
+}
+
+/**
+ * @internal
+ */
+export const _formatDevMessage = (
+  message: string,
+  options: _FormatDevMessageOptions,
+): string => {
+  const header = [`ngx-meta/${options.module}:`, options.property, message]
+    .filter((s) => !!s)
+    .join(' ')
+  const body = options.value ? `-> Value: "${options.value}"` : undefined
+  const footer = options.link
+    ? `For more information, see ${options.link}`
+    : undefined
+  return [header, body, footer].filter((s) => !!s).join('\n')
+}

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
@@ -1,4 +1,5 @@
 import { _maybeNonHttpUrlDevMessage } from './maybe-non-http-url-dev-message'
+import { DUMMY_FORMAT_DEV_MESSAGE_OPTIONS } from './__tests__/dummy-format-dev-message-options'
 
 describe('maybeNonHttpUrlDevMessage', () => {
   const sut = _maybeNonHttpUrlDevMessage
@@ -17,7 +18,7 @@ describe('maybeNonHttpUrlDevMessage', () => {
     for (const testCase of TEST_CASES) {
       describe(`like when URL ${testCase.case}`, () => {
         it('should not emit any message', () => {
-          sut(testCase.url)
+          sut(testCase.url, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
           expect(console.error).not.toHaveBeenCalled()
         })
@@ -36,31 +37,13 @@ describe('maybeNonHttpUrlDevMessage', () => {
     for (const testCase of TEST_CASES) {
       describe(`like when URL ${testCase.case}`, () => {
         it('should emit a message about it', () => {
-          sut(testCase.url)
+          sut(testCase.url, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
           expect(console.error).toHaveBeenCalledWith(
-            jasmine.stringContaining(testCase.url),
+            jasmine.stringContaining('URL must be absolute'),
           )
         })
       })
     }
-
-    it('should emit a message containing the provided extra options', () => {
-      let receivedMessage: string
-      ;(console.error as jasmine.Spy).and.callFake(
-        (message) => (receivedMessage = message),
-      )
-      const opts = {
-        module: 'graphTweet',
-        property: 'profile image',
-        link: 'https://example.com/url-error',
-      } satisfies Parameters<typeof sut>[1]
-
-      sut(TEST_CASES[0].url, opts)
-
-      expect(receivedMessage!).toContain(opts.module)
-      expect(receivedMessage!).toContain(opts.property)
-      expect(receivedMessage!).toContain(opts.link)
-    })
   })
 })

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
@@ -9,7 +9,7 @@
  * @internal
  */
 export const _maybeNonHttpUrlDevMessage = (
-  url?: string | URL,
+  url: string | URL | undefined | null,
   opts: { module?: string; property?: string; link?: string } = {},
 ) => {
   const urlStr = url?.toString()

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.ts
@@ -1,3 +1,8 @@
+import {
+  _formatDevMessage,
+  _FormatDevMessageOptions,
+} from './format-dev-message'
+
 /**
  * Logs an error message about a URL not being HTTP or HTTPs
  *
@@ -8,19 +13,18 @@
  *
  * @internal
  */
+/* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
 export const _maybeNonHttpUrlDevMessage = (
   url: string | URL | undefined | null,
-  opts: { module?: string; property?: string; link?: string } = {},
+  opts: _FormatDevMessageOptions,
 ) => {
   const urlStr = url?.toString()
-  if (!urlStr || urlStr.startsWith('http') || urlStr.startsWith('https')) {
-    return
+  if (urlStr && !(urlStr.startsWith('http') || urlStr.startsWith('https'))) {
+    console.error(
+      _formatDevMessage(
+        'URL must be absolute and use either http or https',
+        opts,
+      ),
+    )
   }
-  const moduleStr = opts.module ? `/${opts.module}` : ''
-  const propertyStr = opts.property ? `${opts.property} ` : ''
-  const linkStr = opts.link ? `For more information, see ${opts.link}` : ''
-  console.error(
-    `ngx-meta${moduleStr}: ${propertyStr}URL must be absolute and use either http or https.\n` +
-      ` -> Invalid ${propertyStr}URL: ${urlStr}\n${linkStr}`,
-  )
 }

--- a/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
@@ -1,4 +1,5 @@
 import { _maybeTooLongDevMessage } from './maybe-too-long-dev-message'
+import { DUMMY_FORMAT_DEV_MESSAGE_OPTIONS } from './__tests__/dummy-format-dev-message-options'
 
 describe('maybeTooLongDevMessage', () => {
   const sut = _maybeTooLongDevMessage
@@ -9,8 +10,9 @@ describe('maybeTooLongDevMessage', () => {
 
   describe('when message is not defined', () => {
     const message = undefined
+
     it('should not emit any message', () => {
-      sut(message, 300)
+      sut(message, 300, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
       expect(console.warn).not.toHaveBeenCalled()
     })
@@ -21,7 +23,7 @@ describe('maybeTooLongDevMessage', () => {
     const maxLength = 300
 
     it('should not emit any message', () => {
-      sut(message, maxLength)
+      sut(message, maxLength, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
       expect(console.warn).not.toHaveBeenCalled()
     })
@@ -32,10 +34,10 @@ describe('maybeTooLongDevMessage', () => {
     const maxLength = 10
 
     it('should emit a message about it', () => {
-      sut(message, maxLength)
+      sut(message, maxLength, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
       expect(console.warn).toHaveBeenCalledWith(
-        jasmine.stringContaining('too long'),
+        jasmine.stringContaining('exceeds recommended size'),
       )
     })
   })

--- a/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
@@ -1,0 +1,42 @@
+import { _maybeTooLongDevMessage } from './maybe-too-long-dev-message'
+
+describe('maybeTooLongDevMessage', () => {
+  const sut = _maybeTooLongDevMessage
+
+  beforeEach(() => {
+    spyOn(console, 'warn')
+  })
+
+  describe('when message is not defined', () => {
+    const message = undefined
+    it('should not emit any message', () => {
+      sut(message, 300)
+
+      expect(console.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when message is not too long', () => {
+    const message = 'short'
+    const maxLength = 300
+
+    it('should not emit any message', () => {
+      sut(message, maxLength)
+
+      expect(console.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when message is too long', () => {
+    const message = 'looooooooooooooooooooooooong'
+    const maxLength = 10
+
+    it('should emit a message about it', () => {
+      sut(message, maxLength)
+
+      expect(console.warn).toHaveBeenCalledWith(
+        jasmine.stringContaining('too long'),
+      )
+    })
+  })
+})

--- a/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.ts
@@ -1,3 +1,8 @@
+import {
+  _formatDevMessage,
+  _FormatDevMessageOptions,
+} from './format-dev-message'
+
 /**
  * Logs a warn message when a value string exceeds a length threshold
  *
@@ -7,11 +12,15 @@
  *
  * @internal
  */
+/* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
 export const _maybeTooLongDevMessage = (
   value: string | undefined | null,
   maxLength: number,
+  opts: _FormatDevMessageOptions,
 ) => {
   if (value && value.length > maxLength) {
-    console.warn('String is too long')
+    console.warn(
+      _formatDevMessage(`exceeds recommended size of ${maxLength} chars`, opts),
+    )
   }
 }

--- a/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.ts
+++ b/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.ts
@@ -1,0 +1,17 @@
+/**
+ * Logs a warn message when a value string exceeds a length threshold
+ *
+ * Useful to warn developers about some metadata improperly used
+ *
+ * MUST be used with `ngDevMode` so that this message only runs in development
+ *
+ * @internal
+ */
+export const _maybeTooLongDevMessage = (
+  value: string | undefined | null,
+  maxLength: number,
+) => {
+  if (value && value.length > maxLength) {
+    console.warn('String is too long')
+  }
+}

--- a/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
@@ -1,4 +1,7 @@
-import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
+import {
+  makeOpenGraphMetadataProvider,
+  OPEN_GRAPH_KEBAB_CASE_KEY,
+} from './make-open-graph-metadata-provider'
 import {
   _GLOBAL_DESCRIPTION,
   _maybeTooLongDevMessage,
@@ -19,7 +22,12 @@ export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
       (description: OpenGraph['description']) => {
         /* istanbul ignore next */
         if (ngDevMode) {
-          _maybeTooLongDevMessage(description, 300)
+          _maybeTooLongDevMessage(description, 300, {
+            module: OPEN_GRAPH_KEBAB_CASE_KEY,
+            property: _GLOBAL_DESCRIPTION,
+            value: description,
+            link: 'https://stackoverflow.com/q/8914476/3263250',
+          })
         }
         metaService.set(
           makeOpenGraphMetaDefinition(_GLOBAL_DESCRIPTION),

--- a/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
@@ -1,9 +1,29 @@
 import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
-import { _GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
+import {
+  _GLOBAL_DESCRIPTION,
+  _maybeTooLongDevMessage,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
+import { OpenGraph } from './open-graph'
+import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
 
 /**
  * Manages the {@link OpenGraph.description} metadata
  * @public
  */
 export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
-  makeOpenGraphMetadataProvider(_GLOBAL_DESCRIPTION, { g: _GLOBAL_DESCRIPTION })
+  makeOpenGraphMetadataProvider(_GLOBAL_DESCRIPTION, {
+    g: _GLOBAL_DESCRIPTION,
+    s:
+      (metaService: NgxMetaMetaService) =>
+      (description: OpenGraph['description']) => {
+        /* istanbul ignore next */
+        if (ngDevMode) {
+          _maybeTooLongDevMessage(description, 300)
+        }
+        metaService.set(
+          makeOpenGraphMetaDefinition(_GLOBAL_DESCRIPTION),
+          description,
+        )
+      },
+  })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
@@ -1,5 +1,13 @@
-import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
-import { _GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
+import {
+  makeTwitterCardMetadataProvider,
+  TWITTER_KEY_KEBAB_CASE,
+} from './make-twitter-card-metadata-provider'
+import {
+  _GLOBAL_DESCRIPTION,
+  _maybeTooLongDevMessage,
+} from '@davidlj95/ngx-meta/core'
+import { TwitterCard } from './twitter-card'
+import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
 
 /**
  * Manages the {@link TwitterCard.description} metadata
@@ -8,4 +16,19 @@ import { _GLOBAL_DESCRIPTION } from '@davidlj95/ngx-meta/core'
 export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER =
   makeTwitterCardMetadataProvider(_GLOBAL_DESCRIPTION, {
     g: _GLOBAL_DESCRIPTION,
+    s: (metaService) => (description: TwitterCard['description']) => {
+      /* istanbul ignore next */
+      if (ngDevMode) {
+        _maybeTooLongDevMessage(description, 200, {
+          module: TWITTER_KEY_KEBAB_CASE,
+          property: _GLOBAL_DESCRIPTION,
+          value: description,
+          link: 'https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=n/a-,twitter%3Adescription,-Description%20of%20content',
+        })
+      }
+      metaService.set(
+        makeTwitterCardMetaDefinition(_GLOBAL_DESCRIPTION),
+        description,
+      )
+    },
   })


### PR DESCRIPTION
# Issue or need

Open Graph and Twitter Cards description property are recommended not to be excessively long. It could be nice to inform developers when the maximum recommended size is exceeded

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Warn about excessive length for Open Graph / Twitter Card too long descriptions when running on development

Refactors to introduce a common utility for formatting dev messages around

Skips coverage in the new functions given the issue with coverage reporting & source maps

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
