### PR TITLE
chore: add comments to coverage ignored blocks

### DIFF
--- a/projects/ngx-meta/src/core/src/make-metadata-manager-provider-from-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/make-metadata-manager-provider-from-setter-factory.ts
@@ -55,7 +55,7 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
     m?: MetadataResolverOptions['objectMerge']
   },
 ): FactoryProvider => {
-  /* istanbul ignore next */
+  /* istanbul ignore next - simple enough */
   const deps = opts.d ?? []
   return {
     provide: NgxMetaMetadataManager,

--- a/projects/ngx-meta/src/core/src/ngx-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta.service.ts
@@ -78,7 +78,7 @@ export class NgxMetaService {
    */
   public setOne(globalOrJsonPath: string, value: unknown): void {
     const managers = this.registry.findByGlobalOrJsonPath(globalOrJsonPath)
-    /* istanbul ignore if */
+    /* istanbul ignore next - not unit tested hence no warning test */
     if (ngDevMode && [...managers].length === 0) {
       console.warn(
         _formatDevMessage(

--- a/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/open-graph-description-metadata-provider.ts
@@ -18,7 +18,7 @@ export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
     s:
       (metaService: NgxMetaMetaService) =>
       (description: OpenGraph['description']) => {
-        /* istanbul ignore next */
+        /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
         if (ngDevMode) {
           _maybeTooLongDevMessage(description, 300, {
             module: _MODULE_NAME,

--- a/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/twitter-card-description-metadata-provider.ts
@@ -15,7 +15,7 @@ export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER =
   makeTwitterCardMetadataProvider(_GLOBAL_DESCRIPTION, {
     g: _GLOBAL_DESCRIPTION,
     s: (metaService) => (description: TwitterCard['description']) => {
-      /* istanbul ignore next */
+      /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
       if (ngDevMode) {
         _maybeTooLongDevMessage(description, 200, {
           module: _MODULE_NAME,


### PR DESCRIPTION
# Issue or need

Some code branches are ignored for coverage count. Due to several reasons. However some of those ignores do not specify a reason

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a reason to missing code coverage ignores without one

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
