### PR TITLE
docs: add reminder about values setting in defaults guide

### DIFF
--- a/projects/ngx-meta/docs/content/guides/defaults.md
+++ b/projects/ngx-meta/docs/content/guides/defaults.md
@@ -4,6 +4,12 @@ If you want every page in your site to have some metadata values, a good option 
 
 This way, everytime you set your metadata values (either using the service or the route's data), if no value is provided for some metadata, default value will be used instead.
 
+??? info "Remember to either use the routing module or call the service"
+
+    As defaults are applied when setting metadata values. So if no metadata values are being set, no defaults will be applied.
+    Metadata values can be set [using the service](./set-metadata-using-service.md) or when navigating to a new route when
+    [using routing](./set-metadata-using-routing.md)
+
 ## Providing default values
 
 === "For non-standalone, module-based apps"


### PR DESCRIPTION
# Issue or need

When adding the library to one of my projects, found out that defaults were not being applied. Turns out neither routing module had been provided or `NgxMetaService.set` was called, so nothing happened.

<!-- Describe here WHAT issue or need you're solving -->
Fixes #776

# Proposed changes

Remember in defaults guide that a metadata values setting process must happen in order for defaults to be applied

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
