### PR TITLE
refactor: organize manager providers by version

### DIFF
--- a/projects/ngx-meta/src/core/src/managers/provider/index.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/index.ts
@@ -1,20 +1,3 @@
-export {
-  provideNgxMetaManager,
-  withManagerDeps,
-  withManagerGlobal,
-  withManagerObjectMerging,
-  withManagerJsonPath,
-  _ProvideNgxMetaManagerOptions,
-} from './provide-ngx-meta-manager'
-export {
-  _provideNgxMetaModuleManager,
-  _ProvideNgxMetaModuleManagerOptions,
-  _withModuleManagerNameAttribute,
-  _withModuleManagerSetterFactory,
-  _withModuleManagerSameGlobalKey,
-} from './provide-ngx-meta-module-manager'
-export {
-  makeMetadataManagerProviderFromSetterFactory,
-  MetadataSetterFactory,
-  MakeMetadataManagerProviderFromSetterFactoryOptions,
-} from './make-metadata-manager-provider-from-setter-factory'
+export * from './v1'
+export * from './v2'
+export { MetadataSetterFactory } from './metadata-setter-factory'

--- a/projects/ngx-meta/src/core/src/managers/provider/metadata-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/metadata-setter-factory.ts
@@ -1,0 +1,13 @@
+import { FactoryProvider } from '@angular/core'
+import { MetadataSetter } from '../ngx-meta-metadata-manager'
+
+/**
+ * Utility type for a factory function that returns a {@link MetadataSetter} given some injectable dependencies.
+ *
+ * Used as part of {@link makeMetadataManagerProviderFromSetterFactory}.
+ *
+ * @public
+ */
+export type MetadataSetterFactory<T> = (
+  ...deps: Exclude<FactoryProvider['deps'], undefined>
+) => MetadataSetter<T>

--- a/projects/ngx-meta/src/core/src/managers/provider/v1/index.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v1/index.ts
@@ -1,0 +1,4 @@
+export {
+  makeMetadataManagerProviderFromSetterFactory,
+  MakeMetadataManagerProviderFromSetterFactoryOptions,
+} from './make-metadata-manager-provider-from-setter-factory'

--- a/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
@@ -1,9 +1,9 @@
 import {
   MetadataResolverOptions,
-  MetadataSetter,
   NgxMetaMetadataManager,
-} from '../ngx-meta-metadata-manager'
+} from '../../ngx-meta-metadata-manager'
 import { FactoryProvider } from '@angular/core'
+import { MetadataSetterFactory } from '../metadata-setter-factory'
 
 /**
  * Creates an Angular {@link https://angular.dev/guide/di/dependency-injection-providers#factory-providers-usefactory | factory provider}
@@ -44,17 +44,6 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
     deps,
   }
 }
-
-/**
- * Utility type for a factory function that returns a {@link MetadataSetter} given some injectable dependencies.
- *
- * Used as part of {@link makeMetadataManagerProviderFromSetterFactory}.
- *
- * @public
- */
-export type MetadataSetterFactory<T> = (
-  ...deps: Exclude<FactoryProvider['deps'], undefined>
-) => MetadataSetter<T>
 
 /**
  * Options argument object for {@link makeMetadataManagerProviderFromSetterFactory}.

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/index.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/index.ts
@@ -1,0 +1,15 @@
+export {
+  provideNgxMetaManager,
+  withManagerDeps,
+  withManagerGlobal,
+  withManagerObjectMerging,
+  withManagerJsonPath,
+  _ProvideNgxMetaManagerOptions,
+} from './provide-ngx-meta-manager'
+export {
+  _provideNgxMetaModuleManager,
+  _ProvideNgxMetaModuleManagerOptions,
+  _withModuleManagerNameAttribute,
+  _withModuleManagerSetterFactory,
+  _withModuleManagerSameGlobalKey,
+} from './provide-ngx-meta-module-manager'

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.spec.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.spec.ts
@@ -3,8 +3,8 @@ import { FactoryProvider, InjectionToken, Provider } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { DOCUMENT } from '@angular/common'
 import { Router } from '@angular/router'
-import { MetadataSetterFactory } from './make-metadata-manager-provider-from-setter-factory'
-import { _isDefined, withOptions } from '../../utils'
+import { MetadataSetterFactory } from '../metadata-setter-factory'
+import { _isDefined, withOptions } from '../../../utils'
 import {
   provideNgxMetaManager,
   withManagerDeps,

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.ts
@@ -1,10 +1,10 @@
-import { MetadataSetterFactory } from './make-metadata-manager-provider-from-setter-factory'
 import { FactoryProvider } from '@angular/core'
 import {
   MetadataResolverOptions,
   NgxMetaMetadataManager,
-} from '../ngx-meta-metadata-manager'
-import { GlobalMetadata } from '../../globals'
+} from '../../ngx-meta-metadata-manager'
+import { GlobalMetadata } from '../../../globals'
+import { MetadataSetterFactory } from '../metadata-setter-factory'
 
 /**
  * Creates an {@link NgxMetaMetadataManager} provider to manage some metadata.

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-module-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-module-manager.ts
@@ -10,9 +10,9 @@ import {
   NgxMetaElementsService,
   withContentAttribute,
   withNameAttribute,
-} from '../../meta-elements'
-import { MetadataSetterFactory } from './make-metadata-manager-provider-from-setter-factory'
-import { withOptions } from '../../utils'
+} from '../../../meta-elements'
+import { MetadataSetterFactory } from '../metadata-setter-factory'
+import { withOptions } from '../../../utils'
 
 /**
  * @internal


### PR DESCRIPTION
# Issue or need

v1 and v2 provider manager APIs are in the same directory. It's not explicit just by looking at dir structure which API is used, which is old...

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Organize by version directories. Extract common outside

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
