### PR TITLE
docs: remove @see usages & use display name syntax

### DIFF
--- a/projects/ngx-meta/e2e/cypress/support/commands.ts
+++ b/projects/ngx-meta/e2e/cypress/support/commands.ts
@@ -81,7 +81,7 @@ const HTML_SCRIPTS_BUT_JSON_LD = new RegExp(
  *
  * Does not remove JSON-LD metadata scripts
  *
- * @see Inspired from {@link https://blog.simonireilly.com/posts/server-side-rendering-tests-in-cypress/}
+ * Inspired from {@link https://blog.simonireilly.com/posts/server-side-rendering-tests-in-cypress/}
  */
 Cypress.Commands.add<'simulateSSRForRequest'>(
   'simulateSSRForRequest',

--- a/projects/ngx-meta/example-apps/src/add-imports-from-template-into-source-file.ts
+++ b/projects/ngx-meta/example-apps/src/add-imports-from-template-into-source-file.ts
@@ -18,7 +18,7 @@ type DeclarationsByModuleSpecifier = Map<
  * from same module specifier
  *
  * This may give issues, as merging declarations imports is not always possible
- * @see {@link mergeImportDeclarations}
+ * {@link mergeImportDeclarations}
  *
  * Then creates the merged declarations list by merging existing imports from
  * {@link destination} source file with merged {@link template} imports

--- a/projects/ngx-meta/src/core/src/global-metadata.ts
+++ b/projects/ngx-meta/src/core/src/global-metadata.ts
@@ -49,7 +49,7 @@ export interface GlobalMetadata {
   /**
    * Sets localization of this page
    *
-   * Value must be a valid language tag complying with BCP 47
+   * Value must be a valid language tag complying with BCP 47.
    * For instance: "`es`" or "`es-ES`"
    *
    * For:
@@ -58,7 +58,11 @@ export interface GlobalMetadata {
    *
    *  - {@link OpenGraph.locale} (needs Open Graph module)
    *
-   * @see {@link https://datatracker.ietf.org/doc/html/rfc5646 | RFC 5646/BCP 47}
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://datatracker.ietf.org/doc/html/rfc5646 | RFC 5646 / BCP 47}
    */
   readonly locale?: string | null
 

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
@@ -36,8 +36,11 @@ export class NgxMetaCoreModule {
    * NgxMetaCoreModule.forRoot(withNgxMetaDefaults({title: 'Default title'})
    * ```
    *
-   * @see {@link withNgxMetaDefaults}
-   * @see {@link https://ngx-meta.dev/guides/defaults/}
+   * See also:
+   *
+   *  - {@link withNgxMetaDefaults}
+   *
+   *  - {@link https://ngx-meta.dev/guides/defaults/ | Defaults guide}
    *
    * @param features - Features to configure the core module with
    */

--- a/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
@@ -18,8 +18,11 @@ import { CORE_PROVIDERS } from './core-providers'
  * )
  * ```
  *
- * @see {@link withNgxMetaDefaults}
- * @see {@link https://ngx-meta.dev/guides/defaults/ | Defaults guide}
+ * See also:
+ *
+ * - {@link withNgxMetaDefaults}
+ *
+ * - {@link https://ngx-meta.dev/guides/defaults/ | Defaults guide}
  *
  * @param features - Features to configure
  *

--- a/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
+++ b/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
@@ -14,7 +14,7 @@ import { DEFAULTS_TOKEN } from './defaults-token'
  *
  * - {@link NgxMetaCoreModule.(forRoot:1)} to use it with module based APIs
  *
- * - Defaults guide in {@link https://ngx-meta.dev/guides/defaults/}
+ * - {@link https://ngx-meta.dev/guides/defaults/ | Defaults guide}
  *
  * @param defaults - Default metadata values to use
  *

--- a/projects/ngx-meta/src/open-graph/src/open-graph-image.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-image.ts
@@ -8,7 +8,11 @@ export interface OpenGraphImage {
    *
    * Can be unset to use image from global metadata
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Aurl
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Aurl | Property specs}
    */
   readonly url?: URL | string
 
@@ -18,35 +22,55 @@ export interface OpenGraphImage {
    *
    * Can be unset to use image from global metadata
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Aalt
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Aalt | Property specs}
    */
   readonly alt?: string
 
   /**
    * An alternate url to use if the webpage requires HTTPS.
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Asecure_url
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Asecure_url | Property specs}
    */
   readonly secureUrl?: URL | string | null
 
   /**
    * A MIME type for this image.
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Atype
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Atype | Property specs}
    */
   readonly type?: string | null
 
   /**
    * The number of pixels wide.
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Awidth
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Awidth | Property specs}
    */
   readonly width?: number | null
 
   /**
    * The number of pixels high.
    *
-   * @see https://ogp.me/#structured:~:text=og%3Aimage%3Aheight
+   * @remarks
+   *
+   * See also:
+   *
+   * - {@link https://ogp.me/#structured:~:text=og%3Aimage%3Aheight | Property specs}
    */
   readonly height?: number | null
 }


### PR DESCRIPTION
# Issue or need

After writing some docs, realized that there are some `@see` TSDoc syntax usages around. However [that's not officially supported by API Extractor](https://api-extractor.com/pages/tsdoc/doc_comment_syntax/).

So what ends up happening is that those blocks do not appear in the online docs after API Documenter runs.

Also, in previous PRs started removing `@link` references with display texts because it looked weird in WebStorm:

![image](https://github.com/user-attachments/assets/adc42e2e-5e73-4d5c-9338-bf8e095c99c8)


> Notice the `| ` prefix. Tried to remove that to see if it works, but then it's invalid syntax for API Documenter & WebStorm

But it works anyway (clicking goes to the expected link). And it's shown as expected when processing with API Documenter.


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Replace `@see` usages with `See also` blocks

Add display text references back

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
