### PR TITLE
refactor: provide head element mgr with root factory

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -34,12 +34,6 @@ const enum __CoreFeatureKind {
 // @internal (undocumented)
 type __CoreFeatures = ReadonlyArray<__CoreFeature<__CoreFeatureKind>>;
 
-// @internal (undocumented)
-export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_FACTORY: (doc: Document) => (selector: string, element: HTMLElement | null | undefined) => void;
-
-// @internal (undocumented)
-export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER: FactoryProvider;
-
 // Warning: (ae-forgotten-export) The symbol "_JSON_LD_KEY" needs to be exported by the entry point all-entry-points.d.ts
 //
 // @internal (undocumented)

--- a/projects/ngx-meta/src/core/src/core-providers.ts
+++ b/projects/ngx-meta/src/core/src/core-providers.ts
@@ -1,9 +1,4 @@
-import { __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER } from './head-element-upsert-or-remove'
 import { METADATA_RESOLVER_PROVIDER } from './metadata-resolver'
 import { MetadataRegistry } from './metadata-registry'
 
-export const CORE_PROVIDERS = [
-  __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER,
-  METADATA_RESOLVER_PROVIDER,
-  MetadataRegistry,
-]
+export const CORE_PROVIDERS = [METADATA_RESOLVER_PROVIDER, MetadataRegistry]

--- a/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.spec.ts
@@ -3,7 +3,6 @@ import { TestBed } from '@angular/core/testing'
 import { HeadElementHarness } from './__tests__/head-element-harness'
 import { DOCUMENT } from '@angular/common'
 import {
-  __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER,
   _HEAD_ELEMENT_UPSERT_OR_REMOVE,
   _HeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'
@@ -95,8 +94,6 @@ describe('Head element upsert or remove', () => {
 })
 
 function makeSut() {
-  TestBed.configureTestingModule({
-    providers: [__HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER],
-  })
+  TestBed.configureTestingModule({})
   return TestBed.inject(_HEAD_ELEMENT_UPSERT_OR_REMOVE)
 }

--- a/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.ts
+++ b/projects/ngx-meta/src/core/src/head-element-upsert-or-remove.ts
@@ -1,22 +1,29 @@
-import { FactoryProvider, InjectionToken } from '@angular/core'
+import { inject, InjectionToken } from '@angular/core'
 import { DOCUMENT } from '@angular/common'
 
 /**
  * @internal
  */
-export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_FACTORY =
-  (doc: Document) =>
-  (selector: string, element: HTMLElement | null | undefined) => {
-    const existingScriptElement = doc.head.querySelector(selector)
-    if (existingScriptElement) {
-      doc.head.removeChild(existingScriptElement)
-    }
+export const _HEAD_ELEMENT_UPSERT_OR_REMOVE =
+  new InjectionToken<_HeadElementUpsertOrRemove>(
+    ngDevMode ? 'NgxMeta head element upsert or remove util' : 'NgxMetaHEUOR',
+    {
+      factory: () => {
+        const head = inject(DOCUMENT).head
+        return (selector: string, element: HTMLElement | null | undefined) => {
+          const existingScriptElement = head.querySelector(selector)
+          if (existingScriptElement) {
+            head.removeChild(existingScriptElement)
+          }
 
-    if (element === null || element === undefined) {
-      return
-    }
-    doc.head.appendChild(element)
-  }
+          if (element === null || element === undefined) {
+            return
+          }
+          head.appendChild(element)
+        }
+      },
+    },
+  )
 
 /**
  * @internal
@@ -25,19 +32,3 @@ export type _HeadElementUpsertOrRemove = (
   selector: string,
   element: HTMLElement | null | undefined,
 ) => void
-
-/**
- * @internal
- */
-export const _HEAD_ELEMENT_UPSERT_OR_REMOVE =
-  new InjectionToken<_HeadElementUpsertOrRemove>(
-    ngDevMode ? 'NgxMeta head element upsert or remove util' : 'NgxMetaHEUOR',
-  )
-/**
- * @internal
- */
-export const __HEAD_ELEMENT_UPSERT_OR_REMOVE_PROVIDER: FactoryProvider = {
-  provide: _HEAD_ELEMENT_UPSERT_OR_REMOVE,
-  useFactory: __HEAD_ELEMENT_UPSERT_OR_REMOVE_FACTORY,
-  deps: [DOCUMENT],
-}


### PR DESCRIPTION
# Issue or need

This is the first of a series of PRs regarding the same topic.

Some time ago, started to use injection tokens to save some bytes here and there. As an injection token providing a function is way ligther than an `@Injectable` service.

To do so, thought that the only way to inject dependencies when using injection tokens was by using a `FactoryProvider` and specifying some `deps`

However seems we can use the `inject` function inside the `new InjectionToken`'s `factory` option in second argument object. By doing so, there's no need to specify the provider apart.

> It's safe to use the `inject` function around. It has been there [since version 6](https://v6.angular.io/api/core/inject). Though bear in mind that injection options (optional, skip self, ...) were first specified as binary flags. Then in v14 flags were deprecated and the new way is an options object with booleans. But v14 is not supported officially anyway so we can use it with options object without any issues.

This allows to have less code around (no need to specify provider anymore). Plus we avoid forgetting to provide the factory for an injection token by mistake. As the injection token implementation contains both the injection token and the factory to inject it.

The only caveat: if in the future we want users to be able to customize the injectable piece of code, we'll need to split again the token from the provision. But til that happens, this is better.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use injection token factory + `inject` function for head element upsert or remove util. Remove unneeded provider.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
