### PR TITLE
refactor: use lazy injection token for JSON metadata resolver

### DIFF
--- a/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import {
-  METADATA_JSON_RESOLVER,
+  metadataJsonResolver,
   MetadataJsonResolver,
 } from './metadata-json-resolver'
 import { MetadataValues } from '../service'
@@ -167,5 +167,5 @@ describe('Metadata JSON resolver', () => {
 
 function makeSut(): MetadataJsonResolver {
   TestBed.configureTestingModule({})
-  return TestBed.inject(METADATA_JSON_RESOLVER)
+  return TestBed.inject(metadataJsonResolver())
 }

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.ts
@@ -1,13 +1,14 @@
 import { MetadataValues } from '../service'
-import { InjectionToken } from '@angular/core'
 import { MetadataResolverOptions } from '../managers'
 import { isObject } from '../utils/is-object'
-import { _isDefined } from '../utils'
+import { _isDefined, _LazyInjectionToken, _makeInjectionToken } from '../utils'
 
-export const METADATA_JSON_RESOLVER = new InjectionToken<MetadataJsonResolver>(
-  ngDevMode ? 'NgxMeta JSON Resolver' : 'NgxMetaJR',
-  {
-    factory: () => (values, resolverOptions) => {
+export const metadataJsonResolver: _LazyInjectionToken<
+  MetadataJsonResolver
+> = () =>
+  _makeInjectionToken(
+    ngDevMode ? 'JSON Resolver' : 'JR',
+    () => (values, resolverOptions) => {
       if (values === undefined) {
         return
       }
@@ -39,8 +40,7 @@ export const METADATA_JSON_RESOLVER = new InjectionToken<MetadataJsonResolver>(
       }
       return globalValue
     },
-  },
-)
+  )
 
 export type MetadataJsonResolver = (
   values: MetadataValues | undefined,

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
@@ -6,7 +6,7 @@ import { MetadataValues } from '../service'
 import { DEFAULTS } from '../defaults/defaults'
 import { METADATA_RESOLVER, MetadataResolver } from './metadata-resolver'
 import {
-  METADATA_JSON_RESOLVER,
+  metadataJsonResolver,
   MetadataJsonResolver,
 } from './metadata-json-resolver'
 import { MetadataResolverOptions } from '../managers'
@@ -32,7 +32,7 @@ describe('Metadata resolver', () => {
   }
   function injectSpies() {
     jsonResolver = TestBed.inject(
-      METADATA_JSON_RESOLVER,
+      metadataJsonResolver(),
     ) as jasmine.Spy<MetadataJsonResolver>
     routeMetadataStrategy = TestBed.inject(
       _ROUTE_METADATA_STRATEGY,
@@ -187,7 +187,7 @@ function makeSut(opts: { defaults?: MetadataValues } = {}): MetadataResolver {
   TestBed.configureTestingModule({
     providers: [
       MockProvider(
-        METADATA_JSON_RESOLVER,
+        metadataJsonResolver(),
         jasmine.createSpy('Metadata JSON resolver'),
       ),
       MockProvider(

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
@@ -1,7 +1,7 @@
 import { inject, InjectionToken } from '@angular/core'
 import { MetadataValues } from '../service'
 import { injectDefaults } from '../defaults/defaults'
-import { METADATA_JSON_RESOLVER } from './metadata-json-resolver'
+import { metadataJsonResolver } from './metadata-json-resolver'
 import { MetadataResolverOptions } from '../managers'
 import { isObject } from '../utils/is-object'
 import { injectRouteMetadataStrategy } from '../routing/route-metadata-strategy'
@@ -10,7 +10,7 @@ export const METADATA_RESOLVER = new InjectionToken<MetadataResolver>(
   ngDevMode ? 'NgxMeta Metadata Resolver' : 'NgxMetaMR',
   {
     factory: () => {
-      const jsonResolver = inject(METADATA_JSON_RESOLVER)
+      const jsonResolver = inject(metadataJsonResolver())
       const routeMetadataStrategy = injectRouteMetadataStrategy()
       const defaults = injectDefaults()
       return (values, resolverOptions) => {


### PR DESCRIPTION
# Issue or need

Same as #902 but for JSON metadata resolver

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Same as #902 but for JSON metadata resolver

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
