### PR TITLE
refactor: remove lib prefix from route values service

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -264,15 +264,6 @@ export interface NgxMetaRouteData<Metadata = MetadataValues> {
     meta: Metadata;
 }
 
-// @internal (undocumented)
-export class _NgxMetaRouteValuesService {
-    constructor(router: Router);
-    // (undocumented)
-    get(): MetadataValues;
-    // (undocumented)
-    set(values: MetadataValues | undefined): void;
-}
-
 // @public
 export class NgxMetaRoutingModule {
     // (undocumented)
@@ -436,6 +427,15 @@ export const provideNgxMetaStandard: () => Provider[];
 
 // @public
 export const provideNgxMetaTwitterCard: () => Provider[];
+
+// @internal (undocumented)
+export class _RouteValuesService {
+    constructor(router: Router);
+    // (undocumented)
+    get(): MetadataValues;
+    // (undocumented)
+    set(values: MetadataValues | undefined): void;
+}
 
 // @public
 export interface Standard {

--- a/projects/ngx-meta/src/core/index.ts
+++ b/projects/ngx-meta/src/core/index.ts
@@ -15,7 +15,7 @@ export * from './src/ngx-meta-meta.service'
 export * from './src/ngx-meta-metadata-manager'
 export * from './src/metadata-values'
 export * from './src/ngx-meta.service'
-export * from './src/ngx-meta-route-values.service'
+export * from './src/route-values.service'
 // Internal utils
 export * from './src/format-dev-message'
 export * from './src/maybe-non-http-url-dev-message'

--- a/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 
 import { MockProvider, MockProviders } from 'ng-mocks'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
-import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
+import { _RouteValuesService } from './route-values.service'
 import { MetadataValues } from './metadata-values'
 import { Provider } from '@angular/core'
 import { DEFAULTS_TOKEN } from './defaults-token'
@@ -28,7 +28,7 @@ describe('Metadata resolver', () => {
   const VALUE = 'value'
   const DUMMY_ROUTE_VALUES = { route: 'values' }
   let jsonResolver: jasmine.Spy<MetadataJsonResolver>
-  let routeMetadataValues: jasmine.SpyObj<_NgxMetaRouteValuesService>
+  let routeMetadataValues: jasmine.SpyObj<_RouteValuesService>
   let sut: MetadataResolver
 
   function mockJsonResolver(returnMap: Map<MetadataValues, unknown>) {
@@ -41,8 +41,8 @@ describe('Metadata resolver', () => {
       METADATA_JSON_RESOLVER,
     ) as jasmine.Spy<MetadataJsonResolver>
     routeMetadataValues = TestBed.inject(
-      _NgxMetaRouteValuesService,
-    ) as jasmine.SpyObj<_NgxMetaRouteValuesService>
+      _RouteValuesService,
+    ) as jasmine.SpyObj<_RouteValuesService>
   }
 
   describe('when value exists in provided values', () => {
@@ -192,7 +192,7 @@ describe('Metadata resolver', () => {
 function makeSut(opts: { defaults?: MetadataValues } = {}): MetadataResolver {
   const providers: Provider[] = [
     METADATA_RESOLVER_PROVIDER,
-    MockProviders(_NgxMetaRouteValuesService),
+    MockProviders(_RouteValuesService),
     MockProvider(
       METADATA_JSON_RESOLVER,
       jasmine.createSpy('Metadata JSON resolver'),

--- a/projects/ngx-meta/src/core/src/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.ts
@@ -1,6 +1,6 @@
 import { FactoryProvider, InjectionToken, Optional } from '@angular/core'
 import { MetadataValues } from './metadata-values'
-import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
+import { _RouteValuesService } from './route-values.service'
 import { DEFAULTS_TOKEN } from './defaults-token'
 import {
   METADATA_JSON_RESOLVER,
@@ -25,7 +25,7 @@ export const METADATA_RESOLVER_FACTORY: (
 ) => MetadataResolver =
   (
     jsonResolver: MetadataJsonResolver,
-    routeMetadataValues: _NgxMetaRouteValuesService | null,
+    routeMetadataValues: _RouteValuesService | null,
     defaults: MetadataValues | null,
   ) =>
   (values, resolverOptions) => {
@@ -50,7 +50,7 @@ export const METADATA_RESOLVER_PROVIDER: FactoryProvider = {
   useFactory: METADATA_RESOLVER_FACTORY,
   deps: [
     METADATA_JSON_RESOLVER,
-    [_NgxMetaRouteValuesService, new Optional()],
+    [_RouteValuesService, new Optional()],
     [DEFAULTS_TOKEN, new Optional()],
   ],
 }

--- a/projects/ngx-meta/src/core/src/route-values.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/route-values.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 
-import { _NgxMetaRouteValuesService } from './ngx-meta-route-values.service'
+import { _RouteValuesService } from './route-values.service'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MockProviders } from 'ng-mocks'
 import { Router } from '@angular/router'
 
 describe('Route values service', () => {
   enableAutoSpy()
-  let sut: _NgxMetaRouteValuesService
+  let sut: _RouteValuesService
   let router: jasmine.SpyObj<Router>
   const dummyValues = { foo: 'bar' }
   const url = '/set-url'
@@ -56,7 +56,7 @@ describe('Route values service', () => {
 
 function makeSut() {
   TestBed.configureTestingModule({
-    providers: [_NgxMetaRouteValuesService, MockProviders(Router)],
+    providers: [_RouteValuesService, MockProviders(Router)],
   })
-  return TestBed.inject(_NgxMetaRouteValuesService)
+  return TestBed.inject(_RouteValuesService)
 }

--- a/projects/ngx-meta/src/core/src/route-values.service.ts
+++ b/projects/ngx-meta/src/core/src/route-values.service.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router'
  * @internal
  */
 @Injectable()
-export class _NgxMetaRouteValuesService {
+export class _RouteValuesService {
   private url?: string
   private values: MetadataValues = {}
 

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.spec.ts
@@ -16,10 +16,7 @@ import {
 } from './ngx-meta-route-strategy'
 import { enableAutoSpy } from '@davidlj95/ngx-meta/__tests__/enable-auto-spy'
 import { Subscription } from 'rxjs'
-import {
-  _NgxMetaRouteValuesService,
-  NgxMetaService,
-} from '@davidlj95/ngx-meta/core'
+import { _RouteValuesService, NgxMetaService } from '@davidlj95/ngx-meta/core'
 
 describe('Router listener service', () => {
   enableAutoSpy()
@@ -119,8 +116,8 @@ describe('Router listener service', () => {
           NgxMetaService,
         ) as unknown as jasmine.SpyObj<NgxMetaService>
         const routeMetadataValues = TestBed.inject(
-          _NgxMetaRouteValuesService,
-        ) as unknown as jasmine.SpyObj<_NgxMetaRouteValuesService>
+          _RouteValuesService,
+        ) as unknown as jasmine.SpyObj<_RouteValuesService>
 
         sut.listen()
 
@@ -152,7 +149,7 @@ function makeSut(
     NgxMetaRouterListenerService,
     MockProvider(Router, { events: events$ } as Partial<Router>, 'useValue'),
     MockProvider(ActivatedRoute, activatedRoute, 'useValue'),
-    MockProviders(NgxMetaService, _NgxMetaRouteValuesService),
+    MockProviders(NgxMetaService, _RouteValuesService),
   ]
 
   if (opts.strategy) {

--- a/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/ngx-meta-router-listener.service.ts
@@ -7,7 +7,7 @@ import {
 } from './ngx-meta-route-strategy'
 import {
   _formatDevMessage,
-  _NgxMetaRouteValuesService,
+  _RouteValuesService,
   NgxMetaService,
 } from '@davidlj95/ngx-meta/core'
 import { _MODULE_NAME } from './module-name'
@@ -30,7 +30,7 @@ export class NgxMetaRouterListenerService implements OnDestroy {
     @Inject(NGX_META_ROUTE_STRATEGY)
     private readonly strategy: NgxMetaRouteStrategy | null,
     private readonly ngxMetaService: NgxMetaService,
-    private readonly routeMetadataValues: _NgxMetaRouteValuesService,
+    private readonly routeValuesService: _RouteValuesService,
   ) {}
 
   public listen() {
@@ -69,7 +69,7 @@ export class NgxMetaRouterListenerService implements OnDestroy {
           }
           const values = this.strategy(this.activatedRoute.snapshot)
           this.ngxMetaService.set(values)
-          this.routeMetadataValues.set(values)
+          this.routeValuesService.set(values)
         },
       })
   }

--- a/projects/ngx-meta/src/routing/src/routing-providers.ts
+++ b/projects/ngx-meta/src/routing/src/routing-providers.ts
@@ -1,4 +1,4 @@
-import { _NgxMetaRouteValuesService } from '@davidlj95/ngx-meta/core'
+import { _RouteValuesService } from '@davidlj95/ngx-meta/core'
 import { ENVIRONMENT_INITIALIZER, Provider, ValueProvider } from '@angular/core'
 import { NgxMetaRouterListenerService } from './ngx-meta-router-listener.service'
 import { NGX_META_ROUTE_STRATEGY } from './ngx-meta-route-strategy'
@@ -21,5 +21,5 @@ export const DEFAULT_METADATA_ROUTE_STRATEGY: ValueProvider = {
 export const ROUTING_PROVIDERS = [
   DEFAULT_METADATA_ROUTE_STRATEGY,
   ROUTING_INITIALIZER,
-  _NgxMetaRouteValuesService,
+  _RouteValuesService,
 ]


### PR DESCRIPTION
# Issue or need

Route values service isn't publicly exposed. No need to add lib prefix then to avoid collisions

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove lib prefix name from route values service

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
