### PR TITLE
refactor: remove underscore prefix from core feature APIs

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -12,27 +12,6 @@ import { MetaDefinition } from '@angular/platform-browser';
 import { ModuleWithProviders } from '@angular/core';
 import { Provider } from '@angular/core';
 
-// Warning: (ae-forgotten-export) The symbol "__CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts
-//
-// @internal (undocumented)
-interface __CoreFeature<FeatureKind extends __CoreFeatureKind> {
-    // (undocumented)
-    _kind: FeatureKind;
-    // (undocumented)
-    _providers: Provider[];
-}
-
-// @internal
-const enum __CoreFeatureKind {
-    // (undocumented)
-    Defaults = 0
-}
-
-// Warning: (ae-forgotten-export) The symbol "__CoreFeature" needs to be exported by the entry point all-entry-points.d.ts
-//
-// @internal (undocumented)
-type __CoreFeatures = ReadonlyArray<__CoreFeature<__CoreFeatureKind>>;
-
 // Warning: (ae-forgotten-export) The symbol "KEY" needs to be exported by the entry point all-entry-points.d.ts
 //
 // @internal (undocumented)
@@ -64,6 +43,27 @@ export const __STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<Sta
 
 // @internal (undocumented)
 export const __TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY: (metaService: NgxMetaMetaService) => (image: TwitterCard['image']) => void;
+
+// Warning: (ae-forgotten-export) The symbol "CoreFeatureKind" needs to be exported by the entry point all-entry-points.d.ts
+//
+// @internal (undocumented)
+interface CoreFeature<FeatureKind extends CoreFeatureKind> {
+    // (undocumented)
+    _kind: FeatureKind;
+    // (undocumented)
+    _providers: Provider[];
+}
+
+// @internal
+const enum CoreFeatureKind {
+    // (undocumented)
+    Defaults = 0
+}
+
+// Warning: (ae-forgotten-export) The symbol "CoreFeature" needs to be exported by the entry point all-entry-points.d.ts
+//
+// @internal (undocumented)
+type CoreFeatures = ReadonlyArray<CoreFeature<CoreFeatureKind>>;
 
 // @internal (undocumented)
 export const _formatDevMessage: (message: string, options: _FormatDevMessageOptions) => string;
@@ -211,8 +211,8 @@ export type MetadataValues = object;
 
 // @public
 export class NgxMetaCoreModule {
-    // Warning: (ae-forgotten-export) The symbol "__CoreFeatures" needs to be exported by the entry point all-entry-points.d.ts
-    static forRoot(...features: __CoreFeatures): ModuleWithProviders<NgxMetaCoreModule>;
+    // Warning: (ae-forgotten-export) The symbol "CoreFeatures" needs to be exported by the entry point all-entry-points.d.ts
+    static forRoot(...features: CoreFeatures): ModuleWithProviders<NgxMetaCoreModule>;
     // @deprecated
     static forRoot(options: NgxMetaCoreModuleForRootOptions): ModuleWithProviders<NgxMetaCoreModule>;
 }
@@ -407,7 +407,7 @@ export type OpenGraphProfileGender = typeof OPEN_GRAPH_PROFILE_GENDER_FEMALE | t
 export type OpenGraphType = typeof OPEN_GRAPH_TYPE_MUSIC_SONG | typeof OPEN_GRAPH_TYPE_MUSIC_ALBUM | typeof OPEN_GRAPH_TYPE_MUSIC_PLAYLIST | typeof OPEN_GRAPH_TYPE_MUSIC_RADIO_STATION | typeof OPEN_GRAPH_TYPE_VIDEO_MOVIE | typeof OPEN_GRAPH_TYPE_VIDEO_EPISODE | typeof OPEN_GRAPH_TYPE_VIDEO_TV_SHOW | typeof OPEN_GRAPH_TYPE_VIDEO_OTHER | typeof OPEN_GRAPH_TYPE_ARTICLE | typeof OPEN_GRAPH_TYPE_BOOK | typeof OPEN_GRAPH_TYPE_PROFILE | typeof OPEN_GRAPH_TYPE_WEBSITE;
 
 // @public
-export const provideNgxMetaCore: (...features: __CoreFeatures) => EnvironmentProviders;
+export const provideNgxMetaCore: (...features: CoreFeatures) => EnvironmentProviders;
 
 // @public
 export const provideNgxMetaJsonLd: () => Provider[];
