### PR TITLE
test: simplify head element harness API surface

### DIFF
--- a/projects/ngx-meta/src/core/src/head-elements/__tests__/head-element-harness.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/__tests__/head-element-harness.ts
@@ -16,12 +16,12 @@ export class HeadElementHarness {
     this.doc.head.appendChild(element)
   }
 
-  getAll(selector: string): NodeListOf<HTMLElement> {
-    return this.doc.querySelectorAll(selector)
+  getAllDummyElements(): NodeListOf<HTMLElement> {
+    return this.doc.head.querySelectorAll(this.dummySelector)
   }
 
-  remove(selector: string): void {
-    const elements = this.getAll(selector)
+  removeAllDummyElements(): void {
+    const elements = this.getAllDummyElements()
     elements.forEach((element) => {
       element.remove()
     })

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -19,12 +19,12 @@ describe('Head element upsert or remove', () => {
     dummyElement = headElementHarness.createDummyElement('dummy 1')
   })
   afterEach(() => {
-    headElementHarness.remove(headElementHarness.dummySelector)
+    headElementHarness.removeAllDummyElements()
   })
 
   describe('when element does not exist already', () => {
     beforeEach(() => {
-      expect(headElementHarness.getAll(headElementHarness.dummySelector))
+      expect(headElementHarness.getAllDummyElements())
         .withContext('element does not exist already')
         .toHaveSize(0)
     })
@@ -33,9 +33,7 @@ describe('Head element upsert or remove', () => {
       it('should append it to head', () => {
         sut(headElementHarness.dummySelector, dummyElement)
 
-        const elements = headElementHarness.getAll(
-          headElementHarness.dummySelector,
-        )
+        const elements = headElementHarness.getAllDummyElements()
         expect(elements).toHaveSize(1)
         const element = elements[0]
         expect(element).toEqual(dummyElement)
@@ -47,9 +45,7 @@ describe('Head element upsert or remove', () => {
         it('should do nothing', () => {
           sut(headElementHarness.dummySelector, testCase)
 
-          expect(
-            headElementHarness.getAll(headElementHarness.dummySelector),
-          ).toHaveSize(0)
+          expect(headElementHarness.getAllDummyElements()).toHaveSize(0)
         })
       })
     })
@@ -58,7 +54,7 @@ describe('Head element upsert or remove', () => {
   describe('when element exists already', () => {
     beforeEach(() => {
       headElementHarness.appendElement(dummyElement)
-      expect(headElementHarness.getAll(headElementHarness.dummySelector))
+      expect(headElementHarness.getAllDummyElements())
         .withContext('element exists already')
         .toHaveSize(1)
     })
@@ -69,9 +65,7 @@ describe('Head element upsert or remove', () => {
           headElementHarness.createDummyElement('dummy 2')
         sut(headElementHarness.dummySelector, anotherDummyElement)
 
-        const elements = headElementHarness.getAll(
-          headElementHarness.dummySelector,
-        )
+        const elements = headElementHarness.getAllDummyElements()
         expect(elements).toHaveSize(1)
         const element = elements[0]
         expect(element).toEqual(anotherDummyElement)
@@ -83,9 +77,7 @@ describe('Head element upsert or remove', () => {
         it('should remove it', () => {
           sut(headElementHarness.dummySelector, testCase)
 
-          expect(
-            headElementHarness.getAll(headElementHarness.dummySelector),
-          ).toHaveSize(0)
+          expect(headElementHarness.getAllDummyElements()).toHaveSize(0)
         })
       })
     })


### PR DESCRIPTION
# Issue or need

Head element harness APIs to get and remove elements were called with something the own harness owns

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove argument, use the selector available.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
