### PR TITLE
feat: change provider API to return environment providers

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -374,7 +374,7 @@ export const provideNgxMetaOpenGraph: () => Provider[];
 export const provideNgxMetaOpenGraphProfile: () => Provider[];
 
 // @public
-export const provideNgxMetaRouting: () => Provider[];
+export const provideNgxMetaRouting: () => EnvironmentProviders;
 
 // @public
 export const provideNgxMetaStandard: () => Provider[];

--- a/projects/ngx-meta/src/routing/src/providers/ngx-meta-routing.module.ts
+++ b/projects/ngx-meta/src/routing/src/providers/ngx-meta-routing.module.ts
@@ -14,7 +14,7 @@ export class NgxMetaRoutingModule {
   static forRoot(): ModuleWithProviders<NgxMetaRoutingModule> {
     return {
       ngModule: NgxMetaRoutingModule,
-      providers: provideNgxMetaRouting(),
+      providers: [provideNgxMetaRouting()],
     }
   }
 }

--- a/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
+++ b/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
@@ -1,4 +1,9 @@
-import { ENVIRONMENT_INITIALIZER, inject, Provider } from '@angular/core'
+import {
+  ENVIRONMENT_INITIALIZER,
+  EnvironmentProviders,
+  inject,
+  makeEnvironmentProviders,
+} from '@angular/core'
 import { _ROUTE_METADATA_STRATEGY } from '@davidlj95/ngx-meta/core'
 import { DEFAULT_ROUTE_METADATA_STRATEGY } from '../route-metadata/default-route-metadata-strategy'
 import { ROUTER_LISTENER } from '../listener/router-listener'
@@ -14,14 +19,15 @@ import { ROUTER_LISTENER } from '../listener/router-listener'
  *
  * @public
  */
-export const provideNgxMetaRouting = (): Provider[] => [
-  {
-    provide: _ROUTE_METADATA_STRATEGY,
-    useExisting: DEFAULT_ROUTE_METADATA_STRATEGY,
-  },
-  {
-    provide: ENVIRONMENT_INITIALIZER,
-    multi: true,
-    useFactory: () => inject(ROUTER_LISTENER).listen,
-  },
-]
+export const provideNgxMetaRouting = (): EnvironmentProviders =>
+  makeEnvironmentProviders([
+    {
+      provide: _ROUTE_METADATA_STRATEGY,
+      useExisting: DEFAULT_ROUTE_METADATA_STRATEGY,
+    },
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      multi: true,
+      useFactory: () => inject(ROUTER_LISTENER).listen,
+    },
+  ])


### PR DESCRIPTION
# Issue or need

Routing provider API `provideNgxMetaRouting` is returning an array of providers. Those may be used at a `@Component` injector. But that makes no sense for the module.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Return them as environment providers. This way can't be used in component injectors.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
