### PR TITLE
refactor: provide metadata registry in root

### DIFF
--- a/projects/ngx-meta/src/core/src/core-providers.ts
+++ b/projects/ngx-meta/src/core/src/core-providers.ts
@@ -1,3 +1,0 @@
-import { MetadataRegistry } from './metadata-registry'
-
-export const CORE_PROVIDERS = [MetadataRegistry]

--- a/projects/ngx-meta/src/core/src/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/metadata-registry.ts
@@ -4,7 +4,7 @@ import { NgxMetaMetadataManager } from './ngx-meta-metadata-manager'
 /**
  * @internal
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class MetadataRegistry {
   private readonly byId = new Map<string, NgxMetaMetadataManager>()
 

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
@@ -1,6 +1,5 @@
 import { ModuleWithProviders, NgModule } from '@angular/core'
 import { MetadataValues } from './metadata-values'
-import { CORE_PROVIDERS } from './core-providers'
 import { withNgxMetaDefaults } from './with-ngx-meta-defaults'
 import {
   __CoreFeature,
@@ -90,7 +89,6 @@ export class NgxMetaCoreModule {
     return {
       ngModule: NgxMetaCoreModule,
       providers: [
-        ...CORE_PROVIDERS,
         ...__providersFromCoreFeatures([
           ...optionFeaturesOrFirstFeature,
           ...features,

--- a/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
@@ -1,6 +1,5 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core'
 import { __CoreFeatures, __providersFromCoreFeatures } from './core-feature'
-import { CORE_PROVIDERS } from './core-providers'
 
 /**
  * Adds core services of the library to the application.
@@ -31,7 +30,4 @@ import { CORE_PROVIDERS } from './core-providers'
 export const provideNgxMetaCore = (
   ...features: __CoreFeatures
 ): EnvironmentProviders =>
-  makeEnvironmentProviders([
-    ...CORE_PROVIDERS,
-    ...__providersFromCoreFeatures(features),
-  ])
+  makeEnvironmentProviders([...__providersFromCoreFeatures(features)])


### PR DESCRIPTION
# Issue or need

Metadata registry is the last core provider to be defined. However, it's not needed.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Removes the core provider for metadata registry by allowing one to be injected in root with `providedIn: 'root'`

Removes core providers & its usages from module APIs and standalone APIs

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
