### PR TITLE
refactor: turn default route metadata strategy into provider

### DIFF
--- a/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
+++ b/projects/ngx-meta/src/routing/src/providers/provide-ngx-meta-routing.ts
@@ -4,8 +4,7 @@ import {
   inject,
   makeEnvironmentProviders,
 } from '@angular/core'
-import { _routeMetadataStrategy } from '@davidlj95/ngx-meta/core'
-import { DEFAULT_ROUTE_METADATA_STRATEGY } from '../route-metadata/default-route-metadata-strategy'
+import { DEFAULT_ROUTE_METADATA_STRATEGY_PROVIDER } from '../route-metadata/default-route-metadata-strategy'
 import { ROUTER_LISTENER } from '../listener/router-listener'
 
 /**
@@ -21,10 +20,7 @@ import { ROUTER_LISTENER } from '../listener/router-listener'
  */
 export const provideNgxMetaRouting = (): EnvironmentProviders =>
   makeEnvironmentProviders([
-    {
-      provide: _routeMetadataStrategy(),
-      useExisting: DEFAULT_ROUTE_METADATA_STRATEGY,
-    },
+    DEFAULT_ROUTE_METADATA_STRATEGY_PROVIDER,
     {
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,

--- a/projects/ngx-meta/src/routing/src/route-metadata/default-route-metadata-strategy.spec.ts
+++ b/projects/ngx-meta/src/routing/src/route-metadata/default-route-metadata-strategy.spec.ts
@@ -1,8 +1,9 @@
 import { MockProvider, MockService } from 'ng-mocks'
 import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router'
 import { TestBed } from '@angular/core/testing'
-import { DEFAULT_ROUTE_METADATA_STRATEGY } from './default-route-metadata-strategy'
 import { NgxMetaRouteData } from './ngx-meta-route-data'
+import { _routeMetadataStrategy } from '../../../core'
+import { DEFAULT_ROUTE_METADATA_STRATEGY_PROVIDER } from './default-route-metadata-strategy'
 
 describe('Default route metadata strategy', () => {
   it('returns current route snapshot metadata key', () => {
@@ -26,7 +27,8 @@ const makeSut = (opts: { activatedRouteSnapshot: ActivatedRouteSnapshot }) => {
   TestBed.configureTestingModule({
     providers: [
       MockProvider(ActivatedRoute, { snapshot: opts.activatedRouteSnapshot }),
+      DEFAULT_ROUTE_METADATA_STRATEGY_PROVIDER,
     ],
   })
-  return TestBed.inject(DEFAULT_ROUTE_METADATA_STRATEGY)
+  return TestBed.inject(_routeMetadataStrategy())
 }

--- a/projects/ngx-meta/src/routing/src/route-metadata/default-route-metadata-strategy.ts
+++ b/projects/ngx-meta/src/routing/src/route-metadata/default-route-metadata-strategy.ts
@@ -1,24 +1,16 @@
-import { inject, InjectionToken } from '@angular/core'
+import { FactoryProvider } from '@angular/core'
 import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router'
-import { _RouteMetadataStrategy } from '@davidlj95/ngx-meta/core'
+import { _routeMetadataStrategy } from '@davidlj95/ngx-meta/core'
 import { NgxMetaRouteData } from './ngx-meta-route-data'
 
-export const DEFAULT_ROUTE_METADATA_STRATEGY =
-  new InjectionToken<_RouteMetadataStrategy>(
-    ngDevMode ? 'NgxMeta Default route metadata strategy' : 'NgxMetaDRMS',
-    {
-      factory: () => {
-        const activatedRoute = inject(ActivatedRoute)
-        return () => {
-          let currentRouteSnapshot: ActivatedRouteSnapshot =
-            activatedRoute.snapshot
-          while (currentRouteSnapshot.firstChild != null) {
-            currentRouteSnapshot = currentRouteSnapshot.firstChild
-          }
-          return currentRouteSnapshot.data[
-            'meta' satisfies keyof NgxMetaRouteData
-          ]
-        }
-      },
-    },
-  )
+export const DEFAULT_ROUTE_METADATA_STRATEGY_PROVIDER: FactoryProvider = {
+  provide: _routeMetadataStrategy(),
+  useFactory: (activatedRoute: ActivatedRoute) => () => {
+    let currentRouteSnapshot: ActivatedRouteSnapshot = activatedRoute.snapshot
+    while (currentRouteSnapshot.firstChild != null) {
+      currentRouteSnapshot = currentRouteSnapshot.firstChild
+    }
+    return currentRouteSnapshot.data['meta' satisfies keyof NgxMetaRouteData]
+  },
+  deps: [ActivatedRoute],
+}


### PR DESCRIPTION
# Issue or need

Same as #902 for default route metadata strategy

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Turn default route metadata strategy into a provider so no need to use a non-tree shakeable lazy injection token

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