@@ -572,7 +572,7 @@ export interface TwitterCardSiteUsername {
 export type TwitterCardType = typeof TWITTER_CARD_TYPE_SUMMARY | typeof TWITTER_CARD_TYPE_SUMMARY_LARGE_IMAGE | typeof TWITTER_CARD_TYPE_APP | typeof TWITTER_CARD_TYPE_PLAYER;
 
 // @public
-export const withNgxMetaDefaults: (defaults: MetadataValues) => __CoreFeature<__CoreFeatureKind.Defaults>;
+export const withNgxMetaDefaults: (defaults: MetadataValues) => CoreFeature<CoreFeatureKind.Defaults>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/ngx-meta/src/core/src/core-feature.ts
+++ b/projects/ngx-meta/src/core/src/core-feature.ts
@@ -6,45 +6,36 @@ import { Provider } from '@angular/core'
  * https://github.com/angular/angular/blob/17.0.7/packages/router/src/provide_router.ts#L80-L96
  * @internal
  */
-export const enum __CoreFeatureKind {
+export const enum CoreFeatureKind {
   Defaults,
 }
 
 /**
  * @internal
  */
-export interface __CoreFeature<FeatureKind extends __CoreFeatureKind> {
+export interface CoreFeature<FeatureKind extends CoreFeatureKind> {
   _kind: FeatureKind
   _providers: Provider[]
 }
 
-/**
- * @internal
- */
-export const __coreFeature = <FeatureKind extends __CoreFeatureKind>(
+export const coreFeature = <FeatureKind extends CoreFeatureKind>(
   kind: FeatureKind,
   providers: Provider[],
-): __CoreFeature<FeatureKind> => ({
+): CoreFeature<FeatureKind> => ({
   _kind: kind,
   _providers: providers,
 })
 
-/**
- * @internal
- */
 export const isCoreFeature = (
   anObject: object,
-): anObject is __CoreFeature<__CoreFeatureKind> =>
-  ('_providers' satisfies keyof __CoreFeature<__CoreFeatureKind>) in anObject
+): anObject is CoreFeature<CoreFeatureKind> =>
+  ('_providers' satisfies keyof CoreFeature<CoreFeatureKind>) in anObject
 
 /**
  * @internal
  */
-export type __CoreFeatures = ReadonlyArray<__CoreFeature<__CoreFeatureKind>>
+export type CoreFeatures = ReadonlyArray<CoreFeature<CoreFeatureKind>>
 
-/**
- * @internal
- */
-export const __providersFromCoreFeatures = (
-  features: __CoreFeatures,
+export const providersFromCoreFeatures = (
+  features: CoreFeatures,
 ): ReadonlyArray<Provider> => features.map((f) => f._providers)

--- a/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
+++ b/projects/ngx-meta/src/core/src/ngx-meta-core.module.ts
@@ -2,11 +2,11 @@ import { ModuleWithProviders, NgModule } from '@angular/core'
 import { MetadataValues } from './metadata-values'
 import { withNgxMetaDefaults } from './with-ngx-meta-defaults'
 import {
-  __CoreFeature,
-  __CoreFeatureKind,
-  __CoreFeatures,
-  __providersFromCoreFeatures,
+  CoreFeature,
+  CoreFeatureKind,
+  CoreFeatures,
   isCoreFeature,
+  providersFromCoreFeatures,
 } from './core-feature'
 
 /**
@@ -35,7 +35,7 @@ export class NgxMetaCoreModule {
    * @param features - Features to configure the core module with
    */
   static forRoot(
-    ...features: __CoreFeatures
+    ...features: CoreFeatures
   ): ModuleWithProviders<NgxMetaCoreModule>
 
   /**
@@ -73,8 +73,8 @@ export class NgxMetaCoreModule {
   static forRoot(
     optionsOrFeature:
       | NgxMetaCoreModuleForRootOptions
-      | __CoreFeature<__CoreFeatureKind> = {},
-    ...features: __CoreFeatures
+      | CoreFeature<CoreFeatureKind> = {},
+    ...features: CoreFeatures
   ): ModuleWithProviders<NgxMetaCoreModule> {
     const optionFeaturesOrFirstFeature = isCoreFeature(optionsOrFeature)
       ? [optionsOrFeature]
@@ -84,7 +84,7 @@ export class NgxMetaCoreModule {
     return {
       ngModule: NgxMetaCoreModule,
       providers: [
-        ...__providersFromCoreFeatures([
+        ...providersFromCoreFeatures([
           ...optionFeaturesOrFirstFeature,
           ...features,
         ]),

--- a/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/provide-ngx-meta-core.ts
@@ -1,5 +1,5 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core'
-import { __CoreFeatures, __providersFromCoreFeatures } from './core-feature'
+import { CoreFeatures, providersFromCoreFeatures } from './core-feature'
 
 /**
  * Provides `ngx-meta`'s core library services.
@@ -18,6 +18,6 @@ import { __CoreFeatures, __providersFromCoreFeatures } from './core-feature'
  * @public
  */
 export const provideNgxMetaCore = (
-  ...features: __CoreFeatures
+  ...features: CoreFeatures
 ): EnvironmentProviders =>
-  makeEnvironmentProviders([...__providersFromCoreFeatures(features)])
+  makeEnvironmentProviders([...providersFromCoreFeatures(features)])

--- a/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
+++ b/projects/ngx-meta/src/core/src/with-ngx-meta-defaults.ts
@@ -1,5 +1,5 @@
 import { MetadataValues } from './metadata-values'
-import { __coreFeature, __CoreFeature, __CoreFeatureKind } from './core-feature'
+import { coreFeature, CoreFeature, CoreFeatureKind } from './core-feature'
 import { DEFAULTS } from './defaults'
 
 /**
@@ -40,7 +40,7 @@ import { DEFAULTS } from './defaults'
  */
 export const withNgxMetaDefaults = (
   defaults: MetadataValues,
-): __CoreFeature<__CoreFeatureKind.Defaults> =>
-  __coreFeature(__CoreFeatureKind.Defaults, [
+): CoreFeature<CoreFeatureKind.Defaults> =>
+  coreFeature(CoreFeatureKind.Defaults, [
     { provide: DEFAULTS, useValue: defaults },
   ])


### PR DESCRIPTION
# Issue or need

Core feature internal APIs aren't exported. No need to prefix them then

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove the underscore prefix.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
