### PR TITLE
chore: improve Cypress setup

### DIFF
--- a/projects/ngx-meta/e2e/cypress/support/commands.ts
+++ b/projects/ngx-meta/e2e/cypress/support/commands.ts
@@ -1,44 +1,6 @@
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
-
 import { ROUTES } from '../fixtures/routes'
 import { JSON_LD_MIME } from './json-ld'
-import { RouteMatcher } from 'cypress/types/net-stubbing'
 
 Cypress.Commands.add<'getMeta'>('getMeta', (name) => {
   cy.get(`meta[name="${name}"]`)
@@ -51,11 +13,11 @@ Cypress.Commands.add<'getMetaWithProperty'>(
   },
 )
 
-Cypress.Commands.add<'shouldHaveContent', Cypress.Chainable<HTMLMetaElement>>(
+Cypress.Commands.add<'shouldHaveContent'>(
   'shouldHaveContent',
   { prevSubject: true },
   (prevSubject) => {
-    return cy.wrap(prevSubject).should('have.attr', 'content')
+    cy.wrap(prevSubject).should('have.attr', 'content')
   },
 )
 
@@ -104,20 +66,3 @@ Cypress.Commands.add<'shouldNotContainAppScripts'>(
       .should('not.exist')
   },
 )
-
-// 👇 Make TypeScript happy (not in Cypress docs though)
-// https://stackoverflow.com/a/59499895/3263250
-export {}
-
-declare global {
-  namespace Cypress {
-    interface Chainable<Subject> {
-      goToRootPage(): Chainable<void>
-      getMeta(name: string): Chainable<HTMLMetaElement>
-      getMetaWithProperty(property: string): Chainable<HTMLMetaElement>
-      shouldHaveContent(): Chainable<Subject>
-      simulateSSRForRequest(url: RouteMatcher): Chainable<void>
-      shouldNotContainAppScripts(): Chainable<void>
-    }
-  }
-}

--- a/projects/ngx-meta/e2e/cypress/support/cypress.d.ts
+++ b/projects/ngx-meta/e2e/cypress/support/cypress.d.ts
@@ -1,0 +1,14 @@
+import { RouteMatcher } from 'cypress/types/net-stubbing'
+
+declare global {
+  module Cypress {
+    interface Chainable {
+      goToRootPage(): Chainable<void>
+      getMeta(name: string): Chainable<HTMLMetaElement>
+      getMetaWithProperty(property: string): Chainable<HTMLMetaElement>
+      shouldHaveContent(): Chainable<string | null>
+      simulateSSRForRequest(url: RouteMatcher): Chainable<void>
+      shouldNotContainAppScripts(): Chainable<void>
+    }
+  }
+}


### PR DESCRIPTION
# Issue or need

Cypress setup was:
 - Raising a linter error [about namespaces: `@typescript-eslint/no-namespace`](https://typescript-eslint.io/rules/no-namespace/)
 - Using `Subject` generic, when a specific type could be used. Also the chained type returned is a string or nothing.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Solve the linter error by moving Cypress definitions to a definition file. Must not be in `types/`, otherwise rest of Cypress types are removed.

Followed Cypress guide about it: https://docs.cypress.io/guides/tooling/typescript-support#Using-an-External-Typings-File

Replaced `Subject` with concrete `HTMLMetaElement`. Remove unneeded extra type declaration in commands file.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
