### PR TITLE
refactor: remove prefix from router listener service

### DIFF
--- a/projects/ngx-meta/src/routing/src/router-listener.service.spec.ts
+++ b/projects/ngx-meta/src/routing/src/router-listener.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 
-import { NgxMetaRouterListenerService } from './ngx-meta-router-listener.service'
+import { RouterListenerService } from './router-listener.service'
 import { MockProvider, MockProviders, MockService } from 'ng-mocks'
 import {
   ActivatedRoute,
@@ -38,7 +38,7 @@ describe('Router listener service', () => {
   })
 
   describe('when already listening', () => {
-    let sut: NgxMetaRouterListenerService
+    let sut: RouterListenerService
 
     beforeEach(() => {
       sut = makeSut()
@@ -137,7 +137,7 @@ function makeSut(
     strategy?: NgxMetaRouteStrategy
     activatedRoute?: ActivatedRoute
   } = {},
-): NgxMetaRouterListenerService {
+): RouterListenerService {
   const events$ = opts.events$ ?? new EventEmitter()
   const activatedRoute =
     opts.activatedRoute ??
@@ -146,7 +146,7 @@ function makeSut(
     } as Partial<ActivatedRoute>)
 
   const providers: Provider[] = [
-    NgxMetaRouterListenerService,
+    RouterListenerService,
     MockProvider(Router, { events: events$ } as Partial<Router>, 'useValue'),
     MockProvider(ActivatedRoute, activatedRoute, 'useValue'),
     MockProviders(NgxMetaService, _RouteValuesService),
@@ -162,7 +162,7 @@ function makeSut(
     providers,
   })
 
-  return TestBed.inject(NgxMetaRouterListenerService)
+  return TestBed.inject(RouterListenerService)
 }
 
 function makeNavigationEvent(type: EventType): NavigationEvent {

--- a/projects/ngx-meta/src/routing/src/router-listener.service.ts
+++ b/projects/ngx-meta/src/routing/src/router-listener.service.ts
@@ -17,7 +17,7 @@ import { _MODULE_NAME } from './module-name'
 export const NAVIGATION_END_EVENT_TYPE = new NavigationEnd(0, '', '').type
 
 @Injectable({ providedIn: 'root' })
-export class NgxMetaRouterListenerService implements OnDestroy {
+export class RouterListenerService implements OnDestroy {
   // Replace by `takeUntilDestroyed` when stable & oldest Angular supported version is v16 where it was introduced
   // https://angular.dev/api/core/rxjs-interop/takeUntilDestroyed
   // https://github.com/angular/angular/commit/e8831984601da631afc29f9fd72d36f57696f936

--- a/projects/ngx-meta/src/routing/src/routing-providers.ts
+++ b/projects/ngx-meta/src/routing/src/routing-providers.ts
@@ -5,7 +5,7 @@ import {
   Provider,
   ValueProvider,
 } from '@angular/core'
-import { NgxMetaRouterListenerService } from './ngx-meta-router-listener.service'
+import { RouterListenerService } from './router-listener.service'
 import { NGX_META_ROUTE_STRATEGY } from './ngx-meta-route-strategy'
 import { CURRENT_ROUTE_DATA_ROUTE_STRATEGY } from './current-route-data-strategy'
 
@@ -13,7 +13,7 @@ export const ROUTING_INITIALIZER: Provider = {
   provide: ENVIRONMENT_INITIALIZER,
   multi: true,
   useFactory: () => {
-    const routerListener = inject(NgxMetaRouterListenerService)
+    const routerListener = inject(RouterListenerService)
     return () => {
       routerListener.listen()
     }


### PR DESCRIPTION
# Issue or need

Router listener has the library but isn't exported

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove the prefix til exported at least

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
