### PR TITLE
refactor: inline setter factories

### DIFF
--- a/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
+++ b/projects/ngx-meta/src/json-ld/src/managers/json-ld-metadata-provider.ts
@@ -4,34 +4,31 @@ import {
   _HeadElementUpsertOrRemove,
   _isDefined,
   makeMetadataManagerProviderFromSetterFactory,
-  MetadataSetterFactory,
 } from '@davidlj95/ngx-meta/core'
 import { JsonLdMetadata } from './json-ld-metadata'
 
 const KEY = 'jsonLd' satisfies keyof JsonLdMetadata
 const SCRIPT_TYPE = 'application/ld+json'
 
-export const JSON_LD_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  JsonLdMetadata[typeof KEY]
-> =
-  (headElementUpsertOrRemove: _HeadElementUpsertOrRemove, doc: Document) =>
-  (jsonLd) => {
-    let scriptElement: HTMLScriptElement | undefined
-    if (_isDefined(jsonLd)) {
-      scriptElement = doc.createElement('script')
-      scriptElement.setAttribute('type', SCRIPT_TYPE)
-      scriptElement.innerHTML = JSON.stringify(jsonLd)
-    }
-    headElementUpsertOrRemove(`script[type='${SCRIPT_TYPE}']`, scriptElement)
-  }
-
 /**
  * Manages the {@link JsonLdMetadata.jsonLd} metadata
  * @public
  */
 export const JSON_LD_METADATA_PROVIDER =
-  makeMetadataManagerProviderFromSetterFactory(
-    JSON_LD_METADATA_SETTER_FACTORY,
+  makeMetadataManagerProviderFromSetterFactory<JsonLdMetadata['jsonLd']>(
+    (headElementUpsertOrRemove: _HeadElementUpsertOrRemove, doc: Document) =>
+      (jsonLd) => {
+        let scriptElement: HTMLScriptElement | undefined
+        if (_isDefined(jsonLd)) {
+          scriptElement = doc.createElement('script')
+          scriptElement.setAttribute('type', SCRIPT_TYPE)
+          scriptElement.innerHTML = JSON.stringify(jsonLd)
+        }
+        headElementUpsertOrRemove(
+          `script[type='${SCRIPT_TYPE}']`,
+          scriptElement,
+        )
+      },
     {
       d: [_headElementUpsertOrRemove(), DOCUMENT],
       jP: [KEY],

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.ts
@@ -19,52 +19,54 @@ const NO_KEY_VALUE: OpenGraph[typeof _GLOBAL_IMAGE] = {
   height: null,
 }
 
-export const OPEN_GRAPH_IMAGE_SETTER_FACTORY =
-  (metaElementsService: NgxMetaElementsService) =>
-  (value: OpenGraph[typeof _GLOBAL_IMAGE]) => {
-    const imageUrl = value?.url?.toString()
-    const effectiveValue: OpenGraph[typeof _GLOBAL_IMAGE] = _isDefined(imageUrl)
-      ? value
-      : NO_KEY_VALUE
-    // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
-    ngDevMode &&
-      _maybeNonHttpUrlDevMessage(imageUrl, {
-        module: MODULE_NAME,
-        property: _GLOBAL_IMAGE,
-        value: imageUrl,
-        link: 'https://stackoverflow.com/a/9858694/3263250',
-      })
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE),
-      withContentAttribute(imageUrl),
-    )
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'alt'),
-      withContentAttribute(effectiveValue?.alt),
-    )
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'secure_url'),
-      withContentAttribute(effectiveValue?.secureUrl?.toString()),
-    )
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'type'),
-      withContentAttribute(effectiveValue?.type),
-    )
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'width'),
-      withContentAttribute(effectiveValue?.width?.toString()),
-    )
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'height'),
-      withContentAttribute(effectiveValue?.height?.toString()),
-    )
-  }
-
 /**
  * Manages the {@link OpenGraph.image} metadata
  * @public
  */
 export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
   _GLOBAL_IMAGE,
