### PR TITLE
test: add and use util to inject one metadata manager

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -99,6 +99,9 @@ export const _HEAD_ELEMENT_UPSERT_OR_REMOVE: InjectionToken<_HeadElementUpsertOr
 // @internal (undocumented)
 export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
 
+// @internal (undocumented)
+export const _injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager>;
+
 // @internal
 export const _isDefined: <T>(value: T | null | undefined) => value is T;
 

--- a/projects/ngx-meta/src/__tests__/inject-one-metadata-manager.ts
+++ b/projects/ngx-meta/src/__tests__/inject-one-metadata-manager.ts
@@ -1,0 +1,23 @@
+/**
+ * Injects the only metadata manager found.
+ *
+ * Throws if no one is found or more than one is found.
+ */
+import {
+  _injectMetadataManagers,
+  NgxMetaMetadataManager,
+} from '@davidlj95/ngx-meta/core'
+import { TestBed } from '@angular/core/testing'
+
+export const injectOneMetadataManager = <T>(): NgxMetaMetadataManager<T> => {
+  const managers = TestBed.runInInjectionContext(_injectMetadataManagers)
+  if (managers.length > 1) {
+    throw new Error(
+      `More than one metadata manager found (${managers.length}). Just one is expected`,
+    )
+  }
+  if (managers.length === 0) {
+    throw new Error(`No metadata manager found. One is expected`)
+  }
+  return managers[0]
+}

--- a/projects/ngx-meta/src/core/src/managers/index.ts
+++ b/projects/ngx-meta/src/core/src/managers/index.ts
@@ -4,6 +4,7 @@ export {
   MakeMetadataManagerProviderFromSetterFactoryOptions,
 } from './make-metadata-manager-provider-from-setter-factory'
 export {
+  _injectMetadataManagers,
   NgxMetaMetadataManager,
   MetadataSetter,
   MetadataResolverOptions,

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, Provider } from '@angular/core'
 import {
-  injectMetadataManagers,
+  _injectMetadataManagers,
   NgxMetaMetadataManager,
 } from './ngx-meta-metadata-manager'
 
