### PR TITLE
refactor: rename defaults token to defaults

### DIFF
--- a/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
+++ b/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
@@ -6,7 +6,7 @@ import {
 import { MetadataResolverOptions, MetadataValues } from '../core'
 import { Provider } from '@angular/core'
 import { MockProvider } from 'ng-mocks'
-import { DEFAULTS_TOKEN } from '../core/src/defaults-token'
+import { DEFAULTS } from '../core/src/defaults'
 
 // Relates to https://github.com/davidlj95/ngx/issues/426
 // TBH, this is needed cause both Metadata JSON resolver and Metadata resolver
@@ -92,7 +92,7 @@ describe('Metadata value resolver object merging', () => {
 
 function makeSut(opts: { defaults?: MetadataValues } = {}) {
   const DEFAULT_PROVIDER: Provider[] = opts.defaults
-    ? [MockProvider(DEFAULTS_TOKEN, opts.defaults)]
+    ? [MockProvider(DEFAULTS, opts.defaults)]
     : []
   TestBed.configureTestingModule({
     providers: [METADATA_RESOLVER_PROVIDER, ...DEFAULT_PROVIDER],

--- a/projects/ngx-meta/src/core/src/defaults.ts
+++ b/projects/ngx-meta/src/core/src/defaults.ts
@@ -1,9 +1,9 @@
 import { inject, InjectionToken } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 
-export const DEFAULTS_TOKEN = new InjectionToken<MetadataValues>(
+export const DEFAULTS = new InjectionToken<MetadataValues>(
   ngDevMode ? 'NgxMeta Metadata defaults' : 'NgxMetaDefs',
 )
 
 export const injectDefaults = (): MetadataValues | null =>
-  inject(DEFAULTS_TOKEN, { optional: true })
+  inject(DEFAULTS, { optional: true })

--- a/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-json-resolver.ts
@@ -3,15 +3,10 @@ import { InjectionToken } from '@angular/core'
 import { MetadataResolverOptions } from './ngx-meta-metadata-manager'
 import { isObject } from './is-object'
 
-export type MetadataJsonResolver = (
-  values: MetadataValues | undefined,
-  resolverOptions: MetadataResolverOptions,
-) => unknown
 export const METADATA_JSON_RESOLVER = new InjectionToken<MetadataJsonResolver>(
   ngDevMode ? 'NgxMeta JSON Resolver' : 'NgxMetaJR',
   {
-    providedIn: 'root',
-    factory: (): MetadataJsonResolver => (values, resolverOptions) => {
+    factory: () => (values, resolverOptions) => {
       if (values === undefined) {
         return
       }
@@ -45,5 +40,10 @@ export const METADATA_JSON_RESOLVER = new InjectionToken<MetadataJsonResolver>(
     },
   },
 )
+
+export type MetadataJsonResolver = (
+  values: MetadataValues | undefined,
+  resolverOptions: MetadataResolverOptions,
+) => unknown
 
 type StringIndexedObject = Record<string, unknown>

--- a/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.spec.ts
@@ -5,7 +5,7 @@ import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { _RouteValuesService } from './route-values.service'
 import { MetadataValues } from './metadata-values'
 import { Provider } from '@angular/core'
-import { DEFAULTS_TOKEN } from './defaults-token'
+import { DEFAULTS } from './defaults'
 import {
   METADATA_RESOLVER,
   METADATA_RESOLVER_PROVIDER,
@@ -199,7 +199,7 @@ function makeSut(opts: { defaults?: MetadataValues } = {}): MetadataResolver {
     ),
   ]
   if (opts.defaults) {
-    providers.push(MockProvider(DEFAULTS_TOKEN, opts.defaults))
+    providers.push(MockProvider(DEFAULTS, opts.defaults))
   }
   TestBed.configureTestingModule({
     providers,

--- a/projects/ngx-meta/src/core/src/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/metadata-resolver.ts
@@ -1,7 +1,7 @@
 import { FactoryProvider, InjectionToken, Optional } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 import { _RouteValuesService } from './route-values.service'
-import { DEFAULTS_TOKEN } from './defaults-token'
+import { DEFAULTS } from './defaults'
 import {
   METADATA_JSON_RESOLVER,
   MetadataJsonResolver,
@@ -51,6 +51,6 @@ export const METADATA_RESOLVER_PROVIDER: FactoryProvider = {
   deps: [
     METADATA_JSON_RESOLVER,
     [_RouteValuesService, new Optional()],
-    [DEFAULTS_TOKEN, new Optional()],
+    [DEFAULTS, new Optional()],
   ],
 }

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { NgxMetaCoreModule } from './ngx-meta-core.module'
-import { injectDefaults } from './defaults-token'
+import { injectDefaults } from './defaults'
 import { ModuleWithProviders } from '@angular/core'
 import { GlobalMetadata } from './global-metadata'
 import { withNgxMetaDefaults } from './with-ngx-meta-defaults'

--- a/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
+++ b/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
@@ -1,6 +1,6 @@
 import { MetadataValues } from './metadata-values'
 import { __coreFeature, __CoreFeature, __CoreFeatureKind } from './core-feature'
-import { DEFAULTS_TOKEN } from './defaults-token'
+import { DEFAULTS } from './defaults'
 
 /**
  * Sets up default metadata values.
@@ -24,5 +24,5 @@ export const withNgxMetaDefaults = (
   defaults: MetadataValues,
 ): __CoreFeature<__CoreFeatureKind.Defaults> =>
   __coreFeature(__CoreFeatureKind.Defaults, [
-    { provide: DEFAULTS_TOKEN, useValue: defaults },
+    { provide: DEFAULTS, useValue: defaults },
   ])


### PR DESCRIPTION
# Issue or need

Just the defaults injection token uses the `_TOKEN` suffix. 

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Let's remove it to keep things short.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
