### PR TITLE
Revert "refactor: add head element util inject function and use it (#894)"

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -100,9 +100,6 @@ export const _HEAD_ELEMENT_UPSERT_OR_REMOVE: InjectionToken<_HeadElementUpsertOr
 export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
 
 // @internal (undocumented)
-export const _injectHeadElementUpsertOrRemove: () => _HeadElementUpsertOrRemove;
-
-// @internal (undocumented)
 export const _injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager>;
 
 // @internal

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -3,8 +3,8 @@ import { TestBed } from '@angular/core/testing'
 import { HeadElementHarness } from './__tests__/head-element-harness'
 import { DOCUMENT } from '@angular/common'
 import {
+  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
   _HeadElementUpsertOrRemove,
-  _injectHeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'
 
 describe('Head element upsert or remove', () => {
@@ -95,5 +95,5 @@ describe('Head element upsert or remove', () => {
 
 function makeSut() {
   TestBed.configureTestingModule({})
-  return TestBed.runInInjectionContext(_injectHeadElementUpsertOrRemove)
+  return TestBed.inject(_HEAD_ELEMENT_UPSERT_OR_REMOVE)
 }

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
@@ -33,9 +33,3 @@ export type _HeadElementUpsertOrRemove = (
   selector: string,
   element: HTMLElement | null | undefined,
 ) => void
-
-/**
- * @internal
- */
-export const _injectHeadElementUpsertOrRemove = () =>
-  inject(_HEAD_ELEMENT_UPSERT_OR_REMOVE)

--- a/projects/ngx-meta/src/core/src/head-elements/index.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/index.ts
@@ -1,5 +1,4 @@
 export {
   _HEAD_ELEMENT_UPSERT_OR_REMOVE,
   _HeadElementUpsertOrRemove,
-  _injectHeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'

--- a/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
@@ -1,22 +1,21 @@
+import { DOCUMENT } from '@angular/common'
 import {
-  _injectHeadElementUpsertOrRemove,
+  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _HeadElementUpsertOrRemove,
   _isDefined,
   makeMetadataManagerProviderFromSetterFactory,
   MetadataSetterFactory,
 } from '@davidlj95/ngx-meta/core'
 import { JsonLdMetadata } from './json-ld-metadata'
-import { DOCUMENT } from '@angular/common'
-import { inject } from '@angular/core'
 
 const KEY = 'jsonLd' satisfies keyof JsonLdMetadata
 const SCRIPT_TYPE = 'application/ld+json'
 
 export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   JsonLdMetadata[typeof KEY]
-> = () => {
-  const doc = inject(DOCUMENT)
-  const headElementUpsertOrRemove = _injectHeadElementUpsertOrRemove()
-  return (jsonLd) => {
+> =
+  (headElementUpsertOrRemove: _HeadElementUpsertOrRemove, doc: Document) =>
+  (jsonLd) => {
     let scriptElement: HTMLScriptElement | undefined
     if (_isDefined(jsonLd)) {
       scriptElement = doc.createElement('script')
@@ -25,7 +24,6 @@ export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
     }
     headElementUpsertOrRemove(`script[type='${SCRIPT_TYPE}']`, scriptElement)
   }
-}
 
 /**
  * Manages the {@link JsonLdMetadata.jsonLd} metadata
@@ -35,6 +33,7 @@ export const JSON_LD_METADATA_PROVIDER =
   makeMetadataManagerProviderFromSetterFactory(
     JSON_LD_METADATA_SETTER_FACTORY,
     {
+      d: [_HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT],
       jP: [KEY],
     },
   )

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
@@ -1,8 +1,8 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
 import {
   _GLOBAL_CANONICAL_URL,
+  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
   _HeadElementUpsertOrRemove,
-  _injectHeadElementUpsertOrRemove,
   _isDefined,
   _maybeNonHttpUrlDevMessage,
   _URL_RESOLVER,
@@ -12,17 +12,13 @@ import {
 import { DOCUMENT } from '@angular/common'
 import { Standard } from '../types'
 import { MODULE_NAME } from '../module-name'
-import { inject } from '@angular/core'
 
 export const STANDARD_CANONICAL_URL_SETTER_FACTORY: (
   headElementUpsertOrRemove: _HeadElementUpsertOrRemove,
   doc: Document,
   urlResolver: _UrlResolver,
-) => MetadataSetter<Standard[typeof _GLOBAL_CANONICAL_URL]> = () => {
-  const headElementUpsertOrRemove = _injectHeadElementUpsertOrRemove()
-  const doc = inject(DOCUMENT)
-  const urlResolver = inject(_URL_RESOLVER)
-  return (url) => {
+) => MetadataSetter<Standard[typeof _GLOBAL_CANONICAL_URL]> =
+  (headElementUpsertOrRemove, doc, urlResolver) => (url) => {
     const resolvedUrl = urlResolver(url)
     ngDevMode &&
       _maybeNonHttpUrlDevMessage(resolvedUrl, {
@@ -40,7 +36,6 @@ export const STANDARD_CANONICAL_URL_SETTER_FACTORY: (
     }
     headElementUpsertOrRemove(SELECTOR, linkElement)
   }
-}
 
 /**
  * Manages the {@link Standard.canonicalUrl} metadata
@@ -50,6 +45,7 @@ export const STANDARD_CANONICAL_URL_METADATA_PROVIDER =
   makeStandardMetadataProvider(_GLOBAL_CANONICAL_URL, {
     g: _GLOBAL_CANONICAL_URL,
     s: STANDARD_CANONICAL_URL_SETTER_FACTORY,
+    d: [_HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT, _URL_RESOLVER],
   })
 
 const LINK_TAG = 'link'


### PR DESCRIPTION
# Issue or need

After merging #894, wasn't quite happy with the increase in bundle size.

Studying it a little bit, seems it's actually cheaper (in terms of uncompressed bundle size) to use `deps`. This is because:
 - Avoid declaring variables & calling injectors. Which is an extra `let ` keyword (4 bytes) + `d=i(tk)` calls to the injection functions (2 extra bytes. As `tk`, `d` and one comma were already in the `deps` version). 4 bytes + 2 bytes * each dep.
 - Avoid creating another function within the function. Which is an extra `return ` keyword plus the extra `{` for the body. 8 bytes.
 - Avoid defining the injection function. Extra `fn=()=>i(tk)`. Extra 12 bytes

Given in there 2 factories were changed:
 - JSON LD: 4 bytes + 2 bytes * 2 deps + 8 bytes. Extra 16 bytes.
 - Standard canonical URL: 4 bytes + 2 bytes * 3 deps + 8 bytes. Extra 18 bytes.
 
 So 34 bytes + the injection function of 12 bytes -> 46 bytes moar.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Go back to injecting via the `deps` option of factory providers.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
