### PR TITLE
feat: add type helper to with global manager API

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -610,7 +610,7 @@ export const withManagerDeps: (...deps: Exclude<FactoryProvider['deps'], undefin
 // Warning: (ae-incompatible-release-tags) The symbol "withManagerGlobal" is marked as @alpha, but its signature references "_ProvideNgxMetaManagerOptions" which is marked as @internal
 //
 // @alpha
-export const withManagerGlobal: (global: string) => _ProvideNgxMetaManagerOptions;
+export const withManagerGlobal: <G extends string = keyof GlobalMetadata>(global: G) => _ProvideNgxMetaManagerOptions;
 
 // @alpha
 export const withManagerJsonPath: (...jsonPath: MetadataResolverOptions['jsonPath']) => string;

--- a/projects/ngx-meta/src/core/src/managers/provider/provide-ngx-meta-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/provide-ngx-meta-manager.ts
@@ -4,6 +4,7 @@ import {
   MetadataResolverOptions,
   NgxMetaMetadataManager,
 } from '../ngx-meta-metadata-manager'
+import { GlobalMetadata } from '../../globals'
 
 /**
  * Creates an {@link NgxMetaMetadataManager} provider to manage some metadata.
@@ -114,8 +115,8 @@ export const withManagerDeps = (
  *
  * @alpha
  */
-export const withManagerGlobal = (
-  global: string,
+export const withManagerGlobal = <G extends string = keyof GlobalMetadata>(
+  global: G,
 ): _ProvideNgxMetaManagerOptions => ({ g: global })
 
 /**


### PR DESCRIPTION
# Issue or need

The method `withManagerGlobal` to provide a global for a metadata manager can be improved so that by default it suggests to use one of the globals defined in `GlobalMetadata`

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add generic type defaulting to a key of `GlobalMetadata`

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
