### PR TITLE
chore: remove unneeded double underscore prefixes

### DIFF
--- a/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
@@ -10,7 +10,7 @@ import { JsonLdMetadata } from './json-ld-metadata'
 const KEY = 'jsonLd' satisfies keyof JsonLdMetadata
 const SCRIPT_TYPE = 'application/ld+json'
 
-export const __JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
+export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   JsonLdMetadata[typeof KEY]
 > =
   (headElementUpsertOrRemove: _HeadElementUpsertOrRemove, doc: Document) =>
@@ -30,7 +30,7 @@ export const __JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
  */
 export const JSON_LD_METADATA_PROVIDER =
   makeMetadataManagerProviderFromSetterFactory(
-    __JSON_LD_METADATA_SETTER_FACTORY,
+    JSON_LD_METADATA_SETTER_FACTORY,
     {
       d: [_HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT],
       jP: [KEY],

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
@@ -4,7 +4,7 @@ import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { OpenGraphImage } from './open-graph-image'
 import { OpenGraph } from './open-graph'
-import { __OPEN_GRAPH_IMAGE_SETTER_FACTORY } from './open-graph-image-metadata-provider'
+import { OPEN_GRAPH_IMAGE_SETTER_FACTORY } from './open-graph-image-metadata-provider'
 
 describe('Open Graph image metadata', () => {
   enableAutoSpy()
@@ -77,5 +77,5 @@ function makeSut(): MetadataSetter<OpenGraph['image']> {
   TestBed.configureTestingModule({
     providers: [MockProviders(NgxMetaMetaService)],
   })
-  return __OPEN_GRAPH_IMAGE_SETTER_FACTORY(TestBed.inject(NgxMetaMetaService))
+  return OPEN_GRAPH_IMAGE_SETTER_FACTORY(TestBed.inject(NgxMetaMetaService))
 }

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
@@ -17,7 +17,7 @@ const NO_KEY_VALUE: OpenGraph[typeof _GLOBAL_IMAGE] = {
   height: null,
 }
 
-export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
+export const OPEN_GRAPH_IMAGE_SETTER_FACTORY =
   (metaService: NgxMetaMetaService) =>
   (value: OpenGraph[typeof _GLOBAL_IMAGE]) => {
     const imageUrl = value?.url?.toString()
@@ -59,5 +59,5 @@ export const __OPEN_GRAPH_IMAGE_SETTER_FACTORY =
  */
 export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
   _GLOBAL_IMAGE,
-  { s: __OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: _GLOBAL_IMAGE, m: true },
+  { s: OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: _GLOBAL_IMAGE, m: true },
 )


### PR DESCRIPTION
# Issue or need

After last PRs, exported APIs have been reduced to avoid exporting private APIs. However maybe some APIs despite not exported still are prefixed with `__` to be marked as private

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Search for those private APIs and remove the `__` given they're not exported anymore

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
