### PR TITLE
chore: turn is array utility into type

### DIFF
--- a/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.ts
@@ -10,7 +10,7 @@ import { StandardThemeColorMetadataObject } from './standard-theme-color-metadat
 export const STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   Standard[typeof KEY]
 > = (ngxMetaMetaService: NgxMetaMetaService) => (value) => {
-  const isValueAnArray = isStandardThemeColorArray(value)
+  const isValueAnArray = (Array.isArray as isStandardThemeColorArray)(value)
   const baseMetaDefinition = makeStandardMetaDefinition(META_NAME)
   if (!value || !isValueAnArray || !value.length) {
     ngxMetaMetaService.set(
@@ -30,9 +30,9 @@ export const STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY: MetadataSetterFactory
 const KEY = 'themeColor' satisfies keyof Standard
 const META_NAME = 'theme-color'
 
-const isStandardThemeColorArray: (
+type isStandardThemeColorArray = (
   value: Standard['themeColor'],
-) => value is ReadonlyArray<StandardThemeColorMetadataObject> = Array.isArray
+) => value is ReadonlyArray<StandardThemeColorMetadataObject>
 
 /**
  * Manages the {@link Standard.themeColor} metadata


### PR DESCRIPTION
# Issue or need

A function was declared to check if it's an array or not in standard theme color metadata setter. With the purpose of being a Typescript type guard.

But if types are the only thing, we can add a type cast and avoid creating an extra function

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Turn type guard into a type, so no need to declare an extra function

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
