### PR TITLE
build: move files for format ignore to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,7 +375,22 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/angular,vim,visualstudiocode,node,webstorm+iml,macos,linux,windows
 .npmrc
 .idea/git_toolbox_blame.xml
+projects/ngx-meta/example-apps/apps
+projects/ngx-meta/docs/includes/CHANGELOG.md
+projects/ngx-meta/docs/includes/README.md
+projects/ngx-meta/docs/content/api
+projects/ngx-meta/docs/includes/bundle-size
+projects/ngx-meta/api-extractor/temp
+projects/ngx-meta/api-extractor/*.api.json
 # Manual edits
+#
+#   Notice this file will also be read by Prettier to ignore files for formatting
+#   So if some files must be excluded for formatting, including them here is a good idea:w
+#   https://prettier.io/docs/en/ignore.html
+#
 # - Comment `.idea` in Angular to include IDE configs
 # - Add `.npmrc` to set registry to simulate releases, but avoid committing that
 # - Add Git Toolbox plugin blame config
+# - Add generated example apps
+# - Add generated docs
+# - Add API Extractor temp files

--- a/projects/ngx-meta/api-extractor/.gitignore
+++ b/projects/ngx-meta/api-extractor/.gitignore
@@ -1,4 +1,0 @@
-# API Extractor temp dir
-temp/
-# JSON docs file
-*.api.json

--- a/projects/ngx-meta/bundle-size/.gitignore
+++ b/projects/ngx-meta/bundle-size/.gitignore
@@ -1,3 +1,0 @@
-out/
-# Manual edits
-# - Output files directory

--- a/projects/ngx-meta/docs/.gitignore
+++ b/projects/ngx-meta/docs/.gitignore
@@ -176,7 +176,3 @@ pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 content/fonts
-includes/CHANGELOG.md
-includes/README.md
-content/api
-includes/bundle-size

--- a/projects/ngx-meta/example-apps/.gitignore
+++ b/projects/ngx-meta/example-apps/.gitignore
@@ -1,3 +1,0 @@
-apps/
-src/**/*.js
-src/**/*.js.map


### PR DESCRIPTION
# Issue or need

Running format check locally reported some files missing formatting. However nothing happened on CI. Smells like some files aren't ignored properly for formatting. Though given they're Git ignored they aren't taken into account in CI/CD as they're not there in the formatting job.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Move file patterns to ignore for formatting to global `.gitignore`. Given [that's the only file Prettier takes into account apart from `.prettierignore`](https://prettier.io/docs/en/ignore). 

So those files are ignored by Git and Prettier at same time.

Remove empty `.gitignore` files

Add notice about this to `.gitignore`

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
