### PR TITLE
refactor: use core provider API from module API

### DIFF
--- a/projects/ngx-meta/src/core/src/providers/core-feature.ts
+++ b/projects/ngx-meta/src/core/src/providers/core-feature.ts
@@ -36,6 +36,5 @@ export const isCoreFeature = (
  */
 export type CoreFeatures = ReadonlyArray<CoreFeature<CoreFeatureKind>>
 
-export const providersFromCoreFeatures = (
-  features: CoreFeatures,
-): ReadonlyArray<Provider> => features.map((f) => f._providers)
+export const providersFromCoreFeatures = (features: CoreFeatures): Provider[] =>
+  features.map((f) => f._providers)

--- a/projects/ngx-meta/src/core/src/providers/ngx-meta-core.module.ts
+++ b/projects/ngx-meta/src/core/src/providers/ngx-meta-core.module.ts
@@ -6,8 +6,8 @@ import {
   CoreFeatureKind,
   CoreFeatures,
   isCoreFeature,
-  providersFromCoreFeatures,
 } from './core-feature'
+import { provideNgxMetaCore } from './provide-ngx-meta-core'
 
 /**
  * Provides `ngx-meta`'s core library services.
@@ -84,10 +84,7 @@ export class NgxMetaCoreModule {
     return {
       ngModule: NgxMetaCoreModule,
       providers: [
-        ...providersFromCoreFeatures([
-          ...optionFeaturesOrFirstFeature,
-          ...features,
-        ]),
+        provideNgxMetaCore(...optionFeaturesOrFirstFeature, ...features),
       ],
     }
   }

--- a/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
@@ -20,4 +20,4 @@ import { CoreFeatures, providersFromCoreFeatures } from './core-feature'
 export const provideNgxMetaCore = (
   ...features: CoreFeatures
 ): EnvironmentProviders =>
-  makeEnvironmentProviders([...providersFromCoreFeatures(features)])
+  makeEnvironmentProviders(providersFromCoreFeatures(features))


### PR DESCRIPTION
# Issue or need

Core module-based API is importing features, but not using provider API. This is not the usual way. And can happen that something is provided in provider API that is then not provided in module-based equivalent.

The pattern is to use the provider API in the module equivalent API. This way we only alter the provider one as source of truth and the module one is kept updated as it's using that one.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use provider API in module API for core module. Also removes the need to create a shallow array by fixing the return type.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
