### PR TITLE
chore: rename unit test suites

### DIFF
--- a/projects/ngx-meta/src/core/src/format-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/format-dev-message.spec.ts
@@ -1,6 +1,6 @@
 import { _formatDevMessage } from './format-dev-message'
 
-describe('formatDevMessage', () => {
+describe('Developer message formatter', () => {
   const sut = _formatDevMessage
   const message = 'Hello World'
   const module = 'core'

--- a/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-non-http-url-dev-message.spec.ts
@@ -1,7 +1,7 @@
 import { _maybeNonHttpUrlDevMessage } from './maybe-non-http-url-dev-message'
 import { DUMMY_FORMAT_DEV_MESSAGE_OPTIONS } from './__tests__/dummy-format-dev-message-options'
 
-describe('maybeNonHttpUrlDevMessage', () => {
+describe('Maybe non HTTP URL developer message', () => {
   const sut = _maybeNonHttpUrlDevMessage
 
   beforeEach(() => {

--- a/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/maybe-too-long-dev-message.spec.ts
@@ -1,7 +1,7 @@
 import { _maybeTooLongDevMessage } from './maybe-too-long-dev-message'
 import { DUMMY_FORMAT_DEV_MESSAGE_OPTIONS } from './__tests__/dummy-format-dev-message-options'
 
-describe('maybeTooLongDevMessage', () => {
+describe('Maybe too long developer message', () => {
   const sut = _maybeTooLongDevMessage
 
   beforeEach(() => {

--- a/projects/ngx-meta/src/core/src/metadata-json-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-json-resolver.spec.ts
@@ -9,7 +9,7 @@ import {
   MetadataResolverOptions,
 } from './ngx-meta-metadata-manager'
 
-describe('Metadata JSON Resolver', () => {
+describe('Metadata JSON resolver', () => {
   let sut: MetadataJsonResolver
 
   beforeEach(() => {

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 import { NgxMetaCoreModule } from './ngx-meta-core.module'
 import { DEFAULTS_TOKEN } from './defaults-token'
 
-describe('NgxMetaCoreModule', () => {
+describe('Core module', () => {
   it('provides no defaults by default', () => {
     TestBed.configureTestingModule({ imports: [NgxMetaCoreModule.forRoot()] })
     expect(TestBed.inject(DEFAULTS_TOKEN, null, { optional: true })).toBeNull()

--- a/projects/ngx-meta/src/core/src/ngx-meta-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-meta.service.spec.ts
@@ -6,7 +6,7 @@ import { Meta } from '@angular/platform-browser'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { makeKeyValMetaDefinition } from './make-key-val-meta-definition'
 
-describe('NgxMeta meta service', () => {
+describe('Meta service', () => {
   enableAutoSpy()
 
   let sut: NgxMetaMetaService

--- a/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-route-values.service.spec.ts
@@ -5,7 +5,7 @@ import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MockProviders } from 'ng-mocks'
 import { Router } from '@angular/router'
 
-describe('NgxMeta route values service', () => {
+describe('Route values service', () => {
   enableAutoSpy()
   let sut: _NgxMetaRouteValuesService
   let router: jasmine.SpyObj<Router>

--- a/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta.service.spec.ts
@@ -6,7 +6,7 @@ import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { METADATA_RESOLVER, MetadataResolver } from './metadata-resolver'
 import { MetadataRegistry } from './metadata-registry'
 
-describe('NgxMeta service', () => {
+describe('Main service', () => {
   enableAutoSpy()
   let sut: NgxMetaService
   let metadataRegistry: jasmine.SpyObj<MetadataRegistry>

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
@@ -21,7 +21,7 @@ import {
   NgxMetaService,
 } from '@davidlj95/ngx-meta/core'
 
-describe('NgxMeta router listener service', () => {
+describe('Router listener service', () => {
   enableAutoSpy()
 
   describe('when not listening yet', () => {


### PR DESCRIPTION
# Issue or need

Some unit test suites use the specific code name for the system under test. For instance, `NgxMetaCoreModule` unit tests. However, most of tests use natural language. Hence less coupled to the implementation and more coupled to the actual functionality to be tested (hence more BDD).

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Look for unit tests whose suites (main `describe` block) use technical names. Replace them with natural language names.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
