### PR TITLE
refactor: use lazy injection token for route metadata strategy

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -392,10 +392,10 @@ export const provideNgxMetaStandard: () => Provider[];
 export const provideNgxMetaTwitterCard: () => Provider[];
 
 // @internal (undocumented)
-export const _ROUTE_METADATA_STRATEGY: InjectionToken<_RouteMetadataStrategy>;
+export type _RouteMetadataStrategy = () => MetadataValues | undefined;
 
 // @internal (undocumented)
-export type _RouteMetadataStrategy = () => MetadataValues | undefined;
+export const _routeMetadataStrategy: _LazyInjectionToken<_RouteMetadataStrategy>;
 
 // @public
 export interface Standard {

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
@@ -10,7 +10,7 @@ import {
   MetadataJsonResolver,
 } from './metadata-json-resolver'
 import { MetadataResolverOptions } from '../managers'
-import { _ROUTE_METADATA_STRATEGY, _RouteMetadataStrategy } from '../routing'
+import { _routeMetadataStrategy, _RouteMetadataStrategy } from '../routing'
 
 describe('Metadata resolver', () => {
   enableAutoSpy()
@@ -35,7 +35,7 @@ describe('Metadata resolver', () => {
       metadataJsonResolver(),
     ) as jasmine.Spy<MetadataJsonResolver>
     routeMetadataStrategy = TestBed.inject(
-      _ROUTE_METADATA_STRATEGY,
+      _routeMetadataStrategy(),
     ) as jasmine.Spy<_RouteMetadataStrategy>
   }
 
@@ -191,7 +191,7 @@ function makeSut(opts: { defaults?: MetadataValues } = {}): MetadataResolver {
         jasmine.createSpy('Metadata JSON resolver'),
       ),
       MockProvider(
-        _ROUTE_METADATA_STRATEGY,
+        _routeMetadataStrategy(),
         jasmine.createSpy('Route metadata strategy'),
       ),
       opts.defaults ? [MockProvider(defaults(), opts.defaults)] : [],

--- a/projects/ngx-meta/src/core/src/routing/index.ts
+++ b/projects/ngx-meta/src/core/src/routing/index.ts
@@ -1,4 +1,4 @@
 export {
   _RouteMetadataStrategy,
-  _ROUTE_METADATA_STRATEGY,
+  _routeMetadataStrategy,
 } from './route-metadata-strategy'

--- a/projects/ngx-meta/src/core/src/routing/route-metadata-strategy.ts
+++ b/projects/ngx-meta/src/core/src/routing/route-metadata-strategy.ts
@@ -1,13 +1,13 @@
-import { inject, InjectionToken } from '@angular/core'
+import { inject } from '@angular/core'
 import { MetadataValues } from '../service'
+import { _LazyInjectionToken, _makeInjectionToken } from '../utils'
 
 /**
  * @internal
  */
-export const _ROUTE_METADATA_STRATEGY =
-  new InjectionToken<_RouteMetadataStrategy>(
-    ngDevMode ? 'NgxMeta Route metadata strategy' : 'NgxMetaRMS',
-  )
+export const _routeMetadataStrategy: _LazyInjectionToken<
+  _RouteMetadataStrategy
+> = () => _makeInjectionToken(ngDevMode ? 'Route metadata strategy' : 'RMS')
 
 /**
  * @internal
@@ -15,4 +15,4 @@ export const _ROUTE_METADATA_STRATEGY =
 export type _RouteMetadataStrategy = () => MetadataValues | undefined
 
 export const injectRouteMetadataStrategy: () => _RouteMetadataStrategy = () =>
-  inject(_ROUTE_METADATA_STRATEGY, { optional: true }) ?? (() => undefined)
+  inject(_routeMetadataStrategy(), { optional: true }) ?? (() => undefined)

--- a/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
+++ b/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
@@ -4,7 +4,7 @@ import {
   inject,
   makeEnvironmentProviders,
 } from '@angular/core'
-import { _ROUTE_METADATA_STRATEGY } from '@davidlj95/ngx-meta/core'
+import { _routeMetadataStrategy } from '@davidlj95/ngx-meta/core'
 import { DEFAULT_ROUTE_METADATA_STRATEGY } from '../route-metadata/default-route-metadata-strategy'
 import { ROUTER_LISTENER } from '../listener/router-listener'
 
@@ -22,7 +22,7 @@ import { ROUTER_LISTENER } from '../listener/router-listener'
 export const provideNgxMetaRouting = (): EnvironmentProviders =>
   makeEnvironmentProviders([
     {
-      provide: _ROUTE_METADATA_STRATEGY,
+      provide: _routeMetadataStrategy(),
       useExisting: DEFAULT_ROUTE_METADATA_STRATEGY,
     },
     {


### PR DESCRIPTION
# Issue or need

Same as #902 for route metadata strategy

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Same as #902 for route metadata strategy

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
