### PR TITLE
refactor: rename util back to make injection token

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -113,12 +113,6 @@ export interface JsonLdMetadata {
     readonly jsonLd?: object | null;
 }
 
-// @internal
-export type _LazyInjectionToken<T> = () => InjectionToken<T>;
-
-// @internal
-export const _lazyInjectionToken: <T>(description: string, factory: () => T) => _LazyInjectionToken<T>;
-
 // @public
 export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, options?: MakeComposedKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 
@@ -126,6 +120,9 @@ export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, op
 export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaDefinitionOptions {
     separator?: string;
 }
+
+// @internal
+export const _makeInjectionToken: <T>(description: string, factory: () => T) => InjectionToken<T>;
 
 // @public
 export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;

--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -113,6 +113,9 @@ export interface JsonLdMetadata {
     readonly jsonLd?: object | null;
 }
 
+// @internal
+export type _LazyInjectionToken<T> = () => InjectionToken<T>;
+
 // @public
 export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, options?: MakeComposedKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 

--- a/projects/ngx-meta/src/core/src/utils/index.ts
+++ b/projects/ngx-meta/src/core/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { _isDefined } from './is-defined'
+export { _LazyInjectionToken } from './lazy-injection-token'
 export { _makeInjectionToken } from './make-injection-token'

--- a/projects/ngx-meta/src/core/src/utils/index.ts
+++ b/projects/ngx-meta/src/core/src/utils/index.ts
@@ -1,5 +1,2 @@
 export { _isDefined } from './is-defined'
-export {
-  _lazyInjectionToken,
-  _LazyInjectionToken,
-} from './lazy-injection-token'
+export { _makeInjectionToken } from './make-injection-token'

--- a/projects/ngx-meta/src/core/src/utils/lazy-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/lazy-injection-token.ts
@@ -1,0 +1,19 @@
+import { InjectionToken } from '@angular/core'
+
+/**
+ * Thunk to delay the instantiation of a new injection token.
+ *
+ * This way the injection token and its factory definition can be tree-shaken if unused.
+ * As their factory functions can bring many unused bytes to the production bundle.
+ *
+ * See also:
+ *
+ * - {@link https://github.com/davidlj95/ngx/pull/892 | PR where need for this was discovered}
+ *
+ * - {@link https://en.wikipedia.org/wiki/Thunk | Thunk definition (computer science)}
+ *
+ * - {@link https://github.com/davidlj95/ngx/pull/903 | Why can't create a helper function to create them}
+ *
+ * @internal
+ */
+export type _LazyInjectionToken<T> = () => InjectionToken<T>

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.spec.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.spec.ts
@@ -1,13 +1,13 @@
 import {
-  _lazyInjectionToken,
+  _makeInjectionToken,
   INJECTION_TOKEN_FACTORIES,
   INJECTION_TOKENS,
-} from './lazy-injection-token'
+} from './make-injection-token'
 import { TestBed } from '@angular/core/testing'
 import { InjectionToken } from '@angular/core'
 