@@ -13,7 +13,7 @@ export interface MetadataRegistry {
 }
 
 const metadataRegistryFactory: () => MetadataRegistry = () => {
-  const managers = injectMetadataManagers()
+  const managers = _injectMetadataManagers()
   const managersById = new Map<string, NgxMetaMetadataManager>()
   const register: MetadataRegistry['register'] = (manager) => {
     if (managersById.has(manager.id)) {

--- a/projects/ngx-meta/src/core/src/managers/ngx-meta-metadata-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/ngx-meta-metadata-manager.ts
@@ -36,7 +36,10 @@ export abstract class NgxMetaMetadataManager<Value = unknown> {
   abstract readonly set: MetadataSetter<Value>
 }
 
-export const injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager> =
+/**
+ * @internal
+ */
+export const _injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager> =
   () =>
     // https://stackoverflow.com/q/74598049/3263250
     (inject(NgxMetaMetadataManager, {

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
@@ -1,14 +1,18 @@
 import { TestBed } from '@angular/core/testing'
-import { MockProviders } from 'ng-mocks'
-import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import { MockProvider } from 'ng-mocks'
+import {
+  NgxMetaMetadataManager,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { OpenGraphImage } from './open-graph-image'
 import { OpenGraph } from '../../types'
-import { OPEN_GRAPH_IMAGE_SETTER_FACTORY } from './open-graph-image-metadata-provider'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
+import { OPEN_GRAPH_IMAGE_METADATA_PROVIDER } from './open-graph-image-metadata-provider'
 
-describe('Open Graph image metadata', () => {
+describe('Open Graph image metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<OpenGraph['image']>
+  let sut: NgxMetaMetadataManager<OpenGraph['image']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
 
   beforeEach(() => {
@@ -29,7 +33,7 @@ describe('Open Graph image metadata', () => {
 
   describe('when url is provided', () => {
     it('should set all meta properties', () => {
-      sut(image)
+      sut.set(image)
 
       const props = Object.keys(image).length
       expect(metaService.set).toHaveBeenCalledTimes(props)
@@ -62,7 +66,7 @@ describe('Open Graph image metadata', () => {
 
   describe('when no url is defined', () => {
     it('should remove all meta properties', () => {
-      sut({ ...image, url: undefined })
+      sut.set({ ...image, url: undefined })
 
       const props = Object.keys(image).length
       expect(metaService.set).toHaveBeenCalledTimes(props)
@@ -73,9 +77,12 @@ describe('Open Graph image metadata', () => {
   })
 })
 
-function makeSut(): MetadataSetter<OpenGraph['image']> {
+function makeSut(): NgxMetaMetadataManager<OpenGraph['image']> {
   TestBed.configureTestingModule({
-    providers: [MockProviders(NgxMetaMetaService)],
+    providers: [
+      MockProvider(NgxMetaMetaService),
+      OPEN_GRAPH_IMAGE_METADATA_PROVIDER,
+    ],
   })
-  return OPEN_GRAPH_IMAGE_SETTER_FACTORY(TestBed.inject(NgxMetaMetaService))
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
@@ -2,18 +2,19 @@ import { TestBed } from '@angular/core/testing'
 import {
   _URL_RESOLVER,
   _UrlResolver,
-  MetadataSetter,
+  NgxMetaMetadataManager,
   NgxMetaMetaService,
 } from '@davidlj95/ngx-meta/core'
 import { OpenGraph } from '../../types'
-import { OPEN_GRAPH_URL_SETTER_FACTORY } from './open-graph-url-metadata-provider'
+import { OPEN_GRAPH_URL_METADATA_PROVIDER } from './open-graph-url-metadata-provider'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MockProvider } from 'ng-mocks'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 
-describe('Open Graph URL metadata', () => {
+describe('Open Graph URL metadata manager', () => {
   enableAutoSpy()
   let urlResolver: jasmine.Spy<_UrlResolver>
-  let sut: MetadataSetter<OpenGraph['url']>
+  let sut: NgxMetaMetadataManager<OpenGraph['url']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
   const dummyUrl = 'dummy-url'
   const dummyResolvedUrl = 'https://example.com/dummy-resolved-url'
@@ -27,7 +28,7 @@ describe('Open Graph URL metadata', () => {
   })
 
   it('should use resolved URL as metadata value', () => {
-    sut(dummyUrl)
+    sut.set(dummyUrl)
 
     expect(metaService.set).toHaveBeenCalledWith(
       jasmine.anything(),
@@ -39,7 +40,7 @@ describe('Open Graph URL metadata', () => {
 
 function makeSut(opts: {
   urlResolver: _UrlResolver
-}): MetadataSetter<OpenGraph['url']> {
+}): NgxMetaMetadataManager<OpenGraph['url']> {
   TestBed.configureTestingModule({
     providers: [
       MockProvider(NgxMetaMetaService),
@@ -47,10 +48,8 @@ function makeSut(opts: {
         provide: _URL_RESOLVER,
         useValue: opts.urlResolver ?? jasmine.createSpy(),
       },
+      OPEN_GRAPH_URL_METADATA_PROVIDER,
     ],
   })
-  return OPEN_GRAPH_URL_SETTER_FACTORY(
-    TestBed.inject(NgxMetaMetaService),
-    TestBed.inject(_URL_RESOLVER),
-  )
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
@@ -4,12 +4,14 @@ import {
   _HeadElementUpsertOrRemove,
   _URL_RESOLVER,
   _UrlResolver,
+  NgxMetaMetadataManager,
 } from '@davidlj95/ngx-meta/core'
 import { TestBed } from '@angular/core/testing'
-import { STANDARD_CANONICAL_URL_SETTER_FACTORY } from './standard-canonical-url-metadata-provider'
-import { DOCUMENT } from '@angular/common'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
+import { Standard } from '../types'
+import { STANDARD_CANONICAL_URL_METADATA_PROVIDER } from './standard-canonical-url-metadata-provider'
 
-describe('Standard canonical URL metadata provider', () => {
+describe('Standard canonical URL metadata manager', () => {
   enableAutoSpy()
 
   const LINK_REL_CANONICAL_SELECTOR = "link[rel='canonical']"
@@ -23,7 +25,7 @@ describe('Standard canonical URL metadata provider', () => {
             jasmine.createSpy<_HeadElementUpsertOrRemove>()
           const sut = makeSut({ headElementUpsertOrRemove })
 
-          sut(testCase)
+          sut.set(testCase)
 
           expect(headElementUpsertOrRemove).toHaveBeenCalledWith(
             LINK_REL_CANONICAL_SELECTOR,
@@ -51,7 +53,7 @@ describe('Standard canonical URL metadata provider', () => {
         })
       const sut = makeSut({ headElementUpsertOrRemove })
 
-      sut(dummyAbsoluteUrl)
+      sut.set(dummyAbsoluteUrl)
 
       expect(receivedSelector).toEqual(LINK_REL_CANONICAL_SELECTOR)
       expect(receivedElement?.tagName.toLowerCase()).toEqual('link')
@@ -72,7 +74,7 @@ describe('Standard canonical URL metadata provider', () => {
 
       const sut = makeSut({ headElementUpsertOrRemove, urlResolver })
 
-      sut(dummyRelativeUrl)
+      sut.set(dummyRelativeUrl)
 
       expect(receivedElement?.getAttribute('href')).toEqual(dummyAbsoluteUrl)
     })
@@ -85,7 +87,7 @@ describe('Standard canonical URL metadata provider', () => {
 
       const sut = makeSut({ urlResolver })
 
-      sut(dummyRelativeUrl)
+      sut.set(dummyRelativeUrl)
 
       expect(console.warn).toHaveBeenCalledWith(
         jasmine.stringContaining('should be absolute'),
@@ -99,7 +101,7 @@ const makeSut = (
     headElementUpsertOrRemove?: _HeadElementUpsertOrRemove
     urlResolver?: _UrlResolver
   } = {},
-) => {
+): NgxMetaMetadataManager<Standard['canonicalUrl']> => {
   TestBed.configureTestingModule({
     providers: [
       {
@@ -116,11 +118,8 @@ const makeSut = (
             .createSpy<_UrlResolver>('URL Resolver')
             .and.callFake((url) => url?.toString()),
       },
+      STANDARD_CANONICAL_URL_METADATA_PROVIDER,
     ],
   })
-  return STANDARD_CANONICAL_URL_SETTER_FACTORY(
-    TestBed.inject(_HEAD_ELEMENT_UPSERT_OR_REMOVE),
-    TestBed.inject(DOCUMENT),
-    TestBed.inject(_URL_RESOLVER),
-  )
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
@@ -1,14 +1,18 @@
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
-import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import {
+  NgxMetaMetadataManager,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { VERSION } from '@angular/core'
 import { Standard } from '../types'
-import { STANDARD_GENERATOR_METADATA_SETTER_FACTORY } from './standard-generator-metadata-provider'
+import { STANDARD_GENERATOR_METADATA_PROVIDER } from './standard-generator-metadata-provider'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 
-describe('Standard generator metadata', () => {
+describe('Standard generator metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<Standard['generator']>
+  let sut: NgxMetaMetadataManager<Standard['generator']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
 
   beforeEach(() => {
@@ -18,34 +22,42 @@ describe('Standard generator metadata', () => {
     ) as jasmine.SpyObj<NgxMetaMetaService>
   })
 
-  it('when not provided should call meta service with nothing value', () => {
-    sut(undefined)
+  describe('when not provided', () => {
+    const TEST_CASES = [null, undefined]
+    TEST_CASES.forEach((testCase) => {
+      describe(`like when ${testCase}`, () => {
+        it(`should call meta service with ${testCase}`, () => {
+          sut.set(undefined)
 
-    expect(metaService.set).toHaveBeenCalledOnceWith(
-      jasmine.anything(),
-      undefined,
-    )
+          expect(metaService.set).toHaveBeenCalledOnceWith(
+            jasmine.anything(),
+            undefined,
+          )
+        })
+      })
+    })
   })
-  it('when null should call meta service with null value', () => {
-    sut(null)
 
-    expect(metaService.set).toHaveBeenCalledOnceWith(jasmine.anything(), null)
-  })
-  it('when true should call meta service with Angular version as value', () => {
-    sut(true)
+  describe('when true', () => {
+    const value: Standard['generator'] = true
 
-    expect(metaService.set).toHaveBeenCalledOnceWith(
-      jasmine.anything(),
-      `Angular v${VERSION.full}`,
-    )
+    it('should call meta service with Angular version as value', () => {
+      sut.set(value)
+
+      expect(metaService.set).toHaveBeenCalledOnceWith(
+        jasmine.anything(),
+        `Angular v${VERSION.full}`,
+      )
+    })
   })
 })
 
-function makeSut(): MetadataSetter<Standard['generator']> {
+function makeSut(): NgxMetaMetadataManager<Standard['generator']> {
   TestBed.configureTestingModule({
-    providers: [MockProvider(NgxMetaMetaService)],
+    providers: [
+      MockProvider(NgxMetaMetaService),
+      STANDARD_GENERATOR_METADATA_PROVIDER,
+    ],
   })
-  return STANDARD_GENERATOR_METADATA_SETTER_FACTORY(
-    TestBed.inject(NgxMetaMetaService),
-  )
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-keywords-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-keywords-metadata-provider.spec.ts
@@ -1,13 +1,17 @@
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
-import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import {
+  NgxMetaMetadataManager,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { Standard } from '../types'
-import { STANDARD_KEYWORDS_METADATA_SETTER_FACTORY } from './standard-keywords-metadata-provider'
+import { STANDARD_KEYWORDS_METADATA_PROVIDER } from './standard-keywords-metadata-provider'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 
-describe('Standard keywords metadata', () => {
+describe('Standard keywords metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<Standard['keywords']>
+  let sut: NgxMetaMetadataManager<Standard['keywords']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
 
   beforeEach(() => {
@@ -22,7 +26,7 @@ describe('Standard keywords metadata', () => {
     const secondKeyword = 'second'
     const thirdKeyword = 'third'
 
-    sut([firstKeyword, secondKeyword, thirdKeyword])
+    sut.set([firstKeyword, secondKeyword, thirdKeyword])
 
     expect(metaService.set).toHaveBeenCalledOnceWith(
       jasmine.anything(),
@@ -31,11 +35,12 @@ describe('Standard keywords metadata', () => {
   })
 })
 
-function makeSut(): MetadataSetter<Standard['keywords']> {
+function makeSut(): NgxMetaMetadataManager<Standard['keywords']> {
   TestBed.configureTestingModule({
-    providers: [MockProvider(NgxMetaMetaService)],
+    providers: [
+      MockProvider(NgxMetaMetaService),
+      STANDARD_KEYWORDS_METADATA_PROVIDER,
+    ],
   })
-  return STANDARD_KEYWORDS_METADATA_SETTER_FACTORY(
-    TestBed.inject(NgxMetaMetaService),
-  )
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
@@ -2,12 +2,13 @@ import { TestBed } from '@angular/core/testing'
 
 import { DOCUMENT } from '@angular/common'
 import { HtmlLangAttributeHarness } from './__tests__/html-lang-attribute-harness'
-import { MetadataSetter } from '@davidlj95/ngx-meta/core'
+import { NgxMetaMetadataManager } from '@davidlj95/ngx-meta/core'
 import { Standard } from '../types'
-import { STANDARD_LOCALE_METADATA_SETTER_FACTORY } from './standard-locale-metadata-provider'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
+import { STANDARD_LOCALE_METADATA_PROVIDER } from './standard-locale-metadata-provider'
 
 describe('Standard locale metadata', () => {
-  let sut: MetadataSetter<Standard['locale']>
+  let sut: NgxMetaMetadataManager<Standard['locale']>
   let htmlLangAttributeHarness: HtmlLangAttributeHarness
 
   beforeEach(() => {
@@ -22,15 +23,19 @@ describe('Standard locale metadata', () => {
   })
 
   describe('when locale is not provided', () => {
-    const locale = undefined
+    const TEST_CASES = [undefined, null]
 
-    it('should remove HTML element lang attribute', () => {
-      htmlLangAttributeHarness.set('es')
-      expect(htmlLangAttributeHarness.get()).toBeTruthy()
+    TEST_CASES.forEach((testCase) => {
+      describe(`like when ${testCase}`, () => {
+        it('should remove HTML element lang attribute', () => {
+          htmlLangAttributeHarness.set('es')
+          expect(htmlLangAttributeHarness.get()).toBeTruthy()
 
-      sut(locale)
+          sut.set(testCase)
 
-      expect(htmlLangAttributeHarness.get()).toBeNull()
+          expect(htmlLangAttributeHarness.get()).toBeNull()
+        })
+      })
     })
   })
 
@@ -38,29 +43,18 @@ describe('Standard locale metadata', () => {
     const locale = 'es-ES'
 
     it('should update HTML element lang attribute', () => {
-      sut(locale)
+      sut.set(locale)
 
       const htmlTagLangAttribute = htmlLangAttributeHarness.get()
       expect(htmlTagLangAttribute).not.toBeNull()
       expect(htmlTagLangAttribute?.value).toEqual(locale)
     })
   })
-
-  describe('when locale is null', () => {
-    const locale = null
-
-    it('should remove HTML element lang attribute', () => {
-      htmlLangAttributeHarness.set('es')
-      expect(htmlLangAttributeHarness.get()).toBeTruthy()
-
-      sut(locale)
-
-      expect(htmlLangAttributeHarness.get()).toBeNull()
-    })
-  })
 })
 
-function makeSut(): MetadataSetter<Standard['locale']> {
-  TestBed.configureTestingModule({})
-  return STANDARD_LOCALE_METADATA_SETTER_FACTORY(TestBed.inject(DOCUMENT))
+function makeSut(): NgxMetaMetadataManager<Standard['locale']> {
+  TestBed.configureTestingModule({
+    providers: [STANDARD_LOCALE_METADATA_PROVIDER],
+  })
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.spec.ts
@@ -1,15 +1,19 @@
-import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import {
+  NgxMetaMetadataManager,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { Standard } from '../types'
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
-import { STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY } from './standard-theme-color-metadata-provider'
+import { STANDARD_THEME_COLOR_METADATA_PROVIDER } from './standard-theme-color-metadata-provider'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { MetaDefinition } from '@angular/platform-browser'
 import { StandardThemeColorMetadataObject } from './standard-theme-color-metadata'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 
-describe('Standard theme color metadata', () => {
+describe('Standard theme color metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<Standard['themeColor']>
+  let sut: NgxMetaMetadataManager<Standard['themeColor']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
 
   const DUMMY_COLOR = 'black'
@@ -23,7 +27,7 @@ describe('Standard theme color metadata', () => {
   })
 
   it('should call the meta service with no value when no value provided', () => {
-    sut(undefined)
+    sut.set(undefined)
 
     expect(metaService.set).toHaveBeenCalledOnceWith(
       jasmine.anything(),
@@ -32,7 +36,7 @@ describe('Standard theme color metadata', () => {
   })
 
   it('should call the meta service with the specified content when a string value is provided', () => {
-    sut(DUMMY_COLOR)
+    sut.set(DUMMY_COLOR)
 
     expect(metaService.set).toHaveBeenCalledOnceWith(
       jasmine.anything(),
@@ -41,7 +45,7 @@ describe('Standard theme color metadata', () => {
   })
 
   it('should call the meta service with no value when an empty array is provided', () => {
-    sut([])
+    sut.set([])
 
     expect(metaService.set).toHaveBeenCalledOnceWith(
       jasmine.anything(),
@@ -57,7 +61,7 @@ describe('Standard theme color metadata', () => {
     const secondMediaDefinition = {
       color: 'white',
     } satisfies MetaDefinition & StandardThemeColorMetadataObject
-    sut([firstMediaDefinition, secondMediaDefinition])
+    sut.set([firstMediaDefinition, secondMediaDefinition])
 
     expect(metaService.set).toHaveBeenCalledWith(
       jasmine.anything(),
@@ -87,11 +91,12 @@ describe('Standard theme color metadata', () => {
   })
 })
 
-function makeSut(): MetadataSetter<Standard['themeColor']> {
+function makeSut(): NgxMetaMetadataManager<Standard['themeColor']> {
   TestBed.configureTestingModule({
-    providers: [MockProvider(NgxMetaMetaService)],
+    providers: [
+      MockProvider(NgxMetaMetaService),
+      STANDARD_THEME_COLOR_METADATA_PROVIDER,
+    ],
   })
-  return STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY(
-    TestBed.inject(NgxMetaMetaService),
-  )
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/standard/src/managers/standard-title-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-title-metadata-provider.spec.ts
@@ -2,13 +2,14 @@ import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
 import { Title } from '@angular/platform-browser'
-import { MetadataSetter } from '@davidlj95/ngx-meta/core'
+import { NgxMetaMetadataManager } from '@davidlj95/ngx-meta/core'
 import { Standard } from '../types'
-import { STANDARD_TITLE_METADATA_SETTER_FACTORY } from './standard-title-metadata-provider'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
+import { STANDARD_TITLE_METADATA_PROVIDER } from './standard-title-metadata-provider'
 
-describe('Standard title metadata', () => {
+describe('Standard title metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<Standard['title']>
+  let sut: NgxMetaMetadataManager<Standard['title']>
   let titleService: jasmine.SpyObj<Title>
 
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe('Standard title metadata', () => {
   })
 
   it('should not update title when title is not provided ', () => {
-    sut(undefined)
+    sut.set(undefined)
 
     expect(titleService.setTitle).not.toHaveBeenCalled()
   })
@@ -25,7 +26,7 @@ describe('Standard title metadata', () => {
   it('should update title when title is empty ', () => {
     const pageTitle = ''
 
-    sut(pageTitle)
+    sut.set(pageTitle)
 
     expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
   })
@@ -33,15 +34,15 @@ describe('Standard title metadata', () => {
   it('should update title when title is provided', () => {
     const pageTitle = 'Page title'
 
-    sut(pageTitle)
+    sut.set(pageTitle)
 
     expect(titleService.setTitle).toHaveBeenCalledOnceWith(pageTitle)
   })
 })
 
-function makeSut(): MetadataSetter<Standard['title']> {
+function makeSut(): NgxMetaMetadataManager<Standard['title']> {
   TestBed.configureTestingModule({
-    providers: [MockProvider(Title)],
+    providers: [MockProvider(Title), STANDARD_TITLE_METADATA_PROVIDER],
   })
-  return STANDARD_TITLE_METADATA_SETTER_FACTORY(TestBed.inject(Title))
+  return injectOneMetadataManager()
 }

--- a/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.spec.ts
@@ -1,17 +1,18 @@
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
-import { MetadataSetter, NgxMetaMetaService } from '@davidlj95/ngx-meta/core'
+import {
+  NgxMetaMetadataManager,
+  NgxMetaMetaService,
+} from '@davidlj95/ngx-meta/core'
 import { TestBed } from '@angular/core/testing'
 import { MockProviders } from 'ng-mocks'
 import { TwitterCard } from '../types'
-import {
-  TWITTER_CARD_IMAGE_METADATA_PROVIDER,
-  TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY,
-} from './twitter-card-image-metadata-provider'
+import { TWITTER_CARD_IMAGE_METADATA_PROVIDER } from './twitter-card-image-metadata-provider'
 import { TwitterCardImage } from './twitter-card-image'
+import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 
-describe('Twitter Card image metadata', () => {
+describe('Twitter Card image metadata manager', () => {
   enableAutoSpy()
-  let sut: MetadataSetter<TwitterCard['image']>
+  let sut: NgxMetaMetadataManager<TwitterCard['image']>
   let metaService: jasmine.SpyObj<NgxMetaMetaService>
 
   beforeEach(() => {
@@ -29,7 +30,7 @@ describe('Twitter Card image metadata', () => {
   describe('when image is provided', () => {
     it('should set all meta properties', () => {
       // noinspection DuplicatedCode
-      sut(image)
+      sut.set(image)
 
       const props = Object.keys(image).length
       expect(metaService.set).toHaveBeenCalledTimes(props)
@@ -46,7 +47,7 @@ describe('Twitter Card image metadata', () => {
 
   describe('when no image provided', () => {
     it('should remove all meta properties', () => {
-      sut(undefined)
+      sut.set(undefined)
 
       const props = Object.keys(image).length
       expect(metaService.set).toHaveBeenCalledTimes(props)
@@ -60,14 +61,12 @@ describe('Twitter Card image metadata', () => {
   })
 })
 
-function makeSut(): MetadataSetter<TwitterCard['image']> {
+function makeSut(): NgxMetaMetadataManager<TwitterCard['image']> {
   TestBed.configureTestingModule({
     providers: [
       MockProviders(NgxMetaMetaService),
       TWITTER_CARD_IMAGE_METADATA_PROVIDER,
     ],
   })
-  return TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY(
-    TestBed.inject(NgxMetaMetaService),
-  )
+  return injectOneMetadataManager()
 }


### PR DESCRIPTION
# Issue or need

A trick is used right now for existing metadata manager tests in order to unit test the metadata manager (its setter, actually).
This is done because metadata managers are provided as part of a `multi` provider for the `NgxMetaMetadataManager` token / abstract class.

So can't inject one specifically.

The trick has been to export the setter factory (that comes with dependencies as arguments). Then, when unit testing, manually inject the needed dependencies.

This is not ideal because it doesn't reflect real use (where automatic injection is done). 

And now is an impediment for a subsequent refactor removing the `deps` usage by calls to `inject` in the factory. Then, a way is needed to unit test metadata managers without manually injecting. As otherwise, an error will appear about using `inject` in a non-injection context.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Introduce `injectOneMetadataManager` util for tests. Which will inject the only metadata manager existing. Or throw otherwise.

`injectMetadataManagers` has been internally exported in order to use it for that util too.

Then, use that util around to avoid the trick.

Other changes: unite `undefined` / `null` test cases in a describe + for loop.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
