### PR TITLE
refactor: rename util to lazy injection token

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -113,6 +113,12 @@ export interface JsonLdMetadata {
     readonly jsonLd?: object | null;
 }
 
+// @internal
+export type _LazyInjectionToken<T> = () => InjectionToken<T>;
+
+// @internal
+export const _lazyInjectionToken: <T>(description: string, factory: () => T) => _LazyInjectionToken<T>;
+
 // @public
 export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, options?: MakeComposedKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 
@@ -120,9 +126,6 @@ export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, op
 export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaDefinitionOptions {
     separator?: string;
 }
-
-// @internal
-export const _makeInjectionToken: <T>(description: string, factory: () => T) => InjectionToken<T>;
 
 // @public
 export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;

--- a/projects/ngx-meta/src/core/src/utils/index.ts
+++ b/projects/ngx-meta/src/core/src/utils/index.ts
@@ -1,2 +1,5 @@
 export { _isDefined } from './is-defined'
-export { _makeInjectionToken } from './make-injection-token'
+export {
+  _lazyInjectionToken,
+  _LazyInjectionToken,
+} from './lazy-injection-token'

--- a/projects/ngx-meta/src/core/src/utils/lazy-injection-token.spec.ts
+++ b/projects/ngx-meta/src/core/src/utils/lazy-injection-token.spec.ts
@@ -1,13 +1,13 @@
 import {
-  _makeInjectionToken,
+  _lazyInjectionToken,
   INJECTION_TOKEN_FACTORIES,
   INJECTION_TOKENS,
-} from './make-injection-token'
+} from './lazy-injection-token'
 import { TestBed } from '@angular/core/testing'
 import { InjectionToken } from '@angular/core'
 
-describe('make injection token', () => {
-  const sut = _makeInjectionToken
+describe('lazy injection token', () => {
+  const sut = _lazyInjectionToken
   const description = 'dummy'
   const factory = () => description
 
@@ -16,25 +16,25 @@ describe('make injection token', () => {
     INJECTION_TOKEN_FACTORIES.clear()
   })
 
-  it('should return an injection token using the provided factory', () => {
+  it('should return a lazy injection token using the provided factory', () => {
     const factoryOutput = factory()
-    const injectionToken = sut(description, factory)
+    const lazyInjectionToken = sut(description, factory)
 
-    expect(TestBed.inject(injectionToken)).toEqual(factoryOutput)
+    expect(TestBed.inject(lazyInjectionToken())).toEqual(factoryOutput)
   })
 
-  it('should return an injection token with given description prefixed by library name', () => {
-    const injectionToken = sut(description, factory)
+  it('should return a lazy injection token with given description prefixed by library name', () => {
+    const lazyInjectionToken = sut(description, factory)
 
-    expect(injectionToken.toString()).toContain(`ngx-meta ${description}`)
+    expect(lazyInjectionToken().toString()).toContain(`ngx-meta ${description}`)
   })
 
-  describe('when making an already existing token', () => {
+  describe('when creating an already existing token', () => {
     let injectionToken: InjectionToken<ReturnType<typeof factory>>
 
     beforeEach(() => {
       spyOn(console, 'warn')
-      injectionToken = sut(description, factory)
+      injectionToken = sut(description, factory)()
     })
 
     const shouldNotLogAnyMessage = () =>
@@ -46,7 +46,7 @@ describe('make injection token', () => {
       let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
 
       beforeEach(() => {
-        secondInjectionToken = sut('another-description', factory)
+        secondInjectionToken = sut('another-description', factory)()
       })
 
       it('should return another injection token', () => {
@@ -60,7 +60,7 @@ describe('make injection token', () => {
       let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
 
       beforeEach(() => {
-        secondInjectionToken = sut(description, factory)
+        secondInjectionToken = sut(description, factory)()
       })
 
       it('should return the same injection token', () => {
@@ -77,7 +77,7 @@ describe('make injection token', () => {
       >
 
       beforeEach(() => {
-        secondInjectionToken = sut(description, anotherFactory)
+        secondInjectionToken = sut(description, anotherFactory)()
       })
 
       it('should return the same injection token if providing same description but different factory', () => {

--- a/projects/ngx-meta/src/core/src/utils/lazy-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/lazy-injection-token.ts
@@ -6,14 +6,16 @@ export const INJECTION_TOKENS = new Map<string, InjectionToken<unknown>>()
 export const INJECTION_TOKEN_FACTORIES = new Map<string, () => unknown>()
 
 /**
- * See https://github.com/davidlj95/ngx/pull/892
+ * A utility function to create lazy injection tokens.
+ *
+ * See {@link _LazyInjectionToken} for more information.
  *
  * @internal
  */
-export const _makeInjectionToken: <T>(
+export const _lazyInjectionToken: <T>(
   description: string,
   factory: () => T,
-) => InjectionToken<T> = (description, factory) => {
+) => _LazyInjectionToken<T> = (description, factory) => () => {
   const injectionToken =
     INJECTION_TOKENS.get(description) ??
     new InjectionToken(`ngx-meta ${description}`, { factory })
@@ -39,3 +41,18 @@ export const _makeInjectionToken: <T>(
   INJECTION_TOKENS.set(description, injectionToken)
   return injectionToken
 }
+
+/**
+ * Thunk to delay the instantiation of a new injection token.
+ * This way they can be tree-shaken if unused.
+ * As their factory functions can bring many unused bytes to the production bundle.
+ *
+ * See also:
+ *
+ * - {@link https://github.com/davidlj95/ngx/pull/892 | PR where need for this was discovered}
+ *
+ * - {@link https://en.wikipedia.org/wiki/Thunk | Thunk definition (computer science)}
+ *
+ * @internal
+ */
+export type _LazyInjectionToken<T> = () => InjectionToken<T>


### PR DESCRIPTION
# Issue or need

After giving a try to apply the recently created (in #892) function to create lazy injection tokens, found out a repeating pattern.

(Lazy) tokens were being declared as:

```typescript
const token = () => _makeInjectionToken('desc', factory)
```

The `() => ` part could actually be part of the util. Given will always be like that in order to allow tree shaking injection tokens.

Actually the util could be as is + then create another one `_lazy` that uses `_make` under the hood. 

Buuut the logic of lazyness is in the `_make` one (not creating 2 tokens if one exists). Soo makes sense that for now it's just one API. 

It's internal, so can be decomposed later if needed.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Rename util to `_lazyInjectionToken` as it will now return lazy injection tokens.

Add a type to specify what actually a `_LazyInjectionToken` is. Plus some docs.

Fix tests

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
