### PR TITLE
Revert "build(deps): update python to v3.12.5"

### DIFF
--- a/projects/ngx-meta/docs/poetry.lock
+++ b/projects/ngx-meta/docs/poetry.lock
@@ -1082,5 +1082,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "==3.12.5"
-content-hash = "06f229f7f66570e55cd7c351361f9225e26d8718decfc8118527cf5ef22eefea"
+python-versions = "==3.12.4"
+content-hash = "b0bfc6e9a09e7ea413c3514f7386b46e345bba33b9bf7d9b52e742e47b59b60f"

--- a/projects/ngx-meta/docs/pyproject.toml
+++ b/projects/ngx-meta/docs/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "==3.12.5"
+python = "==3.12.4"
 mkdocs-autolinks-plugin = "0.7.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Issue or need

In #761, Python version used to build docs was upgraded to 3.12.5

However when merging, the docs job failed because that version isn't available to setup with the `actions/setup-python` action

https://github.com/actions/python-versions/tree/c8a840c66037fea727898f85582bd903c82b4c1b

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Revert the change until that version is published there or can upgrade to a version that is officially released and available to setup with GitHub Actions too

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