-  { s: OPEN_GRAPH_IMAGE_SETTER_FACTORY, g: _GLOBAL_IMAGE, m: true },
+  {
+    s: (metaElementsService: NgxMetaElementsService) => (value) => {
+      const imageUrl = value?.url?.toString()
+      const effectiveValue: OpenGraph[typeof _GLOBAL_IMAGE] = _isDefined(
+        imageUrl,
+      )
+        ? value
+        : NO_KEY_VALUE
+      // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
+      ngDevMode &&
+        _maybeNonHttpUrlDevMessage(imageUrl, {
+          module: MODULE_NAME,
+          property: _GLOBAL_IMAGE,
+          value: imageUrl,
+          link: 'https://stackoverflow.com/a/9858694/3263250',
+        })
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE),
+        withContentAttribute(imageUrl),
+      )
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'alt'),
+        withContentAttribute(effectiveValue?.alt),
+      )
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'secure_url'),
+        withContentAttribute(effectiveValue?.secureUrl?.toString()),
+      )
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'type'),
+        withContentAttribute(effectiveValue?.type),
+      )
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'width'),
+        withContentAttribute(effectiveValue?.width?.toString()),
+      )
+      metaElementsService.set(
+        withOpenGraphPropertyAttribute(_GLOBAL_IMAGE, 'height'),
+        withContentAttribute(effectiveValue?.height?.toString()),
+      )
+    },
+    g: _GLOBAL_IMAGE,
+    m: true,
+  },
 )

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.ts
@@ -11,23 +11,6 @@ import { OpenGraph } from '../../types'
 import { MODULE_NAME } from '../../module-name'
 import { withOpenGraphPropertyAttribute } from '../../utils/with-open-graph-property-attribute'
 
