### PR TITLE
refactor: use lazy injection token for head utility

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -94,10 +94,10 @@ export interface GlobalMetadataImage {
 }
 
 // @internal (undocumented)
-export const _HEAD_ELEMENT_UPSERT_OR_REMOVE: InjectionToken<_HeadElementUpsertOrRemove>;
+export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
 
 // @internal (undocumented)
-export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
+export const _headElementUpsertOrRemove: _LazyInjectionToken<_HeadElementUpsertOrRemove>;
 
 // @internal (undocumented)
 export const _injectMetadataManagers: () => ReadonlyArray<NgxMetaMetadataManager>;

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing'
 import { HeadElementHarness } from './__tests__/head-element-harness'
 import { DOCUMENT } from '@angular/common'
 import {
-  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'
 
@@ -95,5 +95,5 @@ describe('Head element upsert or remove', () => {
 
 function makeSut() {
   TestBed.configureTestingModule({})
-  return TestBed.inject(_HEAD_ELEMENT_UPSERT_OR_REMOVE)
+  return TestBed.inject(_headElementUpsertOrRemove())
 }

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
@@ -1,28 +1,28 @@
-import { inject, InjectionToken } from '@angular/core'
+import { inject } from '@angular/core'
 import { DOCUMENT } from '@angular/common'
-import { _isDefined } from '../utils'
+import { _isDefined, _LazyInjectionToken, _makeInjectionToken } from '../utils'
 
 /**
  * @internal
  */
-export const _HEAD_ELEMENT_UPSERT_OR_REMOVE =
-  new InjectionToken<_HeadElementUpsertOrRemove>(
-    ngDevMode ? 'NgxMeta head element upsert or remove util' : 'NgxMetaHEUOR',
-    {
-      factory: () => {
-        const head = inject(DOCUMENT).head
-        return (selector: string, element: HTMLElement | null | undefined) => {
-          const existingScriptElement = head.querySelector(selector)
-          if (existingScriptElement) {
-            head.removeChild(existingScriptElement)
-          }
-
-          if (!_isDefined(element)) {
-            return
-          }
-          head.appendChild(element)
+export const _headElementUpsertOrRemove: _LazyInjectionToken<
+  _HeadElementUpsertOrRemove
+> = () =>
+  _makeInjectionToken(
+    ngDevMode ? 'Head element upsert or remove util' : 'HEUOR',
+    () => {
+      const head = inject(DOCUMENT).head
+      return (selector, element) => {
+        const existingScriptElement = head.querySelector(selector)
+        if (existingScriptElement) {
+          head.removeChild(existingScriptElement)
         }
-      },
+
+        if (!_isDefined(element)) {
+          return
+        }
+        head.appendChild(element)
+      }
     },
   )
 

--- a/projects/ngx-meta/src/core/src/head-elements/index.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/index.ts
@@ -1,4 +1,4 @@
 export {
-  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'

--- a/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common'
 import {
-  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
   _isDefined,
   makeMetadataManagerProviderFromSetterFactory,
@@ -33,7 +33,7 @@ export const JSON_LD_METADATA_PROVIDER =
   makeMetadataManagerProviderFromSetterFactory(
     JSON_LD_METADATA_SETTER_FACTORY,
     {
-      d: [_HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT],
+      d: [_headElementUpsertOrRemove(), DOCUMENT],
       jP: [KEY],
     },
   )

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
@@ -1,6 +1,6 @@
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import {
-  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
   _URL_RESOLVER,
   _UrlResolver,
@@ -105,7 +105,7 @@ const makeSut = (
   TestBed.configureTestingModule({
     providers: [
       {
-        provide: _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+        provide: _headElementUpsertOrRemove(),
         useValue:
           opts.headElementUpsertOrRemove ??
           jasmine.createSpy('Head element upsert or remove'),

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
@@ -1,7 +1,7 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
 import {
   _GLOBAL_CANONICAL_URL,
-  _HEAD_ELEMENT_UPSERT_OR_REMOVE,
+  _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
   _isDefined,
   _maybeNonHttpUrlDevMessage,
@@ -45,7 +45,7 @@ export const STANDARD_CANONICAL_URL_METADATA_PROVIDER =
   makeStandardMetadataProvider(_GLOBAL_CANONICAL_URL, {
     g: _GLOBAL_CANONICAL_URL,
     s: STANDARD_CANONICAL_URL_SETTER_FACTORY,
-    d: [_HEAD_ELEMENT_UPSERT_OR_REMOVE, DOCUMENT, _URL_RESOLVER],
+    d: [_headElementUpsertOrRemove(), DOCUMENT, _URL_RESOLVER],
   })
 
 const LINK_TAG = 'link'


### PR DESCRIPTION
# Issue or need

After #892 lazy injection tokens are ready to use. Head element upsert or remove is a good start to use it. Because of #891


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use lazy injection token for head element upsert or remove util

Verified that if usages of this token disappear (i.e.: removing standard + JSON LD modules from example app), the injection token and its factory get tree shaken.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
