### PR TITLE
test: add util to test same scenario for null or undefined

### DIFF
--- a/projects/ngx-meta/src/__tests__/like-when-null-or-undefined.ts
+++ b/projects/ngx-meta/src/__tests__/like-when-null-or-undefined.ts
@@ -1,0 +1,10 @@
+export const likeWhenNullOrUndefined = (
+  specDefinitions: (testCase: null | undefined) => void,
+) => {
+  const TEST_CASES = [null, undefined]
+  TEST_CASES.forEach((testCase) => {
+    describe(`like when ${testCase}`, () => {
+      specDefinitions(testCase)
+    })
+  })
+}

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -6,6 +6,7 @@ import {
   _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Head element upsert or remove', () => {
   let sut: _HeadElementUpsertOrRemove
@@ -28,7 +29,7 @@ describe('Head element upsert or remove', () => {
         .toHaveSize(0)
     })
 
-    describe('when element is not null or undefined', () => {
+    describe('when element is defined', () => {
       it('should append it to head', () => {
         sut(headElementHarness.dummySelector, dummyElement)
 
@@ -41,18 +42,17 @@ describe('Head element upsert or remove', () => {
       })
     })
 
-    const TEST_CASES = [null, undefined]
-    for (const TEST_CASE of TEST_CASES) {
-      describe(`when element is ${TEST_CASE}`, () => {
+    describe('when element is not defined', () => {
+      likeWhenNullOrUndefined((testCase) => {
         it('should do nothing', () => {
-          sut(headElementHarness.dummySelector, TEST_CASE)
+          sut(headElementHarness.dummySelector, testCase)
 
           expect(
             headElementHarness.getAll(headElementHarness.dummySelector),
           ).toHaveSize(0)
         })
       })
-    }
+    })
   })
 
   describe('when element exists already', () => {
@@ -63,7 +63,7 @@ describe('Head element upsert or remove', () => {
         .toHaveSize(1)
     })
 
-    describe('when element is not null or undefined', () => {
+    describe('when element is defined', () => {
       it('should update it', () => {
         const anotherDummyElement =
           headElementHarness.createDummyElement('dummy 2')
@@ -78,18 +78,17 @@ describe('Head element upsert or remove', () => {
       })
     })
 
-    const TEST_CASES = [null, undefined]
-    for (const TEST_CASE of TEST_CASES) {
-      describe(`when element is ${TEST_CASE}`, () => {
+    describe('when element is not defined', () => {
+      likeWhenNullOrUndefined((testCase) => {
         it('should remove it', () => {
-          sut(headElementHarness.dummySelector, TEST_CASE)
+          sut(headElementHarness.dummySelector, testCase)
 
           expect(
             headElementHarness.getAll(headElementHarness.dummySelector),
           ).toHaveSize(0)
         })
       })
-    }
+    })
   })
 })
 

--- a/projects/ngx-meta/src/core/src/meta-elements/v2/with-content-attribute.spec.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v2/with-content-attribute.spec.ts
@@ -1,25 +1,22 @@
 import { withContentAttribute } from './with-content-attribute'
 import { NgxMetaElementAttributes } from './ngx-meta-element-attributes'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('with content attribute', () => {
   const sut = withContentAttribute
   const extras = { dummy: 'dummy' } satisfies NgxMetaElementAttributes
 
   describe('when no content is provided', () => {
-    const TEST_CASES = [null, undefined]
-
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when ${testCase}`, () => {
-        describe('when not providing extras', () => {
-          it('should return undefined', () => {
-            expect(sut(testCase)).toBeUndefined()
-          })
+    likeWhenNullOrUndefined((testCase) => {
+      describe('when not providing extras', () => {
+        it('should return undefined', () => {
+          expect(sut(testCase)).toBeUndefined()
         })
+      })
 
-        describe('when providing extras', () => {
-          it('should return undefined', () => {
-            expect(sut(testCase, extras)).toBeUndefined()
-          })
+      describe('when providing extras', () => {
+        it('should return undefined', () => {
+          expect(sut(testCase, extras)).toBeUndefined()
         })
       })
     })

--- a/projects/ngx-meta/src/core/src/url-resolution/default-url-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/url-resolution/default-url-resolver.spec.ts
@@ -6,17 +6,15 @@ import { BaseUrl } from './base-url'
 import { Component } from '@angular/core'
 import { provideRouter } from '@angular/router'
 import { RouterTestingHarness } from '@angular/router/testing'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Default URL resolver', () => {
   describe('when no URL is given', () => {
-    const TEST_CASES = [null, undefined]
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when URL is ${testCase}`, () => {
-        it(`should return ${testCase}`, async () => {
-          const sut = await makeSut()
+    likeWhenNullOrUndefined((testCase) => {
+      it(`should return ${testCase}`, async () => {
+        const sut = await makeSut()
 
-          expect(sut(testCase)).toEqual(testCase)
-        })
+        expect(sut(testCase)).toEqual(testCase)
       })
     })
   })

--- a/projects/ngx-meta/src/core/src/url-resolution/no-op-url-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/url-resolution/no-op-url-resolver.spec.ts
@@ -1,5 +1,6 @@
 import { noOpUrlResolver } from './no-op-url-resolver'
 import { ANGULAR_ROUTER_URL, AngularRouterUrl } from './angular-router-url'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('No Op URL resolver', () => {
   const sut = noOpUrlResolver
@@ -25,13 +26,9 @@ describe('No Op URL resolver', () => {
   })
 
   describe('when no URL is given', () => {
-    const TEST_CASES = [null, undefined]
-
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when URL is ${testCase}`, () => {
-        it(`should return ${testCase}`, () => {
-          expect(sut(testCase)).toEqual(testCase)
-        })
+    likeWhenNullOrUndefined((testCase) => {
+      it(`should return ${testCase}`, () => {
+        expect(sut(testCase)).toEqual(testCase)
       })
     })
   })

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
@@ -10,6 +10,7 @@ import { TestBed } from '@angular/core/testing'
 import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 import { Standard } from '../types'
 import { STANDARD_CANONICAL_URL_METADATA_PROVIDER } from './standard-canonical-url-metadata-provider'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Standard canonical URL metadata manager', () => {
   enableAutoSpy()
@@ -17,21 +18,18 @@ describe('Standard canonical URL metadata manager', () => {
   const LINK_REL_CANONICAL_SELECTOR = "link[rel='canonical']"
 
   describe('when no URL is given', () => {
-    const TEST_CASES = [undefined, null]
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when ${testCase}`, () => {
-        it('should remove the link rel canonical element from the head', () => {
-          const headElementUpsertOrRemove =
-            jasmine.createSpy<_HeadElementUpsertOrRemove>()
-          const sut = makeSut({ headElementUpsertOrRemove })
+    likeWhenNullOrUndefined((testCase) => {
+      it('should remove the link rel canonical element from the head', () => {
+        const headElementUpsertOrRemove =
+          jasmine.createSpy<_HeadElementUpsertOrRemove>()
+        const sut = makeSut({ headElementUpsertOrRemove })
 
-          sut.set(testCase)
+        sut.set(testCase)
 
-          expect(headElementUpsertOrRemove).toHaveBeenCalledWith(
-            LINK_REL_CANONICAL_SELECTOR,
-            jasmine.falsy(),
-          )
-        })
+        expect(headElementUpsertOrRemove).toHaveBeenCalledWith(
+          LINK_REL_CANONICAL_SELECTOR,
+          jasmine.falsy(),
+        )
       })
     })
   })

--- a/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
@@ -9,6 +9,7 @@ import { VERSION } from '@angular/core'
 import { Standard } from '../types'
 import { STANDARD_GENERATOR_METADATA_PROVIDER } from './standard-generator-metadata-provider'
 import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Standard generator metadata manager', () => {
   enableAutoSpy()
@@ -23,17 +24,14 @@ describe('Standard generator metadata manager', () => {
   })
 
   describe('when not provided', () => {
-    const TEST_CASES = [null, undefined]
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when ${testCase}`, () => {
-        it(`should call meta service with ${testCase}`, () => {
-          sut.set(undefined)
+    likeWhenNullOrUndefined((testCase) => {
+      it(`should call meta service with ${testCase}`, () => {
+        sut.set(undefined)
 
-          expect(metaElementsService.set).toHaveBeenCalledOnceWith(
-            jasmine.anything(),
-            undefined,
-          )
-        })
+        expect(metaElementsService.set).toHaveBeenCalledOnceWith(
+          jasmine.anything(),
+          undefined,
+        )
       })
     })
   })

--- a/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing'
 import { MockProvider } from 'ng-mocks'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import {
+  NgxMetaElementNameAttribute,
   NgxMetaElementsService,
   NgxMetaMetadataManager,
 } from '@davidlj95/ngx-meta/core'
@@ -15,6 +16,10 @@ describe('Standard generator metadata manager', () => {
   enableAutoSpy()
   let sut: NgxMetaMetadataManager<Standard['generator']>
   let metaElementsService: jasmine.SpyObj<NgxMetaElementsService>
+  const EXPECTED_NAME_ATTRIBUTE = [
+    'name',
+    'generator',
+  ] satisfies NgxMetaElementNameAttribute
 
   beforeEach(() => {
     sut = makeSut()
@@ -26,10 +31,10 @@ describe('Standard generator metadata manager', () => {
   describe('when not provided', () => {
     likeWhenNullOrUndefined((testCase) => {
       it(`should call meta service with ${testCase}`, () => {
-        sut.set(undefined)
+        sut.set(testCase)
 
         expect(metaElementsService.set).toHaveBeenCalledOnceWith(
-          jasmine.anything(),
+          EXPECTED_NAME_ATTRIBUTE,
           undefined,
         )
       })
@@ -43,7 +48,7 @@ describe('Standard generator metadata manager', () => {
       sut.set(value)
 
       expect(metaElementsService.set).toHaveBeenCalledOnceWith(
-        ['name', 'generator'],
+        EXPECTED_NAME_ATTRIBUTE,
         { content: `Angular v${VERSION.full}` },
       )
     })

--- a/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
@@ -6,6 +6,7 @@ import { NgxMetaMetadataManager } from '@davidlj95/ngx-meta/core'
 import { Standard } from '../types'
 import { injectOneMetadataManager } from '@/ngx-meta/test/inject-one-metadata-manager'
 import { STANDARD_LOCALE_METADATA_PROVIDER } from './standard-locale-metadata-provider'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Standard locale metadata', () => {
   let sut: NgxMetaMetadataManager<Standard['locale']>
@@ -23,18 +24,14 @@ describe('Standard locale metadata', () => {
   })
 
   describe('when locale is not provided', () => {
-    const TEST_CASES = [undefined, null]
+    likeWhenNullOrUndefined((testCase) => {
+      it('should remove HTML element lang attribute', () => {
+        htmlLangAttributeHarness.set('es')
+        expect(htmlLangAttributeHarness.get()).toBeTruthy()
 
-    TEST_CASES.forEach((testCase) => {
-      describe(`like when ${testCase}`, () => {
-        it('should remove HTML element lang attribute', () => {
-          htmlLangAttributeHarness.set('es')
-          expect(htmlLangAttributeHarness.get()).toBeTruthy()
+        sut.set(testCase)
 
-          sut.set(testCase)
-
-          expect(htmlLangAttributeHarness.get()).toBeNull()
-        })
+        expect(htmlLangAttributeHarness.get()).toBeNull()
       })
     })
   })


### PR DESCRIPTION
# Issue or need

There are several unit tests around testing same thing in case of `null` or `undefined`. Starts being repetitive

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Introduce a util to avoid repeating this around.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
