### PR TITLE
refactor: turn main service into a class again

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -157,6 +157,19 @@ export const _maybeNonHttpUrlDevMessage: (url: string | URL | undefined | null, 
 // @internal
 export const _maybeTooLongDevMessage: (value: string | undefined | null, maxLength: number, opts: _FormatDevMessageOptions) => void;
 
+// @internal (undocumented)
+interface MetadataRegistry {
+    // (undocumented)
+    readonly findByGlobalOrJsonPath: (globalOrJsonPath: string) => Iterable<NgxMetaMetadataManager>;
+    // (undocumented)
+    readonly getAll: () => Iterable<NgxMetaMetadataManager>;
+    // (undocumented)
+    readonly register: (manager: NgxMetaMetadataManager) => void;
+}
+
+// @internal (undocumented)
+type MetadataResolver = (values: MetadataValues, resolverOptions: MetadataResolverOptions) => unknown;
+
 // @public
 export interface MetadataResolverOptions {
     readonly global?: string;
@@ -237,10 +250,13 @@ export class NgxMetaRoutingModule {
 }
 
 // @public
-export abstract class NgxMetaService {
-    abstract clear(): void;
-    abstract set(values?: MetadataValues): void;
-    abstract setOne(globalOrJsonPath: string, value: unknown): void;
+export class NgxMetaService {
+    // Warning: (ae-forgotten-export) The symbol "MetadataRegistry" needs to be exported by the entry point all-entry-points.d.ts
+    // Warning: (ae-forgotten-export) The symbol "MetadataResolver" needs to be exported by the entry point all-entry-points.d.ts
+    constructor(registry: MetadataRegistry, resolver: MetadataResolver);
+    clear(): void;
+    set(values?: MetadataValues): void;
+    setOne(globalOrJsonPath: string, value: unknown): void;
 }
 
 // @public

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.ts
@@ -5,6 +5,9 @@ import {
 } from './ngx-meta-metadata-manager'
 import { _LazyInjectionToken, _makeInjectionToken } from '../utils'
 
+/**
+ * @internal
+ */
 export interface MetadataRegistry {
   readonly register: (manager: NgxMetaMetadataManager) => void
   readonly getAll: () => Iterable<NgxMetaMetadataManager>

--- a/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
+++ b/projects/ngx-meta/src/core/src/providers/provide-ngx-meta-core.ts
@@ -1,6 +1,5 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core'
 import { CoreFeatures, providersFromCoreFeatures } from './core-feature'
-import { provideNgxMetaService } from '../service/ngx-meta.service'
 
 /**
  * Provides `ngx-meta`'s core library services.
@@ -23,7 +22,4 @@ import { provideNgxMetaService } from '../service/ngx-meta.service'
 export const provideNgxMetaCore = (
   ...features: CoreFeatures
 ): EnvironmentProviders =>
-  makeEnvironmentProviders([
-    provideNgxMetaService(),
-    providersFromCoreFeatures(features),
-  ])
+  makeEnvironmentProviders([providersFromCoreFeatures(features)])

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.ts
@@ -31,6 +31,9 @@ export const metadataResolver: _LazyInjectionToken<MetadataResolver> = () =>
     }
   })
 
+/**
+ * @internal
+ */
 export type MetadataResolver = (
   values: MetadataValues,
   resolverOptions: MetadataResolverOptions,

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { NgxMetaService, provideNgxMetaService } from './ngx-meta.service'
+import { NgxMetaService } from './ngx-meta.service'
 import { MockProvider } from 'ng-mocks'
 import { makeMetadataManagerSpy } from '../managers/__tests__/make-metadata-manager-spy'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
@@ -76,7 +76,6 @@ describe('Main service', () => {
 function makeSut() {
   TestBed.configureTestingModule({
     providers: [
-      provideNgxMetaService(),
       MockProvider(
         metadataRegistryToken(),
         jasmine.createSpyObj<MetadataRegistry>(['getAll']),


### PR DESCRIPTION
# Issue or need

In #873, the main service `NgxMetaService` was turned into an abstract class so that it could use a provider to provide the implementation and save a few uncompressed bytes (171 bytes in v18)
However, didn't realize that introducing this change would make the service not tree-shakeable. Given when calling `provideNgxMetaCore` (or the module-based equivalent API), it would always be provided.
Even if unused.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Turn it back into a service provided in `root`. This way it can be removed from the bundle if unused.

## Other alternatives considered

### Turn it into a lazy injection token

It's not something very Angular'ish. At least yet? So for an external API would seem weird to use by a developer.

### Keep it as is, service will be used
It is true that the main service will be almost certainly used. Given it's providing the key piece functionality of the library.

So could assume that it will always be used hence no need to provide it in a tree-shakeable manner. And save those 171 bytes.

But a user may only be interested in one of the utils. So allowing tree-shaking could be interesting for those.

Plus this way APIs follow the traditional Angular way of doing things. So less weird things to expect.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
