### PR TITLE
chore: add util to make (lazy) injection tokens

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -118,6 +118,9 @@ export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaD
     separator?: string;
 }
 
+// @internal
+export const _makeInjectionToken: <T>(description: string, factory: () => T) => InjectionToken<T>;
+
 // @public
 export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 

--- a/projects/ngx-meta/src/core/src/utils/index.ts
+++ b/projects/ngx-meta/src/core/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { _isDefined } from './is-defined'
+export { _makeInjectionToken } from './make-injection-token'

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.spec.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.spec.ts
@@ -1,0 +1,94 @@
+import {
+  _makeInjectionToken,
+  INJECTION_TOKEN_FACTORIES,
+  INJECTION_TOKENS,
+} from './make-injection-token'
+import { TestBed } from '@angular/core/testing'
+import { InjectionToken } from '@angular/core'
+
+describe('make injection token', () => {
+  const sut = _makeInjectionToken
+  const description = 'dummy'
+  const factory = () => description
+
+  afterEach(() => {
+    INJECTION_TOKENS.clear()
+    INJECTION_TOKEN_FACTORIES.clear()
+  })
+
+  it('should return an injection token using the provided factory', () => {
+    const factoryOutput = factory()
+    const injectionToken = sut(description, factory)
+
+    expect(TestBed.inject(injectionToken)).toEqual(factoryOutput)
+  })
+
+  it('should return an injection token with given description prefixed by library name', () => {
+    const injectionToken = sut(description, factory)
+
+    expect(injectionToken.toString()).toContain(`ngx-meta ${description}`)
+  })
+
+  describe('when making an already existing token', () => {
+    let injectionToken: InjectionToken<ReturnType<typeof factory>>
+
+    beforeEach(() => {
+      spyOn(console, 'warn')
+      injectionToken = sut(description, factory)
+    })
+
+    const shouldNotLogAnyMessage = () =>
+      it('should not log any message', () => {
+        expect(console.warn).not.toHaveBeenCalled()
+      })
+
+    describe('when providing another description', () => {
+      let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
+
+      beforeEach(() => {
+        secondInjectionToken = sut('another-description', factory)
+      })
+
+      it('should return another injection token', () => {
+        expect(injectionToken).not.toBe(secondInjectionToken)
+      })
+
+      shouldNotLogAnyMessage()
+    })
+
+    describe('when providing same description and factory', () => {
+      let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
+
+      beforeEach(() => {
+        secondInjectionToken = sut(description, factory)
+      })
+
+      it('should return the same injection token', () => {
+        expect(injectionToken).toBe(secondInjectionToken)
+      })
+
+      shouldNotLogAnyMessage()
+    })
+
+    describe('when providing same description but different factory', () => {
+      const anotherFactory = () => 'another'
+      let secondInjectionToken: InjectionToken<
+        ReturnType<typeof anotherFactory>
+      >
+
+      beforeEach(() => {
+        secondInjectionToken = sut(description, anotherFactory)
+      })
+
+      it('should return the same injection token if providing same description but different factory', () => {
+        expect(secondInjectionToken).toBe(injectionToken)
+      })
+
+      it('should warn about it', () => {
+        expect(console.warn).toHaveBeenCalledWith(
+          jasmine.stringContaining('same description but different factory'),
+        )
+      })
+    })
+  })
+})

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
@@ -1,0 +1,41 @@
+import { InjectionToken } from '@angular/core'
+import { _formatDevMessage } from '../messaging'
+import { MODULE_NAME } from '../module-name'
+
+export const INJECTION_TOKENS = new Map<string, InjectionToken<unknown>>()
+export const INJECTION_TOKEN_FACTORIES = new Map<string, () => unknown>()
+
+/**
+ * See https://github.com/davidlj95/ngx/pull/892
+ *
+ * @internal
+ */
+export const _makeInjectionToken: <T>(
+  description: string,
+  factory: () => T,
+) => InjectionToken<T> = (description, factory) => {
+  const injectionToken =
+    INJECTION_TOKENS.get(description) ??
+    new InjectionToken(`ngx-meta ${description}`, { factory })
+  /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
+  if (ngDevMode) {
+    if ((INJECTION_TOKEN_FACTORIES.get(description) ?? factory) !== factory) {
+      console.warn(
+        _formatDevMessage(
+          [
+            'trying to create an injection token with same description but different factory. ',
+            'The existing injection token will be used and this new factory will be ignored. ',
+            'This use case is a bit weird anyway. Ensure no duplicate injection tokens are created. ',
+          ].join('\n'),
+          {
+            module: MODULE_NAME,
+            value: description,
+          },
+        ),
+      )
+    }
+    INJECTION_TOKEN_FACTORIES.set(description, factory)
+  }
+  INJECTION_TOKENS.set(description, injectionToken)
+  return injectionToken
+}


### PR DESCRIPTION
# Issue or need

See #891

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a util to define injection tokens & its factories in a lazy manner. This way, if no one needs them, they won't be created. Neither their factories will end up in the production bundle.

Came with this APIs eventually, though first iteration was `<T>(...args: ConstructorParameters<InjectionToken<T>>) => InjectionToken<T>`. Then, thought that maybe could uncouple to the parameters of the `InjectionToken`. So went with `<T>(injectionTokenFactory: () => InjectionToken<T>) => T`. But then when using the API, we're adding yet another level of indent. Finally, thought that we're also adding `NgxMeta` around in our injection tokens. If we supplied the name here, we could avoid repeating that string around. Plus save the `{ factory: [...] }` object declaration around. So here it is. Tried it a bit with `_HEAD_ELEMENT_UPSERT_OR_REMOVE`. Works fine.

The name went from `lazyInjectionToken` to `makeInjectionToken` given it also adds the library prefix to the injection token name now.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