-export const OPEN_GRAPH_URL_SETTER_FACTORY =
-  (metaElementsService: NgxMetaElementsService, urlResolver: _UrlResolver) =>
-  (url: OpenGraph[typeof KEY]) => {
-    const resolvedUrl = urlResolver(url)
-    ngDevMode &&
-      _maybeNonHttpUrlDevMessage(resolvedUrl, {
-        module: MODULE_NAME,
-        property: KEY,
-        value: resolvedUrl,
-        link: 'https://ogp.me/#metadata',
-      })
-    metaElementsService.set(
-      withOpenGraphPropertyAttribute(KEY),
-      withContentAttribute(urlResolver(url)),
-    )
-  }
-
 const KEY = 'url' satisfies keyof OpenGraph
 
 /**
@@ -38,7 +21,25 @@ export const OPEN_GRAPH_URL_METADATA_PROVIDER = makeOpenGraphMetadataProvider(
   KEY,
   {
     g: _GLOBAL_CANONICAL_URL,
-    s: OPEN_GRAPH_URL_SETTER_FACTORY,
+    s:
+      (
+        metaElementsService: NgxMetaElementsService,
+        urlResolver: _UrlResolver,
+      ) =>
+      (url) => {
+        const resolvedUrl = urlResolver(url)
+        ngDevMode &&
+          _maybeNonHttpUrlDevMessage(resolvedUrl, {
+            module: MODULE_NAME,
+            property: KEY,
+            value: resolvedUrl,
+            link: 'https://ogp.me/#metadata',
+          })
+        metaElementsService.set(
+          withOpenGraphPropertyAttribute(KEY),
+          withContentAttribute(urlResolver(url)),
+        )
+      },
     d: [NgxMetaElementsService, _urlResolver()],
   },
 )

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.ts
@@ -2,40 +2,12 @@ import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-pr
 import {
   _GLOBAL_CANONICAL_URL,
   _headElementUpsertOrRemove,
-  _HeadElementUpsertOrRemove,
   _isDefined,
   _maybeNonHttpUrlDevMessage,
   _urlResolver,
-  _UrlResolver,
-  MetadataSetter,
 } from '@davidlj95/ngx-meta/core'
 import { DOCUMENT } from '@angular/common'
-import { Standard } from '../types'
 import { MODULE_NAME } from '../module-name'
-
-export const STANDARD_CANONICAL_URL_SETTER_FACTORY: (
-  headElementUpsertOrRemove: _HeadElementUpsertOrRemove,
-  doc: Document,
-  urlResolver: _UrlResolver,
-) => MetadataSetter<Standard[typeof _GLOBAL_CANONICAL_URL]> =
-  (headElementUpsertOrRemove, doc, urlResolver) => (url) => {
-    const resolvedUrl = urlResolver(url)
-    ngDevMode &&
-      _maybeNonHttpUrlDevMessage(resolvedUrl, {
-        module: MODULE_NAME,
-        property: _GLOBAL_CANONICAL_URL,
-        value: resolvedUrl,
-        link: 'https://stackoverflow.com/a/8467966/3263250',
-        shouldInsteadOfMust: true,
-      })
-    let linkElement: HTMLLinkElement | undefined
-    if (_isDefined(resolvedUrl)) {
-      linkElement = doc.createElement(LINK_TAG)
-      linkElement.setAttribute(REL_ATTR, CANONICAL_VAL)
-      linkElement.setAttribute('href', resolvedUrl)
-    }
-    headElementUpsertOrRemove(SELECTOR, linkElement)
-  }
 
 /**
  * Manages the {@link Standard.canonicalUrl} metadata
@@ -44,7 +16,24 @@ export const STANDARD_CANONICAL_URL_SETTER_FACTORY: (
 export const STANDARD_CANONICAL_URL_METADATA_PROVIDER =
   makeStandardMetadataProvider(_GLOBAL_CANONICAL_URL, {
     g: _GLOBAL_CANONICAL_URL,
-    s: STANDARD_CANONICAL_URL_SETTER_FACTORY,
+    s: (headElementUpsertOrRemove, doc, urlResolver) => (url) => {
+      const resolvedUrl = urlResolver(url)
+      ngDevMode &&
+        _maybeNonHttpUrlDevMessage(resolvedUrl, {
+          module: MODULE_NAME,
+          property: _GLOBAL_CANONICAL_URL,
+          value: resolvedUrl,
+          link: 'https://stackoverflow.com/a/8467966/3263250',
+          shouldInsteadOfMust: true,
+        })
+      let linkElement: HTMLLinkElement | undefined
+      if (_isDefined(resolvedUrl)) {
+        linkElement = doc.createElement(LINK_TAG)
+        linkElement!.setAttribute(REL_ATTR, CANONICAL_VAL)
+        linkElement!.setAttribute('href', resolvedUrl)
+      }
+      headElementUpsertOrRemove(SELECTOR, linkElement)
+    },
     d: [_headElementUpsertOrRemove(), DOCUMENT, _urlResolver()],
   })
 

--- a/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-generator-metadata-provider.ts
@@ -1,20 +1,11 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
 import { Standard } from '../types'
 import {
-  MetadataSetterFactory,
   NgxMetaElementsService,
   withContentAttribute,
   withNameAttribute,
 } from '@davidlj95/ngx-meta/core'
 import { VERSION } from '@angular/core'
-
-export const STANDARD_GENERATOR_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof KEY]
-> = (metaElementsService: NgxMetaElementsService) => (value) =>
-  metaElementsService.set(
-    withNameAttribute(KEY),
-    withContentAttribute(value === true ? `Angular v${VERSION.full}` : value),
-  )
 
 const KEY = 'generator' satisfies keyof Standard
 
@@ -24,5 +15,11 @@ const KEY = 'generator' satisfies keyof Standard
  */
 export const STANDARD_GENERATOR_METADATA_PROVIDER =
   makeStandardMetadataProvider(KEY, {
-    s: STANDARD_GENERATOR_METADATA_SETTER_FACTORY,
+    s: (metaElementsService: NgxMetaElementsService) => (value) =>
+      metaElementsService.set(
+        withNameAttribute(KEY),
+        withContentAttribute(
+          value === true ? `Angular v${VERSION.full}` : value,
+        ),
+      ),
   })

--- a/projects/ngx-meta/src/standard/src/managers/standard-keywords-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-keywords-metadata-provider.ts
@@ -1,19 +1,10 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
 import { Standard } from '../types'
 import {
-  MetadataSetterFactory,
   NgxMetaElementsService,
   withContentAttribute,
   withNameAttribute,
 } from '@davidlj95/ngx-meta/core'
