### PR TITLE
test: standard theme color metadata setting two metas

### DIFF
--- a/projects/ngx-meta/e2e/cypress/fixtures/all-metadata.json
+++ b/projects/ngx-meta/e2e/cypress/fixtures/all-metadata.json
@@ -12,7 +12,10 @@
     "author": "Mr Bar",
     "keywords": ["foo", "bar"],
     "generator": true,
-    "themeColor": "blue"
+    "themeColor": [
+      { "media": "(prefers-color-scheme: dark)", "color": "darkblue" },
+      { "color": "lightblue" }
+    ]
   },
   "openGraph": {
     "image": {

--- a/projects/ngx-meta/e2e/cypress/support/commands.ts
+++ b/projects/ngx-meta/e2e/cypress/support/commands.ts
@@ -6,6 +6,10 @@ Cypress.Commands.add<'getMeta'>('getMeta', (name) => {
   cy.get(`meta[name="${name}"]`)
 })
 
+Cypress.Commands.add<'getMetas'>('getMetas', (name) => {
+  cy.get(`meta[name="${name}"]`)
+})
+
 Cypress.Commands.add<'getMetaWithProperty'>(
   'getMetaWithProperty',
   (property) => {

--- a/projects/ngx-meta/e2e/cypress/support/cypress.d.ts
+++ b/projects/ngx-meta/e2e/cypress/support/cypress.d.ts
@@ -5,6 +5,7 @@ declare global {
     interface Chainable {
       goToRootPage(): Chainable<void>
       getMeta(name: string): Chainable<HTMLMetaElement>
+      getMetas(name: string): Chainable<JQuery<HTMLMetaElement>>
       getMetaWithProperty(property: string): Chainable<HTMLMetaElement>
       shouldHaveContent(): Chainable<string | null>
       simulateSSRForRequest(url: RouteMatcher): Chainable<void>

--- a/projects/ngx-meta/e2e/cypress/support/metadata/standard.ts
+++ b/projects/ngx-meta/e2e/cypress/support/metadata/standard.ts
@@ -14,16 +14,28 @@ export const shouldContainAllStandardMetadata = () =>
           .and('eq', metadata.standard.keywords.join(','))
         cy.getMeta('generator')
           .shouldHaveContent()
-          .and('match', /^Angular v/)
+          .and('match', /^Angular v1/)
         //👆 v1 cause we E2E test v15+
         cy.getMeta('application-name')
           .shouldHaveContent()
           .and('eq', metadata.applicationName)
         standardCanonicalUrlShouldEqual(metadata.canonicalUrl)
         cy.get('html').should('have.attr', 'lang').and('eq', metadata.locale)
-        cy.getMeta('theme-color')
-          .shouldHaveContent()
-          .and('eq', metadata.standard.themeColor)
+        cy.getMetas('theme-color')
+          .should('have.length', metadata.standard.themeColor.length)
+          .each((element, index) => {
+            cy.wrap(element)
+              .shouldHaveContent()
+              .and('eq', metadata.standard.themeColor[index].color)
+            const media = metadata.standard.themeColor[index].media
+            if (media) {
+              cy.wrap(element)
+                .should('have.attr', 'media')
+                .and('eq', metadata.standard.themeColor[index].media)
+            } else {
+              cy.wrap(element).should('not.have.attr', 'media')
+            }
+          })
       },
     )
   })


### PR DESCRIPTION
# Issue or need

After trying to rebuild the APIs to set `<meta>` elements on the page  (`NgxMetaMetaService`, `NgxMetaMetaDefinition`, ...), inspected how Angular's `Meta` APIs work

And at that point in time wondered what happens with the case that more than one multiple `<meta>` element with same `name` is valid. Like in the case of standard's `<meta name='theme-color'>`.

So added some E2E tests to see what happens when trying to add 2 `<meta name='theme-color'>`. One for dark mode and another for the default (light) mode.

Turns out that the API wasn't working as intended when trying to insert more than one `<meta>`. 2 elements are expected if providing an array with two elements.

However just one is created and later updated. Which makes sense given we call Angular's `Meta.updateTag` API.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add E2E tests to reflect the issue & avoid it from happening in the future.

In #919 new APIs to manage `<meta>` elements are used around. So this should fix the issue. Adding here the tests then to ensure it doesn't repeat again.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
