### PR TITLE
refactor: use lazy injection token for metadata registry

### DIFF
--- a/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
+++ b/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
@@ -1,6 +1,6 @@
 import { ENVIRONMENT_INITIALIZER, inject, Provider } from '@angular/core'
 import {
-  METADATA_REGISTRY,
+  metadataRegistry,
   provideMetadataRegistry,
 } from '../managers/metadata-registry'
 
@@ -20,8 +20,8 @@ export const provideNgxMetaMetadataLoader = (): Provider[] => [
     provide: ENVIRONMENT_INITIALIZER,
     multi: true,
     useFactory: () => {
-      const globalRegistry = inject(METADATA_REGISTRY, { skipSelf: true })
-      const localRegistry = inject(METADATA_REGISTRY)
+      const globalRegistry = inject(metadataRegistry(), { skipSelf: true })
+      const localRegistry = inject(metadataRegistry())
       return () => {
         const localMetadata = localRegistry.getAll()
         for (const metadata of localMetadata) {

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
@@ -1,4 +1,4 @@
-import { METADATA_REGISTRY } from './metadata-registry'
+import { metadataRegistry } from './metadata-registry'
 import { TestBed } from '@angular/core/testing'
 import { makeMetadataManagerSpy } from './__tests__/make-metadata-manager-spy'
 import { MockProvider } from 'ng-mocks'
@@ -82,5 +82,5 @@ function makeSut(
       ),
     ],
   })
-  return TestBed.inject(METADATA_REGISTRY)
+  return TestBed.inject(metadataRegistry())
 }

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
@@ -1,8 +1,9 @@
-import { InjectionToken, Provider } from '@angular/core'
+import { Provider } from '@angular/core'
 import {
   _injectMetadataManagers,
   NgxMetaMetadataManager,
 } from './ngx-meta-metadata-manager'
+import { _LazyInjectionToken, _makeInjectionToken } from '../utils'
 
 export interface MetadataRegistry {
   readonly register: (manager: NgxMetaMetadataManager) => void
@@ -38,12 +39,13 @@ const metadataRegistryFactory: () => MetadataRegistry = () => {
   }
 }
 
-export const METADATA_REGISTRY = new InjectionToken<MetadataRegistry>(
-  ngDevMode ? 'NgxMeta Metadata Registry' : 'NgxMetaMR',
-  { factory: metadataRegistryFactory },
-)
+export const metadataRegistry: _LazyInjectionToken<MetadataRegistry> = () =>
+  _makeInjectionToken(
+    ngDevMode ? 'Metadata Registry' : 'MR',
+    metadataRegistryFactory,
+  )
 
 export const provideMetadataRegistry: () => Provider = () => ({
-  provide: METADATA_REGISTRY,
+  provide: metadataRegistry(),
   useFactory: metadataRegistryFactory,
 })

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -8,7 +8,7 @@ import {
   MetadataResolver,
 } from '../resolvers/metadata-resolver'
 import {
-  METADATA_REGISTRY,
+  metadataRegistry as metadataRegistryToken,
   MetadataRegistry,
 } from '../managers/metadata-registry'
 
@@ -22,7 +22,7 @@ describe('Main service', () => {
   beforeEach(() => {
     sut = makeSut()
     metadataRegistry = TestBed.inject(
-      METADATA_REGISTRY,
+      metadataRegistryToken(),
     ) as jasmine.SpyObj<MetadataRegistry>
     metadataRegistry.getAll.and.returnValue([firstMetadata, secondMetadata])
   })
@@ -78,7 +78,7 @@ function makeSut() {
     providers: [
       provideNgxMetaService(),
       MockProvider(
-        METADATA_REGISTRY,
+        metadataRegistryToken(),
         jasmine.createSpyObj<MetadataRegistry>(['getAll']),
       ),
       MockProvider(METADATA_RESOLVER, jasmine.createSpy('Metadata resolver')),

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.ts
@@ -1,6 +1,6 @@
 import { MetadataValues } from './metadata-values'
 import { FactoryProvider, inject } from '@angular/core'
-import { METADATA_REGISTRY } from '../managers/metadata-registry'
+import { metadataRegistry } from '../managers/metadata-registry'
 import { METADATA_RESOLVER } from '../resolvers/metadata-resolver'
 import { _formatDevMessage } from '../messaging'
 import { MODULE_NAME } from '../module-name'
@@ -81,7 +81,7 @@ export abstract class NgxMetaService {
 export const provideNgxMetaService: () => FactoryProvider = () => ({
   provide: NgxMetaService,
   useFactory: (): NgxMetaService => {
-    const registry = inject(METADATA_REGISTRY)
+    const registry = inject(metadataRegistry())
     const resolver = inject(METADATA_RESOLVER)
     return {
       set(values = {}) {


### PR DESCRIPTION
# Issue or need

Same as #902 for metadata registry

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Same as #902 for metadata registry

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
