### PR TITLE
refactor: move Open Graph main types into directory

### DIFF
--- a/projects/ngx-meta/src/open-graph/index.ts
+++ b/projects/ngx-meta/src/open-graph/index.ts
@@ -1,3 +1,3 @@
-export { OpenGraphMetadata } from './src/open-graph-metadata'
 export * from './src/basic-optional'
 export * from './src/profile'
+export * from './src/types'

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/index.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/index.ts
@@ -1,4 +1,3 @@
-export { OpenGraph } from './open-graph'
 export { OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER } from './open-graph-description-metadata-provider'
 export { OPEN_GRAPH_IMAGE_METADATA_PROVIDER } from './open-graph-image-metadata-provider'
 export { OpenGraphImage } from './open-graph-image'

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-description-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-description-metadata-provider.ts
@@ -4,7 +4,7 @@ import {
   _maybeTooLongDevMessage,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
-import { OpenGraph } from './open-graph'
+import { OpenGraph } from '../../types'
 import { makeOpenGraphMetaDefinition } from '../../utils/make-open-graph-meta-definition'
 import { _MODULE_NAME } from '../../module-name'
 

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
@@ -3,7 +3,7 @@ import { MockProviders } from 'ng-mocks'
 import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { OpenGraphImage } from './open-graph-image'
-import { OpenGraph } from './open-graph'
+import { OpenGraph } from '../../types'
 import { OPEN_GRAPH_IMAGE_SETTER_FACTORY } from './open-graph-image-metadata-provider'
 
 describe('Open Graph image metadata', () => {

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
@@ -1,4 +1,4 @@
-import { OpenGraph } from './open-graph'
+import { OpenGraph } from '../../types'
 import {
   _GLOBAL_IMAGE,
   _maybeNonHttpUrlDevMessage,

--- a/projects/ngx-meta/src/open-graph/src/profile/utils/make-open-graph-profile-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/profile/utils/make-open-graph-profile-metadata-provider.ts
@@ -6,7 +6,7 @@ import { FactoryProvider } from '@angular/core'
 import { OpenGraphProfile } from '../managers'
 import { OPEN_GRAPH_KEY } from '../../utils/make-open-graph-metadata-provider'
 import { makeOpenGraphMetaDefinition } from '../../utils/make-open-graph-meta-definition'
-import { OpenGraph } from '../../basic-optional'
+import { OpenGraph } from '../../types'
 
 export const OPEN_GRAPH_PROFILE_KEY: keyof OpenGraph = 'profile'
 

--- a/projects/ngx-meta/src/open-graph/src/types/index.ts
+++ b/projects/ngx-meta/src/open-graph/src/types/index.ts
@@ -1,0 +1,2 @@
+export { OpenGraph } from './open-graph'
+export { OpenGraphMetadata } from './open-graph-metadata'

--- a/projects/ngx-meta/src/open-graph/src/types/open-graph-metadata.ts
+++ b/projects/ngx-meta/src/open-graph/src/types/open-graph-metadata.ts
@@ -1,4 +1,4 @@
-import { OpenGraph } from './basic-optional'
+import { OpenGraph } from './open-graph'
 
 /**
  * Utility type to provide specific

--- a/projects/ngx-meta/src/open-graph/src/types/open-graph.ts
+++ b/projects/ngx-meta/src/open-graph/src/types/open-graph.ts
@@ -1,6 +1,5 @@
-import { OpenGraphImage } from './open-graph-image'
-import { OpenGraphType } from './open-graph-type'
-import { OpenGraphProfile } from '../../profile'
+import { OpenGraphImage, OpenGraphType } from '../basic-optional'
+import { OpenGraphProfile } from '../profile'
 
 /**
  * {@link https://ngx-meta.dev/built-in-modules/open-graph/ | Open Graph module}

--- a/projects/ngx-meta/src/open-graph/src/utils/make-open-graph-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/utils/make-open-graph-metadata-provider.ts
@@ -5,9 +5,8 @@ import {
   MetadataSetterFactory,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
-import { OpenGraph } from '../basic-optional'
 import { FactoryProvider } from '@angular/core'
-import { OpenGraphMetadata } from '../open-graph-metadata'
+import { OpenGraph, OpenGraphMetadata } from '../types'
 import { makeOpenGraphMetaDefinition } from './make-open-graph-meta-definition'
 
 export const OPEN_GRAPH_KEY: keyof OpenGraphMetadata = 'openGraph'


### PR DESCRIPTION
# Issue or need

Metadata modules have their main types in the `types` directory except for Open Graph

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use that pattern in there too

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
