### PR TITLE
refactor: turn meta service into abstract class with factory provider

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -132,19 +132,6 @@ export const _maybeNonHttpUrlDevMessage: (url: string | URL | undefined | null, 
 // @internal
 export const _maybeTooLongDevMessage: (value: string | undefined | null, maxLength: number, opts: _FormatDevMessageOptions) => void;
 
-// @internal (undocumented)
-interface MetadataRegistry {
-    // (undocumented)
-    readonly findByGlobalOrJsonPath: (globalOrJsonPath: string) => Iterable<NgxMetaMetadataManager>;
-    // (undocumented)
-    readonly getAll: () => Iterable<NgxMetaMetadataManager>;
-    // (undocumented)
-    readonly register: (manager: NgxMetaMetadataManager) => void;
-}
-
-// @internal (undocumented)
-type MetadataResolver = (values: MetadataValues, resolverOptions: MetadataResolverOptions) => unknown;
-
 // @public
 export interface MetadataResolverOptions {
     readonly global?: string;
@@ -225,13 +212,10 @@ export class NgxMetaRoutingModule {
 }
 
 // @public
-export class NgxMetaService {
-    // Warning: (ae-forgotten-export) The symbol "MetadataRegistry" needs to be exported by the entry point all-entry-points.d.ts
-    // Warning: (ae-forgotten-export) The symbol "MetadataResolver" needs to be exported by the entry point all-entry-points.d.ts
-    constructor(registry: MetadataRegistry, resolver: MetadataResolver);
-    clear(): void;
-    set(values?: MetadataValues): void;
-    setOne(globalOrJsonPath: string, value: unknown): void;
+export abstract class NgxMetaService {
+    abstract clear(): void;
+    abstract set(values?: MetadataValues): void;
+    abstract setOne(globalOrJsonPath: string, value: unknown): void;
 }
 
 // @public

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
@@ -4,9 +4,6 @@ import {
   NgxMetaMetadataManager,
 } from './ngx-meta-metadata-manager'
 
-/**
- * @internal
- */
 export interface MetadataRegistry {
   readonly register: (manager: NgxMetaMetadataManager) => void
   readonly getAll: () => Iterable<NgxMetaMetadataManager>

--- a/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
@@ -1,5 +1,6 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core'
 import { CoreFeatures, providersFromCoreFeatures } from './core-feature'
+import { provideNgxMetaService } from '../service/ngx-meta.service'
 
 /**
  * Provides `ngx-meta`'s core library services.
@@ -20,4 +21,7 @@ import { CoreFeatures, providersFromCoreFeatures } from './core-feature'
 export const provideNgxMetaCore = (
   ...features: CoreFeatures
 ): EnvironmentProviders =>
-  makeEnvironmentProviders(providersFromCoreFeatures(features))
+  makeEnvironmentProviders([
+    provideNgxMetaService(),
+    providersFromCoreFeatures(features),
+  ])

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
@@ -40,9 +40,6 @@ export const METADATA_RESOLVER = new InjectionToken<MetadataResolver>(
   },
 )
 
-/**
- * @internal
- */
 export type MetadataResolver = (
   values: MetadataValues,
   resolverOptions: MetadataResolverOptions,

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { NgxMetaService } from './ngx-meta.service'
+import { NgxMetaService, provideNgxMetaService } from './ngx-meta.service'
 import { MockProvider } from 'ng-mocks'
 import { makeMetadataManagerSpy } from '../managers/__tests__/make-metadata-manager-spy'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
@@ -76,7 +76,7 @@ describe('Main service', () => {
 function makeSut() {
   TestBed.configureTestingModule({
     providers: [
-      NgxMetaService,
+      provideNgxMetaService(),
       MockProvider(
         METADATA_REGISTRY,
         jasmine.createSpyObj<MetadataRegistry>(['getAll']),

--- a/projects/ngx-meta/src/routing/src/listener/router-listener.spec.ts
+++ b/projects/ngx-meta/src/routing/src/listener/router-listener.spec.ts
@@ -107,7 +107,10 @@ function makeSut(
   TestBed.configureTestingModule({
     providers: [
       MockProvider(Router, { events: events$ }),
-      MockProvider(NgxMetaService),
+      MockProvider(
+        NgxMetaService,
+        jasmine.createSpyObj<NgxMetaService>(['set']),
+      ),
     ],
   })
 


### PR DESCRIPTION
# Issue or need

`NgxMetaService` could be turned into an abstract class, provided by a factory provider to save some moar bytes

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Try and see how many bytes we save. It's not a breaking change because the abstract class can still be used as injection token. So the API is unchanged.

Trying out because not sure about how much space is saved, how it looks on docs...

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
