### PR TITLE
feat: allow null Twitter Card creator or site

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -513,10 +513,10 @@ export const TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE = "summary_large_image";
 // @public
 export interface TwitterCard {
     readonly card?: TwitterCardType | null;
-    readonly creator?: TwitterCardCreator;
+    readonly creator?: TwitterCardCreator | null;
     readonly description?: string | null;
     readonly image?: TwitterCardImage | null;
-    readonly site?: TwitterCardSite;
+    readonly site?: TwitterCardSite | null;
     readonly title?: string | null;
 }
 

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-creator-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-creator-metadata-provider.ts
@@ -18,11 +18,11 @@ export const TWITTER_CARD_CREATOR_METADATA_PROVIDER =
     s: (metaService: NgxMetaMetaService) => (value) => {
       metaService.set(
         makeTwitterCardMetaDefinition(KEY),
-        (value as TwitterCardCreatorUsername | undefined)?.username,
+        (value as TwitterCardCreatorUsername | undefined | null)?.username,
       )
       metaService.set(
         makeTwitterCardMetaDefinition(KEY, 'id'),
-        (value as TwitterCardCreatorId | undefined)?.id,
+        (value as TwitterCardCreatorId | undefined | null)?.id,
       )
     },
   })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-site-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-site-metadata-provider.ts
@@ -14,11 +14,11 @@ export const TWITTER_CARD_SITE_METADATA_PROVIDER =
     s: (metaService) => (value) => {
       metaService.set(
         makeTwitterCardMetaDefinition(KEY),
-        (value as TwitterCardSiteUsername | undefined)?.username,
+        (value as TwitterCardSiteUsername | undefined | null)?.username,
       )
       metaService.set(
         makeTwitterCardMetaDefinition(KEY, 'id'),
-        (value as TwitterCardSiteId | undefined)?.id,
+        (value as TwitterCardSiteId | undefined | null)?.id,
       )
     },
   })

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card.ts
@@ -31,7 +31,7 @@ export interface TwitterCard {
    *
    * - {@link https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=twitter%3Asite%3Aid,-Same%20as%20twitter | Property specs (ID) }
    */
-  readonly site?: TwitterCardSite
+  readonly site?: TwitterCardSite | null
 
   /**
    * Username or ID of the content creator
@@ -40,7 +40,7 @@ export interface TwitterCard {
    *
    * - {@link https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=twitter%3Acreator%3Aid,-Twitter | Property specs (id) }
    */
-  readonly creator?: TwitterCardCreator
+  readonly creator?: TwitterCardCreator | null
 
   /**
    * Description of content (maximum 200 characters)


### PR DESCRIPTION
# Issue or need

If you set a default Twitter Card creator or site, then overriding that default to unset those metadata values is a bit tricky. 

You need to both set an object with the `id` and `username` properties set to `null` (to be sure that no metadata value is there, as default may have specified one, the other, or both properties):

```typescript
const overrideTwitterSite = { id: null, username: null } satisfies TwitterCard['site']
```

However it would be more convenient to just

```typescript
const overrideTwitterSite = null satisfies TwitterCard['site']
```


<!-- Describe here WHAT issue or need you're solving -->
Fixes #768

# Proposed changes

Allow `null` as value for Twitter Card site / creator metadata 

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
