### PR TITLE
refactor: turn metadata registry into a lightweight token

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -133,14 +133,13 @@ export const _maybeNonHttpUrlDevMessage: (url: string | URL | undefined | null, 
 export const _maybeTooLongDevMessage: (value: string | undefined | null, maxLength: number, opts: _FormatDevMessageOptions) => void;
 
 // @internal (undocumented)
-class MetadataRegistry {
-    constructor(managers: ReadonlyArray<NgxMetaMetadataManager> | null);
+interface MetadataRegistry {
     // (undocumented)
-    findByGlobalOrJsonPath(globalOrJsonPath: string): Iterable<NgxMetaMetadataManager>;
+    readonly findByGlobalOrJsonPath: (globalOrJsonPath: string) => Iterable<NgxMetaMetadataManager>;
     // (undocumented)
-    getAll(): Iterable<NgxMetaMetadataManager>;
+    readonly getAll: () => Iterable<NgxMetaMetadataManager>;
     // (undocumented)
-    register(manager: NgxMetaMetadataManager): void;
+    readonly register: (manager: NgxMetaMetadataManager) => void;
 }
 
 // @internal (undocumented)

--- a/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
+++ b/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
@@ -1,5 +1,8 @@
 import { ENVIRONMENT_INITIALIZER, inject, Provider } from '@angular/core'
-import { MetadataRegistry } from '../managers/metadata-registry'
+import {
+  METADATA_REGISTRY,
+  provideMetadataRegistry,
+} from '../managers/metadata-registry'
 
 /**
  * Allows to load metadata managers after library has been initialized.
@@ -12,13 +15,13 @@ import { MetadataRegistry } from '../managers/metadata-registry'
  * @public
  */
 export const provideNgxMetaMetadataLoader = (): Provider[] => [
-  MetadataRegistry,
+  provideMetadataRegistry(),
   {
     provide: ENVIRONMENT_INITIALIZER,
     multi: true,
     useFactory: () => {
-      const globalRegistry = inject(MetadataRegistry, { skipSelf: true })
-      const localRegistry = inject(MetadataRegistry)
+      const globalRegistry = inject(METADATA_REGISTRY, { skipSelf: true })
+      const localRegistry = inject(METADATA_REGISTRY)
       return () => {
         const localMetadata = localRegistry.getAll()
         for (const metadata of localMetadata) {

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
@@ -1,4 +1,4 @@
-import { MetadataRegistry } from './metadata-registry'
+import { METADATA_REGISTRY } from './metadata-registry'
 import { TestBed } from '@angular/core/testing'
 import { makeMetadataManagerSpy } from './__tests__/make-metadata-manager-spy'
 import { MockProvider } from 'ng-mocks'
@@ -77,11 +77,10 @@ function makeSut(
 ) {
   TestBed.configureTestingModule({
     providers: [
-      MetadataRegistry,
       ...(opts.managers ?? []).map((manager) =>
         MockProvider(NgxMetaMetadataManager, manager, 'useValue', true),
       ),
     ],
   })
-  return TestBed.inject(MetadataRegistry)
+  return TestBed.inject(METADATA_REGISTRY)
 }

--- a/projects/ngx-meta/src/core/src/managers/ngx-meta-metadata-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/ngx-meta-metadata-manager.ts
@@ -1,3 +1,5 @@
+import { inject } from '@angular/core'
+
 /**
  * Abstract class every metadata manager must implement.
  *
@@ -33,6 +35,13 @@ export abstract class NgxMetaMetadataManager<Value = unknown> {
    */
   abstract readonly set: MetadataSetter<Value>
 }
+
+export const injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager> =
+  () =>
+    // https://stackoverflow.com/q/74598049/3263250
+    (inject(NgxMetaMetadataManager, {
+      optional: true,
+    }) as ReadonlyArray<NgxMetaMetadataManager> | null) ?? []
 
 /**
  * Options to resolve metadata values for a metadata manager

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -1,13 +1,16 @@
 import { TestBed } from '@angular/core/testing'
 import { NgxMetaService } from './ngx-meta.service'
-import { MockProvider, MockProviders } from 'ng-mocks'
+import { MockProvider } from 'ng-mocks'
 import { makeMetadataManagerSpy } from '../managers/__tests__/make-metadata-manager-spy'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import {
   METADATA_RESOLVER,
   MetadataResolver,
 } from '../resolvers/metadata-resolver'
-import { MetadataRegistry } from '../managers/metadata-registry'
+import {
+  METADATA_REGISTRY,
+  MetadataRegistry,
+} from '../managers/metadata-registry'
 
 describe('Main service', () => {
   enableAutoSpy()
@@ -19,7 +22,7 @@ describe('Main service', () => {
   beforeEach(() => {
     sut = makeSut()
     metadataRegistry = TestBed.inject(
-      MetadataRegistry,
+      METADATA_REGISTRY,
     ) as jasmine.SpyObj<MetadataRegistry>
     metadataRegistry.getAll.and.returnValue([firstMetadata, secondMetadata])
   })
@@ -74,7 +77,10 @@ function makeSut() {
   TestBed.configureTestingModule({
     providers: [
       NgxMetaService,
-      MockProviders(MetadataRegistry),
+      MockProvider(
+        METADATA_REGISTRY,
+        jasmine.createSpyObj<MetadataRegistry>(['getAll']),
+      ),
       MockProvider(METADATA_RESOLVER, jasmine.createSpy('Metadata resolver')),
     ],
   })

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
@@ -1,6 +1,9 @@
 import { Inject, Injectable } from '@angular/core'
 import { MetadataValues } from './metadata-values'
-import { MetadataRegistry } from '../managers/metadata-registry'
+import {
+  METADATA_REGISTRY,
+  MetadataRegistry,
+} from '../managers/metadata-registry'
 import {
   METADATA_RESOLVER,
   MetadataResolver,
@@ -16,7 +19,7 @@ import { _MODULE_NAME } from '../module-name'
 @Injectable({ providedIn: 'root' })
 export class NgxMetaService {
   constructor(
-    private readonly registry: MetadataRegistry,
+    @Inject(METADATA_REGISTRY) private readonly registry: MetadataRegistry,
     @Inject(METADATA_RESOLVER) private readonly resolver: MetadataResolver,
   ) {}
 


### PR DESCRIPTION
# Issue or need

To save some bytes, metadata registry can be turned into a lightweight token

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Turn metadata registry into an injection token. Create a function to also provide a local one for late loading managers.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
