### PR TITLE
build: fix e2e cypress tests failing if no coverage

### DIFF
--- a/projects/ngx-meta/e2e/cypress/support/coverage.ts
+++ b/projects/ngx-meta/e2e/cypress/support/coverage.ts
@@ -1,4 +1,4 @@
-import { rename, rm } from 'fs/promises'
+import { access, rename, rm } from 'fs/promises'
 import { join } from 'path'
 import { loadNycConfig } from '@istanbuljs/load-nyc-config'
 
@@ -31,7 +31,6 @@ export async function renameJsonReport() {
     return
   }
 
-  console.info('Renaming JSON coverage report')
   const coverageDirectory = join(
     nycConfig.cwd,
     nycConfig.reportDir ?? DEFAULT_COVERAGE_DIR,
@@ -39,11 +38,26 @@ export async function renameJsonReport() {
   const jsonReportName =
     process.env['COVERAGE_JSON_REPORT_NAME'] ?? DEFAULT_RENAMED_JSON_REPORT_NAME
   const oldPath = join(coverageDirectory, DEFAULT_JSON_REPORT_NAME)
+  if (!(await _fileExists(oldPath))) {
+    console.info('No JSON coverage report exists. Skipping rename')
+    return
+  }
   const newPath = join(coverageDirectory, jsonReportName)
+
+  console.info('Renaming JSON coverage report')
   console.info(" Source:      '%s'", oldPath)
   console.info(" Destination: '%s'", newPath)
 
   await rename(oldPath, newPath)
+}
+
+const _fileExists = async (path: string) => {
+  try {
+    await access(path)
+  } catch {
+    return false
+  }
+  return true
 }
 
 const DEFAULT_COVERAGE_DIR = 'coverage'


### PR DESCRIPTION
# Issue or need

Cypress E2E tests fail when no coverage is reported. Given coverage report renamer util tries to move the report even it that one isn't generated.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Skip renaming coverage report if doesn't exist.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
