### PR TITLE
refactor: use dev msg formatter around

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -66,7 +66,10 @@ const enum CoreFeatureKind {
 }
 
 // @internal (undocumented)
-interface _FormatDevMessageOptions {
+export const _formatDevMessage: (message: string, options: _FormatDevMessageOptions) => string;
+
+// @internal (undocumented)
+export interface _FormatDevMessageOptions {
     // (undocumented)
     link?: string;
     // (undocumented)
@@ -162,8 +165,6 @@ export const makeMetadataManagerProviderFromSetterFactory: <T>(setterFactory: Me
 // @internal (undocumented)
 export const _makeMetadataResolverOptions: (jsonPath: MetadataResolverOptions['jsonPath'], global?: MetadataResolverOptions['global'], objectMerge?: MetadataResolverOptions['objectMerge']) => MetadataResolverOptions;
 
-// Warning: (ae-forgotten-export) The symbol "_FormatDevMessageOptions" needs to be exported by the entry point all-entry-points.d.ts
-//
 // @internal
 export const _maybeNonHttpUrlDevMessage: (url: string | URL | undefined | null, opts: _FormatDevMessageOptions) => void;
 

--- a/projects/ngx-meta/src/core/index.ts
+++ b/projects/ngx-meta/src/core/index.ts
@@ -16,6 +16,7 @@ export * from './src/metadata-values'
 export * from './src/ngx-meta.service'
 export * from './src/ngx-meta-route-values.service'
 // Internal utils
+export * from './src/format-dev-message'
 export * from './src/maybe-non-http-url-dev-message'
 export * from './src/maybe-too-long-dev-message'
 export * from './src/no-op'

--- a/projects/ngx-meta/src/core/src/module-name.ts
+++ b/projects/ngx-meta/src/core/src/module-name.ts
@@ -1,0 +1,1 @@
+export const _MODULE_NAME = 'core'

--- a/projects/ngx-meta/src/core/src/ngx-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 import { MetadataRegistry } from './metadata-registry'
 import { METADATA_RESOLVER, MetadataResolver } from './metadata-resolver'
+import { _formatDevMessage } from './format-dev-message'
+import { _MODULE_NAME } from './module-name'
 
 /**
  * Manages the metadata values of the current page
@@ -79,8 +81,10 @@ export class NgxMetaService {
     /* istanbul ignore if */
     if (ngDevMode && [...managers].length === 0) {
       console.warn(
-        "No metadata managers found with global or JSON Path '%s'",
-        globalOrJsonPath,
+        _formatDevMessage(
+          'no metadata managers found for global or JSON Path',
+          { module: _MODULE_NAME, value: globalOrJsonPath },
+        ),
       )
     }
     for (const manager of managers) {

--- a/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/make-open-graph-metadata-provider.ts
@@ -11,7 +11,6 @@ import { OpenGraphMetadata } from './open-graph-metadata'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
 
 export const OPEN_GRAPH_KEY: keyof OpenGraphMetadata = 'openGraph'
-export const OPEN_GRAPH_KEBAB_CASE_KEY = 'open-graph'
 
 export const makeOpenGraphMetadataProvider = <Key extends keyof OpenGraph>(
   key: Key,

--- a/projects/ngx-meta/src/open-graph/src/module-name.ts
+++ b/projects/ngx-meta/src/open-graph/src/module-name.ts
@@ -1,0 +1,1 @@
+export const _MODULE_NAME = 'open-graph'

--- a/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
@@ -1,7 +1,4 @@
-import {
-  makeOpenGraphMetadataProvider,
-  OPEN_GRAPH_KEBAB_CASE_KEY,
-} from './make-open-graph-metadata-provider'
+import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
 import {
   _GLOBAL_DESCRIPTION,
   _maybeTooLongDevMessage,
@@ -9,6 +6,7 @@ import {
 } from '@davidlj95/ngx-meta/core'
 import { OpenGraph } from './open-graph'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
+import { _MODULE_NAME } from './module-name'
 
 /**
  * Manages the {@link OpenGraph.description} metadata
@@ -23,7 +21,7 @@ export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
         /* istanbul ignore next */
         if (ngDevMode) {
           _maybeTooLongDevMessage(description, 300, {
-            module: OPEN_GRAPH_KEBAB_CASE_KEY,
+            module: _MODULE_NAME,
             property: _GLOBAL_DESCRIPTION,
             value: description,
             link: 'https://stackoverflow.com/q/8914476/3263250',

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image-metadata-provider.ts
@@ -4,11 +4,9 @@ import {
   _maybeNonHttpUrlDevMessage,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
-import {
-  makeOpenGraphMetadataProvider,
-  OPEN_GRAPH_KEBAB_CASE_KEY,
-} from './make-open-graph-metadata-provider'
+import { makeOpenGraphMetadataProvider } from './make-open-graph-metadata-provider'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
+import { _MODULE_NAME } from './module-name'
 
 const NO_KEY_VALUE: OpenGraph[typeof _GLOBAL_IMAGE] = {
   url: undefined,
@@ -31,7 +29,7 @@ export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
     // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
       _maybeNonHttpUrlDevMessage(imageUrl, {
-        module: OPEN_GRAPH_KEBAB_CASE_KEY,
+        module: _MODULE_NAME,
         property: _GLOBAL_IMAGE,
         link: 'https://stackoverflow.com/a/9858694/3263250',
       })

--- a/projects/ngx-meta/src/routing/src/module-name.ts
+++ b/projects/ngx-meta/src/routing/src/module-name.ts
@@ -1,0 +1,1 @@
+export const _MODULE_NAME = 'routing'

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
@@ -25,7 +25,7 @@ describe('NgxMeta router listener service', () => {
   enableAutoSpy()
 
   describe('when not listening yet', () => {
-    // Though as probably injected in root module, may never be destroyed 🤷‍
+    // Though as probably injected in root module, may never be destroyed
     it('should subscribe to router events and unsubscribe when destroyed', () => {
       const events$ = new EventEmitter()
       const sut = makeSut({ events$ })
@@ -64,7 +64,7 @@ describe('NgxMeta router listener service', () => {
 
       it('should warn about it', () => {
         expect(console.warn).toHaveBeenCalledOnceWith(
-          jasmine.stringContaining('NgxMetaRouting'),
+          jasmine.stringContaining('twice'),
         )
       })
     })

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
@@ -6,9 +6,11 @@ import {
   NgxMetaRouteStrategy,
 } from './ngx-meta-route-strategy'
 import {
+  _formatDevMessage,
   _NgxMetaRouteValuesService,
   NgxMetaService,
 } from '@davidlj95/ngx-meta/core'
+import { _MODULE_NAME } from './module-name'
 
 // WTF is this? Why not just import `EventType`? Well, compatibility reasons 🙃
 // See https://github.com/davidlj95/ngx/pull/246 for the details
@@ -35,8 +37,13 @@ export class NgxMetaRouterListenerService implements OnDestroy {
     if (this.sub) {
       if (ngDevMode) {
         console.warn(
-          'NgxMetaRoutingModule was set to listen for route changes ' +
-            'twice. Ensure the NgxMetaRoutingModule is not imported twice',
+          _formatDevMessage(
+            [
+              'prevented listening for route changes twice',
+              'Ensure routing provider or module is only imported once',
+            ].join('\n'),
+            { module: _MODULE_NAME },
+          ),
         )
       }
       return
@@ -49,11 +56,13 @@ export class NgxMetaRouterListenerService implements OnDestroy {
           if (!this.strategy) {
             if (ngDevMode) {
               console.warn(
-                '`NgxMetaRoutingModule` tried to set metadata for this ' +
-                  'route but no metadata route strategy was found. ' +
-                  'Provide at least one `MetadataRouteStrategy` to be able ' +
-                  'to resolve metadata from a route and set it in order to ' +
-                  'fix this.',
+                _formatDevMessage(
+                  [
+                    'tried to set metadata for this route, but no metadata route strategy was found',
+                    'Provide at least one `MetadataRouteStrategy` to resolve metadata for a route',
+                  ].join('\n'),
+                  { module: _MODULE_NAME, value: this.router.url },
+                ),
               )
             }
             return

--- a/projects/ngx-meta/src/twitter-card/src/module-name.ts
+++ b/projects/ngx-meta/src/twitter-card/src/module-name.ts
@@ -1,0 +1,1 @@
+export const _MODULE_NAME = 'twitter-card'

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
@@ -1,13 +1,11 @@
-import {
-  makeTwitterCardMetadataProvider,
-  TWITTER_KEY_KEBAB_CASE,
-} from './make-twitter-card-metadata-provider'
+import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
 import {
   _GLOBAL_DESCRIPTION,
   _maybeTooLongDevMessage,
 } from '@davidlj95/ngx-meta/core'
 import { TwitterCard } from './twitter-card'
 import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
+import { _MODULE_NAME } from './module-name'
 
 /**
  * Manages the {@link TwitterCard.description} metadata
@@ -20,7 +18,7 @@ export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER =
       /* istanbul ignore next */
       if (ngDevMode) {
         _maybeTooLongDevMessage(description, 200, {
-          module: TWITTER_KEY_KEBAB_CASE,
+          module: _MODULE_NAME,
           property: _GLOBAL_DESCRIPTION,
           value: description,
           link: 'https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=n/a-,twitter%3Adescription,-Description%20of%20content',

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-image-metadata-provider.ts
@@ -1,7 +1,4 @@
-import {
-  makeTwitterCardMetadataProvider,
-  TWITTER_KEY_KEBAB_CASE,
-} from './make-twitter-card-metadata-provider'
+import { makeTwitterCardMetadataProvider } from './make-twitter-card-metadata-provider'
 import { makeTwitterCardMetaDefinition } from './make-twitter-card-meta-definition'
 import {
   _GLOBAL_IMAGE,
@@ -9,6 +6,7 @@ import {
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
 import { TwitterCard } from './twitter-card'
+import { _MODULE_NAME } from './module-name'
 
 /**
  * @internal
@@ -18,7 +16,7 @@ export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
     // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
       _maybeNonHttpUrlDevMessage(image?.url, {
-        module: TWITTER_KEY_KEBAB_CASE,
+        module: _MODULE_NAME,
         property: 'image',
         link: 'https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736',
       })


### PR DESCRIPTION
# Issue or need

In #747 a function was introduced to format dev messages to be output to the console. However there are places where dev messages are emitted that aren't using that formatter hence message formats may not be consistent

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use the dev message formatter around

Also introduce the convention of using a `MODULE_NAME` constant to define the module when printing messages. Applies that to Open Graph & Twitter Card modules

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
