### PR TITLE
docs: add link to supported metadata elements in features page

### DIFF
--- a/projects/ngx-meta/docs/content/why/features.md
+++ b/projects/ngx-meta/docs/content/why/features.md
@@ -27,7 +27,7 @@ Right now being Angular v16, v17 and v18. Update from an Angular version to anot
 
 ### 👥 Supports most of widely used metadata
 
-Like [`<title>`][title-element], many [standard `<meta>`s][standard meta tags], [Open Graph], [Twitter Cards] and JSON LD [structured data]. But if you want more...
+Like [`<title>`][title-element], many [standard `<meta>`s][standard meta tags], [Open Graph], [Twitter Cards] and JSON LD [structured data]. You can see an exhaustive list in [comparison page](comparison.md#by-specific-metadata-elements). But if you want more...
 
 [title-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 


### PR DESCRIPTION
# Issue or need

One may look for specifically supported metadata elements in features page. However that's in comparison page.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a link

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
