### PR TITLE
refactor: pass document when managing head elements

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -97,7 +97,7 @@ export interface GlobalMetadataImage {
 }
 
 // @internal (undocumented)
-export type _HeadElementUpsertOrRemove = (selector: string, element: HTMLElement | null | undefined) => void;
+export type _HeadElementUpsertOrRemove = (selector: string, elementFactory: (document: Document) => HTMLElement | undefined) => void;
 
 // @internal (undocumented)
 export const _headElementUpsertOrRemove: _LazyInjectionToken<_HeadElementUpsertOrRemove>;

--- a/projects/ngx-meta/src/core/src/head-elements/__tests__/head-element-harness.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/__tests__/head-element-harness.ts
@@ -1,8 +1,8 @@
 export class HeadElementHarness {
   constructor(private readonly doc: Document) {}
 
-  createDummyElement(content: string): HTMLElement {
-    const element = this.doc.createElement('meta')
+  createDummyElement(content: string, document?: Document): HTMLElement {
+    const element = (document ?? this.doc).createElement('meta')
     element.setAttribute('name', 'dummy')
     element.setAttribute('content', content)
     return element
@@ -12,8 +12,8 @@ export class HeadElementHarness {
     return "meta[name='dummy']"
   }
 
-  appendElement(element: HTMLElement): void {
-    this.doc.head.appendChild(element)
+  createAndAppendDummyElement(content: string): HTMLElement {
+    return this.doc.head.appendChild(this.createDummyElement(content))
   }
 
   getAll(selector: string): NodeListOf<HTMLElement> {

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -6,33 +6,41 @@ import {
   _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
 } from './head-element-upsert-or-remove'
-import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Head element upsert or remove', () => {
   let sut: _HeadElementUpsertOrRemove
   let headElementHarness: HeadElementHarness
-  let dummyElement: HTMLElement
 
   beforeEach(() => {
     sut = makeSut()
     headElementHarness = new HeadElementHarness(TestBed.inject(DOCUMENT))
-    dummyElement = headElementHarness.createDummyElement('dummy 1')
   })
   afterEach(() => {
     headElementHarness.remove(headElementHarness.dummySelector)
   })
 
-  describe('when element does not exist already', () => {
+  describe('when no element exists yet', () => {
     beforeEach(() => {
       expect(headElementHarness.getAll(headElementHarness.dummySelector))
         .withContext('element does not exist already')
         .toHaveSize(0)
     })
 
-    describe('when element is defined', () => {
-      it('should append it to head', () => {
-        sut(headElementHarness.dummySelector, dummyElement)
+    describe('when element factory returns an element', () => {
+      let dummyElement: HTMLElement
 
+      beforeEach(() => {
+        sut(
+          headElementHarness.dummySelector,
+          (document) =>
+            (dummyElement = headElementHarness.createDummyElement(
+              'dummy',
+              document,
+            )),
+        )
+      })
+
+      it('should append it to head', () => {
         const elements = headElementHarness.getAll(
           headElementHarness.dummySelector,
         )
@@ -42,33 +50,40 @@ describe('Head element upsert or remove', () => {
       })
     })
 
-    describe('when element is not defined', () => {
-      likeWhenNullOrUndefined((testCase) => {
-        it('should do nothing', () => {
-          sut(headElementHarness.dummySelector, testCase)
+    describe('when element factory returns nothing', () => {
+      it('should do nothing', () => {
+        sut(headElementHarness.dummySelector, () => undefined)
 
-          expect(
-            headElementHarness.getAll(headElementHarness.dummySelector),
-          ).toHaveSize(0)
-        })
+        expect(
+          headElementHarness.getAll(headElementHarness.dummySelector),
+        ).toHaveSize(0)
       })
     })
   })
 
-  describe('when element exists already', () => {
+  describe('when an element already exists', () => {
     beforeEach(() => {
-      headElementHarness.appendElement(dummyElement)
+      headElementHarness.createAndAppendDummyElement('dummy 1')
       expect(headElementHarness.getAll(headElementHarness.dummySelector))
         .withContext('element exists already')
         .toHaveSize(1)
     })
 
-    describe('when element is defined', () => {
-      it('should update it', () => {
-        const anotherDummyElement =
-          headElementHarness.createDummyElement('dummy 2')
-        sut(headElementHarness.dummySelector, anotherDummyElement)
+    describe('when element factory returns an element', () => {
+      let anotherDummyElement: HTMLElement
 
+      beforeEach(() => {
+        sut(
+          headElementHarness.dummySelector,
+          (document) =>
+            (anotherDummyElement = headElementHarness.createDummyElement(
+              'dummy 2',
+              document,
+            )),
+        )
+      })
+
+      it('should update it', () => {
         const elements = headElementHarness.getAll(
           headElementHarness.dummySelector,
         )
@@ -78,15 +93,13 @@ describe('Head element upsert or remove', () => {
       })
     })
 
-    describe('when element is not defined', () => {
-      likeWhenNullOrUndefined((testCase) => {
-        it('should remove it', () => {
-          sut(headElementHarness.dummySelector, testCase)
+    describe('when element factory returns nothing', () => {
+      it('should remove it', () => {
+        sut(headElementHarness.dummySelector, () => undefined)
 
-          expect(
-            headElementHarness.getAll(headElementHarness.dummySelector),
-          ).toHaveSize(0)
-        })
+        expect(
+          headElementHarness.getAll(headElementHarness.dummySelector),
+        ).toHaveSize(0)
       })
     })
   })

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.ts
@@ -11,13 +11,15 @@ export const _headElementUpsertOrRemove: _LazyInjectionToken<
   _makeInjectionToken(
     ngDevMode ? 'Head element upsert or remove util' : 'HEUOR',
     () => {
-      const head = inject(DOCUMENT).head
-      return (selector, element) => {
-        const existingScriptElement = head.querySelector(selector)
-        if (existingScriptElement) {
-          head.removeChild(existingScriptElement)
+      const document = inject(DOCUMENT)
+      const head = document.head
+      return (selector, elementFactory) => {
+        const existingElement = head.querySelector(selector)
+        if (existingElement) {
+          head.removeChild(existingElement)
         }
 
+        const element = elementFactory(document)
         if (!_isDefined(element)) {
           return
         }
@@ -31,5 +33,5 @@ export const _headElementUpsertOrRemove: _LazyInjectionToken<
  */
 export type _HeadElementUpsertOrRemove = (
   selector: string,
-  element: HTMLElement | null | undefined,
+  elementFactory: (document: Document) => HTMLElement | undefined,
 ) => void

--- a/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
@@ -1,4 +1,3 @@
-import { DOCUMENT } from '@angular/common'
 import {
   _headElementUpsertOrRemove,
   _HeadElementUpsertOrRemove,
@@ -13,17 +12,16 @@ const SCRIPT_TYPE = 'application/ld+json'
 
 export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
   JsonLdMetadata[typeof KEY]
-> =
-  (headElementUpsertOrRemove: _HeadElementUpsertOrRemove, doc: Document) =>
-  (jsonLd) => {
-    let scriptElement: HTMLScriptElement | undefined
-    if (_isDefined(jsonLd)) {
-      scriptElement = doc.createElement('script')
-      scriptElement.setAttribute('type', SCRIPT_TYPE)
-      scriptElement.innerHTML = JSON.stringify(jsonLd)
+> = (headElementUpsertOrRemove: _HeadElementUpsertOrRemove) => (jsonLd) =>
+  headElementUpsertOrRemove(`script[type='${SCRIPT_TYPE}']`, (doc) => {
+    if (!_isDefined(jsonLd)) {
+      return
     }
-    headElementUpsertOrRemove(`script[type='${SCRIPT_TYPE}']`, scriptElement)
-  }
+    const scriptElement = doc.createElement('script')
+    scriptElement.setAttribute('type', SCRIPT_TYPE)
+    scriptElement.innerHTML = JSON.stringify(jsonLd)
+    return scriptElement
+  })
 
 /**
  * Manages the {@link JsonLdMetadata.jsonLd} metadata
@@ -33,7 +31,7 @@ export const JSON_LD_METADATA_PROVIDER =
   makeMetadataManagerProviderFromSetterFactory(
     JSON_LD_METADATA_SETTER_FACTORY,
     {
-      d: [_headElementUpsertOrRemove(), DOCUMENT],
+      d: [_headElementUpsertOrRemove()],
       jP: [KEY],
     },
   )

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
@@ -9,33 +9,32 @@ import {
   _UrlResolver,
   MetadataSetter,
 } from '@davidlj95/ngx-meta/core'
-import { DOCUMENT } from '@angular/common'
 import { Standard } from '../types'
 import { MODULE_NAME } from '../module-name'
 
 export const STANDARD_CANONICAL_URL_SETTER_FACTORY: (
   headElementUpsertOrRemove: _HeadElementUpsertOrRemove,
-  doc: Document,
   urlResolver: _UrlResolver,
 ) => MetadataSetter<Standard[typeof _GLOBAL_CANONICAL_URL]> =
-  (headElementUpsertOrRemove, doc, urlResolver) => (url) => {
-    const resolvedUrl = urlResolver(url)
-    ngDevMode &&
-      _maybeNonHttpUrlDevMessage(resolvedUrl, {
-        module: MODULE_NAME,
-        property: _GLOBAL_CANONICAL_URL,
-        value: resolvedUrl,
-        link: 'https://stackoverflow.com/a/8467966/3263250',
-        shouldInsteadOfMust: true,
-      })
-    let linkElement: HTMLLinkElement | undefined
-    if (_isDefined(resolvedUrl)) {
-      linkElement = doc.createElement(LINK_TAG)
+  (headElementUpsertOrRemove, urlResolver) => (url) =>
+    headElementUpsertOrRemove(SELECTOR, (doc) => {
+      const resolvedUrl = urlResolver(url)
+      ngDevMode &&
+        _maybeNonHttpUrlDevMessage(resolvedUrl, {
+          module: MODULE_NAME,
+          property: _GLOBAL_CANONICAL_URL,
+          value: resolvedUrl,
+          link: 'https://stackoverflow.com/a/8467966/3263250',
+          shouldInsteadOfMust: true,
+        })
+      if (!_isDefined(resolvedUrl)) {
+        return
+      }
+      const linkElement = doc.createElement(LINK_TAG)
       linkElement.setAttribute(REL_ATTR, CANONICAL_VAL)
       linkElement.setAttribute('href', resolvedUrl)
-    }
-    headElementUpsertOrRemove(SELECTOR, linkElement)
-  }
+      return linkElement
+    })
 
 /**
  * Manages the {@link Standard.canonicalUrl} metadata
@@ -45,7 +44,7 @@ export const STANDARD_CANONICAL_URL_METADATA_PROVIDER =
   makeStandardMetadataProvider(_GLOBAL_CANONICAL_URL, {
     g: _GLOBAL_CANONICAL_URL,
     s: STANDARD_CANONICAL_URL_SETTER_FACTORY,
-    d: [_headElementUpsertOrRemove(), DOCUMENT, _urlResolver()],
+    d: [_headElementUpsertOrRemove(), _urlResolver()],
   })
 
 const LINK_TAG = 'link'


### PR DESCRIPTION
# Issue or need

When using `_HeadElementUpsertOrRemove`, consumers are forced to inject `DOCUMENT` to create the element to manage. 

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

In order to avoid this extra dependency, the manager now provides the document. The caller receives it when specifying an element factory function instead of an element.

Can't pass just `createElement` because `Illegal invocation` error appears https://stackoverflow.com/q/32423584

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