-describe('lazy injection token', () => {
-  const sut = _lazyInjectionToken
+describe('make injection token', () => {
+  const sut = _makeInjectionToken
   const description = 'dummy'
   const factory = () => description
 
@@ -16,25 +16,25 @@ describe('lazy injection token', () => {
     INJECTION_TOKEN_FACTORIES.clear()
   })
 
-  it('should return a lazy injection token using the provided factory', () => {
+  it('should return an injection token using the provided factory', () => {
     const factoryOutput = factory()
-    const lazyInjectionToken = sut(description, factory)
+    const injectionToken = sut(description, factory)
 
-    expect(TestBed.inject(lazyInjectionToken())).toEqual(factoryOutput)
+    expect(TestBed.inject(injectionToken)).toEqual(factoryOutput)
   })
 
-  it('should return a lazy injection token with given description prefixed by library name', () => {
-    const lazyInjectionToken = sut(description, factory)
+  it('should return an injection token with given description prefixed by library name', () => {
+    const injectionToken = sut(description, factory)
 
-    expect(lazyInjectionToken().toString()).toContain(`ngx-meta ${description}`)
+    expect(injectionToken.toString()).toContain(`ngx-meta ${description}`)
   })
 
-  describe('when creating an already existing token', () => {
+  describe('when making an already existing token', () => {
     let injectionToken: InjectionToken<ReturnType<typeof factory>>
 
     beforeEach(() => {
       spyOn(console, 'warn')
-      injectionToken = sut(description, factory)()
+      injectionToken = sut(description, factory)
     })
 
     const shouldNotLogAnyMessage = () =>
@@ -46,7 +46,7 @@ describe('lazy injection token', () => {
       let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
 
       beforeEach(() => {
-        secondInjectionToken = sut('another-description', factory)()
+        secondInjectionToken = sut('another-description', factory)
       })
 
       it('should return another injection token', () => {
@@ -60,7 +60,7 @@ describe('lazy injection token', () => {
       let secondInjectionToken: InjectionToken<ReturnType<typeof factory>>
 
       beforeEach(() => {
-        secondInjectionToken = sut(description, factory)()
+        secondInjectionToken = sut(description, factory)
       })
 
       it('should return the same injection token', () => {
@@ -77,7 +77,7 @@ describe('lazy injection token', () => {
       >
 
       beforeEach(() => {
-        secondInjectionToken = sut(description, anotherFactory)()
+        secondInjectionToken = sut(description, anotherFactory)
       })
 
       it('should return the same injection token if providing same description but different factory', () => {

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
@@ -6,7 +6,17 @@ export const INJECTION_TOKENS = new Map<string, InjectionToken<unknown>>()
 export const INJECTION_TOKEN_FACTORIES = new Map<string, () => unknown>()
 
 /**
- * See https://github.com/davidlj95/ngx/pull/892
+ * Creates an injection token with the given factory function if it doesn't exist.
+ * To determine if an injection token exists, the description string is used.
+ *
+ * Useful to create {@link _LazyInjectionToken}s.
+
+ * \> The function can't be used to create a lazy injection token directly
+ * \> As a function call won't be tree-shaken. Which is the main purpose of lazy tokens.
+ * \> More in https://github.com/davidlj95/ngx/pull/902
+ *
+ * It also adds the library name as prefix to the injection token description.
+ * In order to locate library's injectable easily when debugging an Angular project.
  *
  * @internal
  */

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
@@ -6,16 +6,14 @@ export const INJECTION_TOKENS = new Map<string, InjectionToken<unknown>>()
 export const INJECTION_TOKEN_FACTORIES = new Map<string, () => unknown>()
 
 /**
- * A utility function to create lazy injection tokens.
- *
- * See {@link _LazyInjectionToken} for more information.
+ * See https://github.com/davidlj95/ngx/pull/892
  *
  * @internal
  */
-export const _lazyInjectionToken: <T>(
+export const _makeInjectionToken: <T>(
   description: string,
   factory: () => T,
-) => _LazyInjectionToken<T> = (description, factory) => () => {
+) => InjectionToken<T> = (description, factory) => {
   const injectionToken =
     INJECTION_TOKENS.get(description) ??
     new InjectionToken(`ngx-meta ${description}`, { factory })
@@ -41,18 +39,3 @@ export const _lazyInjectionToken: <T>(
   INJECTION_TOKENS.set(description, injectionToken)
   return injectionToken
 }
-
-/**
- * Thunk to delay the instantiation of a new injection token.
- * This way they can be tree-shaken if unused.
- * As their factory functions can bring many unused bytes to the production bundle.
- *
- * See also:
- *
- * - {@link https://github.com/davidlj95/ngx/pull/892 | PR where need for this was discovered}
- *
- * - {@link https://en.wikipedia.org/wiki/Thunk | Thunk definition (computer science)}
- *
- * @internal
- */
-export type _LazyInjectionToken<T> = () => InjectionToken<T>


### PR DESCRIPTION
# Issue or need

After trying to use the refactored util in #901 to create lazy injection tokens in #902, found out that injection tokens weren't removed from the main bundle if unused.

Which indeed makes sense. As now those lazy injection tokens are created by calling a function (`_lazyInjectionToken`). A function call isn't tree shakeable :facepalm:

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Reverting changes in #901 . Will add `() => ` around when creating lazy injection tokens.

Keeping the lazy injection token type as I think it's good that it's there and documented.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