-
-export const STANDARD_KEYWORDS_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof KEY]
-> = (metaElementsService: NgxMetaElementsService) => (value) =>
-  metaElementsService.set(
-    withNameAttribute(KEY),
-    withContentAttribute(value?.join(',')),
-  )
 
 const KEY = 'keywords' satisfies keyof Standard
 
@@ -23,5 +14,11 @@ const KEY = 'keywords' satisfies keyof Standard
  */
 export const STANDARD_KEYWORDS_METADATA_PROVIDER = makeStandardMetadataProvider(
   KEY,
-  { s: STANDARD_KEYWORDS_METADATA_SETTER_FACTORY },
+  {
+    s: (metaElementsService: NgxMetaElementsService) => (value) =>
+      metaElementsService.set(
+        withNameAttribute(KEY),
+        withContentAttribute(value?.join(',')),
+      ),
+  },
 )

--- a/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.ts
@@ -1,22 +1,6 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
-import {
-  _GLOBAL_LOCALE,
-  _isDefined,
-  MetadataSetterFactory,
-} from '@davidlj95/ngx-meta/core'
+import { _GLOBAL_LOCALE, _isDefined } from '@davidlj95/ngx-meta/core'
 import { DOCUMENT } from '@angular/common'
-import { Standard } from '../types'
-
-export const STANDARD_LOCALE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof _GLOBAL_LOCALE]
-> = (doc: Document) => (locale) => {
-  const htmlElement = doc.documentElement
-  if (!_isDefined(locale)) {
-    htmlElement.removeAttribute(ATTRIBUTE_NAME)
-    return
-  }
-  htmlElement.setAttribute(ATTRIBUTE_NAME, locale)
-}
 
 const ATTRIBUTE_NAME = 'lang'
 
@@ -28,7 +12,14 @@ export const STANDARD_LOCALE_METADATA_PROVIDER = makeStandardMetadataProvider(
   _GLOBAL_LOCALE,
   {
     g: _GLOBAL_LOCALE,
-    s: STANDARD_LOCALE_METADATA_SETTER_FACTORY,
+    s: (doc: Document) => (locale) => {
+      const htmlElement = doc.documentElement
+      if (!_isDefined(locale)) {
+        htmlElement.removeAttribute(ATTRIBUTE_NAME)
+        return
+      }
+      htmlElement.setAttribute(ATTRIBUTE_NAME, locale)
+    },
     d: [DOCUMENT],
   },
 )

--- a/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-theme-color-metadata-provider.ts
@@ -1,37 +1,29 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
 import {
   _isDefined,
-  MetadataSetterFactory,
   NgxMetaElementsService,
   withContentAttribute,
   withNameAttribute,
 } from '@davidlj95/ngx-meta/core'
-import { Standard } from '../types'
 import { StandardThemeColorMetadataObject } from './standard-theme-color-metadata'
-
-export const STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof KEY]
-> = (metaElementsService: NgxMetaElementsService) => (value) => {
-  const contents = !_isDefined(value)
-    ? []
-    : typeof value === 'string'
-      ? [{ color: value } satisfies StandardThemeColorMetadataObject]
-      : value
-  metaElementsService.set(
-    withNameAttribute('theme-color'),
-    contents.map(({ color, media }) =>
-      withContentAttribute(color, media ? { media } : undefined),
-    ),
-  )
-}
-
-const KEY = 'themeColor' satisfies keyof Standard
 
 /**
  * Manages the {@link Standard.themeColor} metadata
  * @public
  */
 export const STANDARD_THEME_COLOR_METADATA_PROVIDER =
