### PR TITLE
refactor: remove underscore prefix from module name

### DIFF
--- a/projects/ngx-meta/src/core/src/module-name.ts
+++ b/projects/ngx-meta/src/core/src/module-name.ts
@@ -1,1 +1,1 @@
-export const _MODULE_NAME = 'core'
+export const MODULE_NAME = 'core'

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
@@ -6,7 +6,7 @@ import {
   MetadataResolver,
 } from '../resolvers/metadata-resolver'
 import { _formatDevMessage } from '../messaging'
-import { _MODULE_NAME } from '../module-name'
+import { MODULE_NAME } from '../module-name'
 
 /**
  * Manages the metadata values of the current page.
@@ -91,7 +91,7 @@ export class NgxMetaService {
       console.warn(
         _formatDevMessage(
           'no metadata managers found for global or JSON Path',
-          { module: _MODULE_NAME, value: globalOrJsonPath },
+          { module: MODULE_NAME, value: globalOrJsonPath },
         ),
       )
     }

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-description-metadata-provider.ts
@@ -6,7 +6,7 @@ import {
 } from '@davidlj95/ngx-meta/core'
 import { OpenGraph } from './open-graph'
 import { makeOpenGraphMetaDefinition } from '../../utils/make-open-graph-meta-definition'
-import { _MODULE_NAME } from '../../module-name'
+import { MODULE_NAME } from '../../module-name'
 
 /**
  * Manages the {@link OpenGraph.description} metadata
@@ -21,7 +21,7 @@ export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER =
         /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
         if (ngDevMode) {
           _maybeTooLongDevMessage(description, 300, {
-            module: _MODULE_NAME,
+            module: MODULE_NAME,
             property: _GLOBAL_DESCRIPTION,
             value: description,
             link: 'https://stackoverflow.com/q/8914476/3263250',

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
@@ -6,7 +6,7 @@ import {
 } from '@davidlj95/ngx-meta/core'
 import { makeOpenGraphMetadataProvider } from '../../utils/make-open-graph-metadata-provider'
 import { makeOpenGraphMetaDefinition } from '../../utils/make-open-graph-meta-definition'
-import { _MODULE_NAME } from '../../module-name'
+import { MODULE_NAME } from '../../module-name'
 
 const NO_KEY_VALUE: OpenGraph[typeof _GLOBAL_IMAGE] = {
   url: undefined,
@@ -26,7 +26,7 @@ export const OPEN_GRAPH_IMAGE_SETTER_FACTORY =
     // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
       _maybeNonHttpUrlDevMessage(imageUrl, {
-        module: _MODULE_NAME,
+        module: MODULE_NAME,
         property: _GLOBAL_IMAGE,
         link: 'https://stackoverflow.com/a/9858694/3263250',
       })

--- a/projects/ngx-meta/src/open-graph/src/module-name.ts
+++ b/projects/ngx-meta/src/open-graph/src/module-name.ts
@@ -1,1 +1,1 @@
-export const _MODULE_NAME = 'open-graph'
+export const MODULE_NAME = 'open-graph'

--- a/projects/ngx-meta/src/routing/src/listener/router-listener.ts
+++ b/projects/ngx-meta/src/routing/src/listener/router-listener.ts
@@ -2,7 +2,7 @@ import { inject, InjectionToken, OnDestroy } from '@angular/core'
 import { NavigationEnd, Router } from '@angular/router'
 import { filter, Subscription } from 'rxjs'
 import { _formatDevMessage, NgxMetaService } from '@davidlj95/ngx-meta/core'
-import { _MODULE_NAME } from '../module-name'
+import { MODULE_NAME } from '../module-name'
 
 // WTF is this? Why not just import `EventType`? Well, compatibility reasons 🙃
 // See https://github.com/davidlj95/ngx/pull/246 for the details
@@ -27,7 +27,7 @@ export const ROUTER_LISTENER = new InjectionToken<RouterListener>(
                   'prevented listening for route changes twice',
                   'Ensure routing provider or module is only imported once',
                 ].join('\n'),
-                { module: _MODULE_NAME },
+                { module: MODULE_NAME },
               ))
           /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
           if (subscription) {

--- a/projects/ngx-meta/src/routing/src/module-name.ts
+++ b/projects/ngx-meta/src/routing/src/module-name.ts
@@ -1,1 +1,1 @@
-export const _MODULE_NAME = 'routing'
+export const MODULE_NAME = 'routing'

--- a/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-description-metadata-provider.ts
@@ -5,7 +5,7 @@ import {
 } from '@davidlj95/ngx-meta/core'
 import { TwitterCard } from '../types'
 import { makeTwitterCardMetaDefinition } from '../utils/make-twitter-card-meta-definition'
-import { _MODULE_NAME } from '../module-name'
+import { MODULE_NAME } from '../module-name'
 
 /**
  * Manages the {@link TwitterCard.description} metadata
@@ -18,7 +18,7 @@ export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER =
       /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
       if (ngDevMode) {
         _maybeTooLongDevMessage(description, 200, {
-          module: _MODULE_NAME,
+          module: MODULE_NAME,
           property: _GLOBAL_DESCRIPTION,
           value: description,
           link: 'https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=n/a-,twitter%3Adescription,-Description%20of%20content',

--- a/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.ts
@@ -6,14 +6,14 @@ import {
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
 import { TwitterCard } from '../types'
-import { _MODULE_NAME } from '../module-name'
+import { MODULE_NAME } from '../module-name'
 
 export const TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
   (metaService: NgxMetaMetaService) => (image: TwitterCard['image']) => {
     // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
     ngDevMode &&
       _maybeNonHttpUrlDevMessage(image?.url, {
-        module: _MODULE_NAME,
+        module: MODULE_NAME,
         property: 'image',
         link: 'https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736',
       })

--- a/projects/ngx-meta/src/twitter-card/src/module-name.ts
+++ b/projects/ngx-meta/src/twitter-card/src/module-name.ts
@@ -1,1 +1,1 @@
-export const _MODULE_NAME = 'twitter-card'
+export const MODULE_NAME = 'twitter-card'


### PR DESCRIPTION
# Issue or need

Module name isn't exported so shouldn't need the internal underscore prefix

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove it

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
