### PR TITLE
refactor: allow lazy injection tokens not to provide a factory

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -125,7 +125,7 @@ export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaD
 }
 
 // @internal
-export const _makeInjectionToken: <T>(description: string, factory: () => T) => InjectionToken<T>;
+export const _makeInjectionToken: <T>(description: string, factory?: () => T) => InjectionToken<T>;
 
 // @public
 export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;

--- a/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
+++ b/projects/ngx-meta/src/core/src/utils/make-injection-token.ts
@@ -22,14 +22,18 @@ export const INJECTION_TOKEN_FACTORIES = new Map<string, () => unknown>()
  */
 export const _makeInjectionToken: <T>(
   description: string,
-  factory: () => T,
+  factory?: () => T,
 ) => InjectionToken<T> = (description, factory) => {
   const injectionToken =
     INJECTION_TOKENS.get(description) ??
-    new InjectionToken(`ngx-meta ${description}`, { factory })
+    new InjectionToken(
+      `ngx-meta ${description}`,
+      /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
+      factory ? { factory } : undefined,
+    )
   INJECTION_TOKENS.set(description, injectionToken)
   /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
-  if (ngDevMode) {
+  if (ngDevMode && factory) {
     if (
       (INJECTION_TOKEN_FACTORIES.get(description)?.toString() ??
         factory.toString()) !== factory.toString()


### PR DESCRIPTION
# Issue or need

About to use a lazy injection token for the `DEFAULTS` token. But in there, no factory is needed. However, the current util function requires one. 
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Allows util to make lazy injection tokens to create tokens without factories. Useful in the following PR's case.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
