### PR TITLE
feat: allow feature APIs in core module + deprecate options

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -13,6 +13,27 @@ import { ModuleWithProviders } from '@angular/core';
 import { Provider } from '@angular/core';
 import { Router } from '@angular/router';
 
+// Warning: (ae-forgotten-export) The symbol "__CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts
+//
+// @internal (undocumented)
+interface __CoreFeature<FeatureKind extends __CoreFeatureKind> {
+    // (undocumented)
+    _kind: FeatureKind;
+    // (undocumented)
+    _providers: Provider[];
+}
+
+// @internal
+const enum __CoreFeatureKind {
+    // (undocumented)
+    Defaults = 0
+}
+
+// Warning: (ae-forgotten-export) The symbol "__CoreFeature" needs to be exported by the entry point all-entry-points.d.ts
+//
+// @internal (undocumented)
+type __CoreFeatures = ReadonlyArray<__CoreFeature<__CoreFeatureKind>>;
+
 // @internal (undocumented)
 export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_FACTORY: (doc: Document) => (selector: string, element: HTMLElement | null | undefined) => void;
 
@@ -51,22 +72,6 @@ export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY: (metaService: NgxMeta
 
 // @internal (undocumented)
 export const _COMPOSED_KEY_VAL_META_DEFINITION_DEFAULT_SEPARATOR = ":";
-
-// Warning: (ae-forgotten-export) The symbol "CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts
-//
-// @internal (undocumented)
-interface CoreFeature<FeatureKind extends CoreFeatureKind = CoreFeatureKind> {
-    // (undocumented)
-    _kind: FeatureKind;
-    // (undocumented)
-    _providers: Provider[];
-}
-
-// @internal
-const enum CoreFeatureKind {
-    // (undocumented)
-    Defaults = 0
-}
 
 // @internal (undocumented)
 export const _formatDevMessage: (message: string, options: _FormatDevMessageOptions) => string;
@@ -210,9 +215,15 @@ export type MetadataValues = object;
 
 // @public
 export class NgxMetaCoreModule {
-    static forRoot(options?: {
-        defaults?: MetadataValues;
-    }): ModuleWithProviders<NgxMetaCoreModule>;
+    // Warning: (ae-forgotten-export) The symbol "__CoreFeatures" needs to be exported by the entry point all-entry-points.d.ts
+    static forRoot(...features: __CoreFeatures): ModuleWithProviders<NgxMetaCoreModule>;
+    // @deprecated
+    static forRoot(options: NgxMetaCoreModuleForRootOptions): ModuleWithProviders<NgxMetaCoreModule>;
+}
+
+// @public @deprecated
+export interface NgxMetaCoreModuleForRootOptions {
+    defaults?: MetadataValues;
 }
 
 // @public
@@ -408,10 +419,8 @@ export type OpenGraphProfileGender = typeof OPEN_GRAPH_PROFILE_GENDER_FEMALE | t
 // @public
 export type OpenGraphType = typeof OPEN_GRAPH_TYPE_MUSIC_SONG | typeof OPEN_GRAPH_TYPE_MUSIC_ALBUM | typeof OPEN_GRAPH_TYPE_MUSIC_PLAYLIST | typeof OPEN_GRAPH_TYPE_MUSIC_RADIO_STATION | typeof OPEN_GRAPH_TYPE_VIDEO_MOVIE | typeof OPEN_GRAPH_TYPE_VIDEO_EPISODE | typeof OPEN_GRAPH_TYPE_VIDEO_TV_SHOW | typeof OPEN_GRAPH_TYPE_VIDEO_OTHER | typeof OPEN_GRAPH_TYPE_ARTICLE | typeof OPEN_GRAPH_TYPE_BOOK | typeof OPEN_GRAPH_TYPE_PROFILE | typeof OPEN_GRAPH_TYPE_WEBSITE;
 
-// Warning: (ae-forgotten-export) The symbol "CoreFeature" needs to be exported by the entry point all-entry-points.d.ts
-//
 // @public
-export const provideNgxMetaCore: (...features: ReadonlyArray<CoreFeature>) => EnvironmentProviders;
+export const provideNgxMetaCore: (...features: __CoreFeatures) => EnvironmentProviders;
 
 // @public
 export const provideNgxMetaJsonLd: () => Provider[];
@@ -582,7 +591,7 @@ export type TwitterCardType = typeof TWITTER_CARD_TYPE_SUMMARY | typeof TWITTER_
 export const _VAL_ATTRIBUTE_CONTENT = "content";
 
 // @public
-export const withNgxMetaDefaults: (defaults: MetadataValues) => CoreFeature<CoreFeatureKind.Defaults>;
+export const withNgxMetaDefaults: (defaults: MetadataValues) => __CoreFeature<__CoreFeatureKind.Defaults>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/ngx-meta/docs/content/guides/defaults.md
+++ b/projects/ngx-meta/docs/content/guides/defaults.md
@@ -16,18 +16,20 @@ This way, everytime you set your metadata values (either using the service or th
 
     --8<-- "includes/module-apps-explanation.md"
 
-    Open your `app.module.ts` where [`NgxMetaCoreModule`](ngx-meta.ngxmetacoremodule.md) is imported. Provide your default values by calling [`NgxMetaCoreModule.forRoot`](ngx-meta.ngxmetacoremodule.forroot.md) with the options object.
+    Open your `app.module.ts` where [`NgxMetaCoreModule`](ngx-meta.ngxmetacoremodule.md) is imported.
+
+    Provide your default values by adding a call to [`withNgxMetaDefaults`](ngx-meta.withngxmetadefaults.md) with the default values to set.
 
     ```typescript title="app.module.ts"
     @NgModule({
       // ...
       imports: [
         // ...
-        NgxMetaCoreModule.forRoot({
-          defaults: {
+        NgxMetaCoreModule.forRoot(
+          withNgxMetaDefaults({
             description: "Awesome products made real ✨"
-          } satisfies GlobalMetadata
-        }),
+          } satisfies GlobalMetadata),
+        )
       ],
       // ...
     })
@@ -40,7 +42,9 @@ This way, everytime you set your metadata values (either using the service or th
 
     --8<-- "includes/standalone-apps-explanation.md"
 
-    Open your `app.config.ts` file where [`provideNgxMetaCore`](ngx-meta.providengxmetacore.md) is provided. Provide your default values by adding a call to [`withNgxMetaDefaults`](ngx-meta.withngxmetadefaults.md) with the default values to set.
+    Open your `app.config.ts` file where [`provideNgxMetaCore`](ngx-meta.providengxmetacore.md) is provided.
+
+    Provide your default values by adding a call to [`withNgxMetaDefaults`](ngx-meta.withngxmetadefaults.md) with the default values to set.
 
     ```typescript title="app.config.ts"
     export const appConfig: ApplicationConfig = {

--- a/projects/ngx-meta/example-apps/templates/module/src/app/app.module.template.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/app.module.template.ts
@@ -8,7 +8,10 @@ import { RouterOutlet } from '@angular/router'
 import { AllMetaSetByServiceComponent } from './all-meta-set-by-service/all-meta-set-by-service.component'
 import { AllMetaSetByRouteComponent } from './all-meta-set-by-route/all-meta-set-by-route.component'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
-import { NgxMetaCoreModule } from '@davidlj95/ngx-meta/core'
+import {
+  NgxMetaCoreModule,
+  withNgxMetaDefaults,
+} from '@davidlj95/ngx-meta/core'
 import DEFAULTS_JSON from '@/e2e/cypress/fixtures/defaults.json'
 import { NgxMetaRoutingModule } from '@davidlj95/ngx-meta/routing'
 import { NgxMetaStandardModule } from '@davidlj95/ngx-meta/standard'
@@ -34,7 +37,7 @@ import { OneMetaSetByServiceComponent } from './one-meta-set-by-service/one-meta
     NgForOf,
     RouterOutlet,
     JsonPipe,
-    NgxMetaCoreModule.forRoot({ defaults: DEFAULTS_JSON }),
+    NgxMetaCoreModule.forRoot(withNgxMetaDefaults(DEFAULTS_JSON)),
     NgxMetaRoutingModule.forRoot(),
     NgxMetaStandardModule,
     NgxMetaOpenGraphModule,

--- a/projects/ngx-meta/src/core/index.ts
+++ b/projects/ngx-meta/src/core/index.ts
@@ -3,6 +3,7 @@ export * from './src/ngx-meta-core.module'
 export * from './src/ngx-meta-metadata-loader.module'
 export * from './src/provide-ngx-meta-core'
 export * from './src/provide-ngx-meta-metadata-loader'
+export * from './src/with-ngx-meta-defaults'
 // Others
 export * from './src/global-metadata'
 export * from './src/global-metadata-image'

--- a/projects/ngx-meta/src/core/src/core-feature.ts
+++ b/projects/ngx-meta/src/core/src/core-feature.ts
@@ -1,0 +1,50 @@
+import { Provider } from '@angular/core'
+
+/**
+ * Inspired from Angular router
+ *
+ * https://github.com/angular/angular/blob/17.0.7/packages/router/src/provide_router.ts#L80-L96
+ * @internal
+ */
+export const enum __CoreFeatureKind {
+  Defaults,
+}
+
+/**
+ * @internal
+ */
+export interface __CoreFeature<FeatureKind extends __CoreFeatureKind> {
+  _kind: FeatureKind
+  _providers: Provider[]
+}
+
+/**
+ * @internal
+ */
+export const __coreFeature = <FeatureKind extends __CoreFeatureKind>(
+  kind: FeatureKind,
+  providers: Provider[],
+): __CoreFeature<FeatureKind> => ({
+  _kind: kind,
+  _providers: providers,
+})
+
+/**
+ * @internal
+ */
+export const isCoreFeature = (
+  anObject: object,
+): anObject is __CoreFeature<__CoreFeatureKind> =>
+  ('_providers' satisfies keyof __CoreFeature<__CoreFeatureKind>) in anObject
+
+/**
+ * @internal
+ */
+export type __CoreFeatures = ReadonlyArray<__CoreFeature<__CoreFeatureKind>>
+
+/**
+ * @internal
+ */
+export const __providersFromCoreFeatures = (
+  features: __CoreFeatures,
+): ReadonlyArray<Provider> => features.map((f) => f._providers)

--- a/projects/ngx-meta/src/core/src/defaults-token.ts
+++ b/projects/ngx-meta/src/core/src/defaults-token.ts
@@ -1,6 +1,9 @@
-import { InjectionToken } from '@angular/core'
+import { inject, InjectionToken } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 
 export const DEFAULTS_TOKEN = new InjectionToken<MetadataValues>(
   ngDevMode ? 'NgxMeta Metadata defaults' : 'NgxMetaDefs',
 )
+
+export const injectDefaults = (): MetadataValues | null =>
+  inject(DEFAULTS_TOKEN, { optional: true })

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
@@ -1,27 +1,37 @@
 import { TestBed } from '@angular/core/testing'
 import { NgxMetaCoreModule } from './ngx-meta-core.module'
-import { DEFAULTS_TOKEN } from './defaults-token'
+import { injectDefaults } from './defaults-token'
 import { ModuleWithProviders } from '@angular/core'
-import { GlobalMetadata } from '@davidlj95/ngx-meta/core'
+import { GlobalMetadata } from './global-metadata'
+import { withNgxMetaDefaults } from './with-ngx-meta-defaults'
 
 describe('Core module', () => {
+  const defaults: GlobalMetadata = { title: 'Hello World!' }
+
   it('provides no defaults by default', () => {
     makeSut(NgxMetaCoreModule.forRoot())
-    expect(TestBed.inject(DEFAULTS_TOKEN, null, { optional: true })).toBeNull()
+
+    expect(injectDefaultsForTesting()).toBeNull()
   })
 
   it('provides no defaults if options object is empty', () => {
+    // noinspection JSDeprecatedSymbols
     makeSut(NgxMetaCoreModule.forRoot({}))
-    expect(TestBed.inject(DEFAULTS_TOKEN, null, { optional: true })).toBeNull()
+
+    expect(injectDefaultsForTesting()).toBeNull()
   })
 
   it('provides defaults if specified as options object', () => {
-    const defaults: GlobalMetadata = { title: 'Hello World!' }
+    // noinspection JSDeprecatedSymbols
     makeSut(NgxMetaCoreModule.forRoot({ defaults }))
 
-    expect(TestBed.inject(DEFAULTS_TOKEN, null, { optional: true })).toEqual(
-      defaults,
-    )
+    expect(injectDefaultsForTesting()).toEqual(defaults)
+  })
+
+  it('accepts features from provider APIs, like defaults', () => {
+    makeSut(NgxMetaCoreModule.forRoot(withNgxMetaDefaults(defaults)))
+
+    expect(injectDefaultsForTesting()).toEqual(defaults)
   })
 })
 
@@ -30,3 +40,6 @@ const makeSut = (
 ) => {
   TestBed.configureTestingModule({ imports: [moduleWithProviders] })
 }
+
+const injectDefaultsForTesting = (): ReturnType<typeof injectDefaults> =>
+  TestBed.runInInjectionContext(injectDefaults)

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
@@ -1,45 +1,112 @@
 import { ModuleWithProviders, NgModule } from '@angular/core'
 import { MetadataValues } from './metadata-values'
-import { withNgxMetaDefaults } from './provide-ngx-meta-core'
 import { CORE_PROVIDERS } from './core-providers'
+import { withNgxMetaDefaults } from './with-ngx-meta-defaults'
+import {
+  __CoreFeature,
+  __CoreFeatureKind,
+  __CoreFeatures,
+  __providersFromCoreFeatures,
+  isCoreFeature,
+} from './core-feature'
 
 /**
- * Adds core providers of `ngx-meta` to the application.
- * Must use {@link NgxMetaCoreModule.forRoot} method.
+ * Provides `ngx-meta`'s core library services.
  *
- * For standalone apps, use {@link provideNgxMetaCore} instead
+ * Use {@link NgxMetaCoreModule.(forRoot:1)} method. Importing the module alone does nothing.
+ *
+ * For standalone apps, use {@link provideNgxMetaCore} instead.
  *
  * @public
  */
 @NgModule()
 export class NgxMetaCoreModule {
   /**
-   * Provides the core library services
+   * Provides `ngx-meta`'s core library services.
    *
-   * Allows specifying some default metadata values
+   * Accepts optional features configuration. See examples for more info.
+   *
+   * Previous configuration of features with an options object has been deprecated.
+   * See {@link NgxMetaCoreModule.(forRoot:2)} for more information and how to migrate
    *
    * @example
+   * Default metadata values can be set up.
    *
-   * You can set some defaults using the `options` argument
+   * ```typescript
+   * NgxMetaCoreModule.forRoot(withNgxMetaDefaults({title: 'Default title'})
+   * ```
+   *
+   * @see {@link withNgxMetaDefaults}
+   * @see {@link https://ngx-meta.dev/guides/defaults/}
+   *
+   * @param features - Features to configure the core module with
+   */
+  static forRoot(
+    ...features: __CoreFeatures
+  ): ModuleWithProviders<NgxMetaCoreModule>
+
+  /**
+   * Deprecated way of configuring the core module features.
+   *
+   * This way of configuring options doesn't allow tree shaking unneeded features.
+   * So usage is discouraged and deprecated.
+   * See deprecation notice for the tree-shaking friendly alternative
+   *
+   * Checkout the method signature examples for an example on how to migrate to the recommended way
+   *
+   * @deprecated Use {@link NgxMetaCoreModule.(forRoot:1)} with feature APIs as arguments instead.
+   *
+   * @example
    * ```typescript
    * NgxMetaCoreModule.forRoot({defaults: {title: 'Default title'}})
    * ```
    *
-   * @param options - Allows providing some default metadata values using `defaults`
+   * should be migrated to
+   *
+   * ```typescript
+   * NgxMetaCoreModule.forRoot(withNgxMetaDefaults({title: 'Default title'}))
+   * ```
    */
+  // noinspection JSDeprecatedSymbols
   static forRoot(
-    options: {
-      defaults?: MetadataValues
-    } = {},
+    options: NgxMetaCoreModuleForRootOptions,
+  ): ModuleWithProviders<NgxMetaCoreModule>
+
+  // noinspection JSDeprecatedSymbols
+  static forRoot(
+    optionsOrFeature:
+      | NgxMetaCoreModuleForRootOptions
+      | __CoreFeature<__CoreFeatureKind> = {},
+    ...features: __CoreFeatures
   ): ModuleWithProviders<NgxMetaCoreModule> {
+    const optionFeaturesOrFirstFeature = isCoreFeature(optionsOrFeature)
+      ? [optionsOrFeature]
+      : optionsOrFeature.defaults
+        ? [withNgxMetaDefaults(optionsOrFeature.defaults)]
+        : []
     return {
       ngModule: NgxMetaCoreModule,
       providers: [
         ...CORE_PROVIDERS,
-        ...(options.defaults !== undefined
-          ? withNgxMetaDefaults(options.defaults)._providers
-          : []),
+        ...__providersFromCoreFeatures([
+          ...optionFeaturesOrFirstFeature,
+          ...features,
+        ]),
       ],
     }
   }
+}
+
+/**
+ * Configuration options for {@link NgxMetaCoreModule.(forRoot:2)}
+ *
+ * @deprecated Use {@link NgxMetaCoreModule.(forRoot:1)} with feature APIs as arguments instead.
+ *             See {@link NgxMetaCoreModule.(forRoot:2)} for a migration example
+ * @public
+ */
+export interface NgxMetaCoreModuleForRootOptions {
+  /**
+   * See {@link withNgxMetaDefaults}
+   */
+  defaults?: MetadataValues
 }

--- a/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
@@ -1,21 +1,16 @@
-import {
-  EnvironmentProviders,
-  makeEnvironmentProviders,
-  Provider,
-} from '@angular/core'
-import { MetadataValues } from './metadata-values'
-import { DEFAULTS_TOKEN } from './defaults-token'
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core'
+import { __CoreFeatures, __providersFromCoreFeatures } from './core-feature'
 import { CORE_PROVIDERS } from './core-providers'
 
 /**
  * Adds core services of the library to the application.
  *
- * For module-based apps, use {@link NgxMetaCoreModule.forRoot} instead
+ * For module-based apps, you may use {@link NgxMetaCoreModule.(forRoot:1)} instead.
  *
- * Allows specifying some default metadata values. Keep reading.
+ * Configures also extra features. Keep reading to see some examples.
  *
  * @example
- * To specify some default metadata values, use {@link withNgxMetaDefaults}
+ * Default metadata values can be set up with {@link withNgxMetaDefaults}.
  *
  * ```typescript
  * provideNgxMetaCore(
@@ -23,58 +18,17 @@ import { CORE_PROVIDERS } from './core-providers'
  * )
  * ```
  *
- * @param features - Features to configure the core with. Currently just {@link withNgxMetaDefaults} available
+ * @see {@link withNgxMetaDefaults}
+ * @see {@link https://ngx-meta.dev/guides/defaults/ | Defaults guide}
+ *
+ * @param features - Features to configure
  *
  * @public
  */
 export const provideNgxMetaCore = (
-  ...features: ReadonlyArray<CoreFeature>
+  ...features: __CoreFeatures
 ): EnvironmentProviders =>
   makeEnvironmentProviders([
     ...CORE_PROVIDERS,
-    ...features.map((feature) => feature._providers),
-  ])
-
-/**
- * Inspired from Angular's router
- *
- * https://github.com/angular/angular/blob/17.0.7/packages/router/src/provide_router.ts#L80-L96
- * @internal
- */
-const enum CoreFeatureKind {
-  Defaults,
-}
-
-/**
- * @internal
- */
-interface CoreFeature<FeatureKind extends CoreFeatureKind = CoreFeatureKind> {
-  _kind: FeatureKind
-  _providers: Provider[]
-}
-
-const coreFeature = <FeatureKind extends CoreFeatureKind>(
-  kind: FeatureKind,
-  providers: Provider[],
-): CoreFeature<FeatureKind> => ({
-  _kind: kind,
-  _providers: providers,
-})
-
-/**
- * Allows to configure default metadata values.
- *
- * Use it as part of {@link provideNgxMetaCore}
- *
- * For module-based apps, check out {@link NgxMetaCoreModule.forRoot}
- *
- * @param defaults - Default metadata values to use
- *
- * @public
- */
-export const withNgxMetaDefaults = (
-  defaults: MetadataValues,
-): CoreFeature<CoreFeatureKind.Defaults> =>
-  coreFeature(CoreFeatureKind.Defaults, [
-    { provide: DEFAULTS_TOKEN, useValue: defaults },
+    ...__providersFromCoreFeatures(features),
   ])

--- a/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
+++ b/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
@@ -1,0 +1,28 @@
+import { MetadataValues } from './metadata-values'
+import { __coreFeature, __CoreFeature, __CoreFeatureKind } from './core-feature'
+import { DEFAULTS_TOKEN } from './defaults-token'
+
+/**
+ * Sets up default metadata values.
+ *
+ * When setting metadata values for a page, default values will be used as
+ * fallback when a metadata value isn't specified.
+ *
+ * See also:
+ *
+ * - {@link provideNgxMetaCore} to use it with standalone APIs
+ *
+ * - {@link NgxMetaCoreModule.(forRoot:1)} to use it with module based APIs
+ *
+ * - Defaults guide in {@link https://ngx-meta.dev/guides/defaults/}
+ *
+ * @param defaults - Default metadata values to use
+ *
+ * @public
+ */
+export const withNgxMetaDefaults = (
+  defaults: MetadataValues,
+): __CoreFeature<__CoreFeatureKind.Defaults> =>
+  __coreFeature(__CoreFeatureKind.Defaults, [
+    { provide: DEFAULTS_TOKEN, useValue: defaults },
+  ])


### PR DESCRIPTION
# Issue or need

Whilst working in #798, found out that current Angular module APIs to set up the core module do not allow tree shaking of features\*. Whilst provider-based APIs do.

> \* because when doing `options.x ? withFeatureX() : undefined`, that isn't tree shakeable because `options.x` is difficult to tree shake.
> However, using `withFeatureX` or not is easily tree shakeable

For now, it was not very worrying as the only feature on`withNgxMetaDefaults` didn't bring much code with it, so it's not a huge deal to have it always there.

However with #798 we're starting to add hundreds of not tree shakeable bytes. Let's therefore push for tree-shakeable APIs before introducing heavy features that won't be tree shaked.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Allow `NgxMetaCoreModule.forRoot` to accept feature provider APIs in the same way `provideNgxMetaCore` does

Update documentation & example apps to use new syntax

Deprecate using an options object. But leave it there for backwards compatibility. Don't want to bother users with breaking changes!

## Extra changes:
 - Introduce helper to extract provider from core features. So same can be used for provider/standalone & module APIs
 - Extract core feature into its own file. Export them privately to be used by both provider/standalone & module APIs
 - Add a [custom inject function (CIF)](https://nartc.me/blog/inject-function-the-right-way/) to reduce duplicated code injecting defaults. This will also be useful if refactoring to use `factory` of `InjectionToken` to avoid having to declare a provider for each injection token if the token can include the factory itself. When doing so, the `DEFAULTS_TOKEN` dependency may be injected with `injectDefaults` for better type safety. Though it's internal use in that case, it's a better pattern overall in case the API is publicly exported in the feature.
 - Update defaults docs with #798 changes
 - Add `__CoreFeatures` utility type

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