-  makeStandardMetadataProvider(KEY, {
-    s: STANDARD_THEME_COLOR_METADATA_SETTER_FACTORY,
+  makeStandardMetadataProvider('themeColor', {
+    s: (metaElementsService: NgxMetaElementsService) => (value) => {
+      const contents = !_isDefined(value)
+        ? []
+        : typeof value === 'string'
+          ? [{ color: value } satisfies StandardThemeColorMetadataObject]
+          : value
+      metaElementsService.set(
+        withNameAttribute('theme-color'),
+        contents.map(({ color, media }) =>
+          withContentAttribute(color, media ? { media } : undefined),
+        ),
+      )
+    },
   })

--- a/projects/ngx-meta/src/standard/src/managers/standard-title-metadata-provider.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-title-metadata-provider.ts
@@ -1,20 +1,6 @@
 import { makeStandardMetadataProvider } from '../utils/make-standard-metadata-provider'
-import { Standard } from '../types'
 import { Title } from '@angular/platform-browser'
-import {
-  _GLOBAL_TITLE,
-  _isDefined,
-  MetadataSetterFactory,
-} from '@davidlj95/ngx-meta/core'
-
-export const STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
-  Standard[typeof _GLOBAL_TITLE]
-> = (titleService: Title) => (value) => {
-  if (!_isDefined(value)) {
-    return
-  }
-  titleService.setTitle(value)
-}
+import { _GLOBAL_TITLE, _isDefined } from '@davidlj95/ngx-meta/core'
 
 /**
  * Manages the {@link Standard.title} metadata
@@ -22,5 +8,14 @@ export const STANDARD_TITLE_METADATA_SETTER_FACTORY: MetadataSetterFactory<
  */
 export const STANDARD_TITLE_METADATA_PROVIDER = makeStandardMetadataProvider(
   _GLOBAL_TITLE,
-  { g: _GLOBAL_TITLE, s: STANDARD_TITLE_METADATA_SETTER_FACTORY, d: [Title] },
+  {
+    g: _GLOBAL_TITLE,
+    s: (titleService: Title) => (value) => {
+      if (!_isDefined(value)) {
+        return
+      }
+      titleService.setTitle(value)
+    },
+    d: [Title],
+  },
 )

--- a/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.ts
+++ b/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.ts
@@ -5,30 +5,8 @@ import {
   NgxMetaElementsService,
   withContentAttribute,
 } from '@davidlj95/ngx-meta/core'
-import { TwitterCard } from '../types'
 import { MODULE_NAME } from '../module-name'
 import { withTwitterCardNameAttribute } from '../utils/with-twitter-card-name-attribute'
-
-export const TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
-  (metaElementsService: NgxMetaElementsService) =>
-  (image: TwitterCard['image']) => {
-    // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
-    ngDevMode &&
-      _maybeNonHttpUrlDevMessage(image?.url, {
-        module: MODULE_NAME,
-        property: 'image',
-        value: image?.url.toString(),
-        link: 'https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736',
-      })
-    metaElementsService.set(
-      withTwitterCardNameAttribute(_GLOBAL_IMAGE),
-      withContentAttribute(image?.url?.toString()),
-    )
-    metaElementsService.set(
-      withTwitterCardNameAttribute(_GLOBAL_IMAGE, 'alt'),
-      withContentAttribute(image?.alt),
-    )
-  }
 
 /**
  * Manages the {@link TwitterCard.image} metadata
@@ -37,6 +15,23 @@ export const TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY =
 export const TWITTER_CARD_IMAGE_METADATA_PROVIDER =
   makeTwitterCardMetadataProvider(_GLOBAL_IMAGE, {
     g: _GLOBAL_IMAGE,
-    s: TWITTER_CARD_IMAGE_METADATA_SETTER_FACTORY,
+    s: (metaElementsService: NgxMetaElementsService) => (image) => {
+      // Why not an `if`? Checkout https://github.com/davidlj95/ngx/pull/731
+      ngDevMode &&
+        _maybeNonHttpUrlDevMessage(image?.url, {
+          module: MODULE_NAME,
+          property: 'image',
+          value: image?.url.toString(),
+          link: 'https://devcommunity.x.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736',
+        })
+      metaElementsService.set(
+        withTwitterCardNameAttribute(_GLOBAL_IMAGE),
+        withContentAttribute(image?.url?.toString()),
+      )
+      metaElementsService.set(
+        withTwitterCardNameAttribute(_GLOBAL_IMAGE, 'alt'),
+        withContentAttribute(image?.alt),
+      )
+    },
     m: true,
   })


### PR DESCRIPTION
# Issue or need

After #893, there's no need to declare a metadata manager's setter factory apart

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Inline all metadata manager setter factories

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
