### PR TITLE
feat: add type checking for JSON Path utility

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -433,8 +433,10 @@ export type _ProvideNgxMetaManagerOptions = Partial<{
 // @public
 export const provideNgxMetaMetadataLoader: () => Provider[];
 
+// Warning: (ae-forgotten-export) The symbol "StringKeyOf" needs to be exported by the entry point all-entry-points.d.ts
+//
 // @internal (undocumented)
-export const _provideNgxMetaModuleManager: <Type extends object, Key extends Extract<keyof Type, string>>(key: Key, scope: ReadonlyArray<string>, options: _ProvideNgxMetaModuleManagerOptions<Type[Key]>) => FactoryProvider;
+export const _provideNgxMetaModuleManager: <Type extends object, Key extends StringKeyOf<Type>>(key: Key, scope: ReadonlyArray<string>, options: _ProvideNgxMetaModuleManagerOptions<Type[Key]>) => FactoryProvider;
 
 // @internal (undocumented)
 export type _ProvideNgxMetaModuleManagerOptions<T> = Partial<{
@@ -517,6 +519,9 @@ export interface StandardThemeColorMetadataObject {
     color: string;
     media?: string;
 }
+
+// @internal (undocumented)
+type StringKeyOf<T = object> = Extract<keyof T, string>;
 
 // @public
 export const TWITTER_CARD_CARD_METADATA_PROVIDER: FactoryProvider;
@@ -622,8 +627,22 @@ export const withManagerDeps: (...deps: Exclude<FactoryProvider['deps'], undefin
 // @public
 export const withManagerGlobal: <G extends string = keyof GlobalMetadata>(global: G) => _ProvideNgxMetaManagerOptions;
 
+// @internal (undocumented)
+interface WithManagerJsonPath {
+    // (undocumented)
+    <T extends object>(key1: StringKeyOf<T>): string;
+    // (undocumented)
+    <T extends object>(key1: StringKeyOf<T>, key2: StringKeyOf<T[typeof key1]>): string;
+    // (undocumented)
+    <T extends object>(key1: StringKeyOf<T>, key2: StringKeyOf<T[typeof key1]>, key3: StringKeyOf<T[typeof key1][typeof key2]>): string;
+    // (undocumented)
+    (...jsonPaths: ReadonlyArray<string>): string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "WithManagerJsonPath" needs to be exported by the entry point all-entry-points.d.ts
+//
 // @public
-export const withManagerJsonPath: (...jsonPath: MetadataResolverOptions['jsonPath']) => string;
+export const withManagerJsonPath: WithManagerJsonPath;
 
 // Warning: (ae-incompatible-release-tags) The symbol "withManagerObjectMerging" is marked as @public, but its signature references "_ProvideNgxMetaManagerOptions" which is marked as @internal
 //

--- a/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
+++ b/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
@@ -71,6 +71,36 @@ export const provideCustomMetadataManager = () =>
 
 That would be it, there you have your metadata manager provider, ready to inject into your Angular's app dependencies.
 
+??? tip "You can use a helper to create and ensure a JSON Path is valid"
+
+    In the example, instead of `custom.title` JSON Path, you can use [`withManagerJsonPath`](ngx-meta.withmanagerjsonpath.md) helper.
+    It will:
+
+      - Ensure keys are valid (belong to the given type).
+
+      - Join the keys with a `.`
+
+    ```typescript
+    import {
+      withManagerJsonPath,
+    } from '@davidlj95/ngx-meta/core'
+
+    interface CustomMetadata {
+      custom: {
+        title: string
+      }
+    }
+
+    export const provideCustomMetadataManager = () =>
+      provideNgxMetaManager<string | undefined>(
+        withManagerJsonPath<CustomMetadata>('custom', 'title'),
+        // ...
+      )
+    )
+    ```
+
+    Check out [`withManagerJsonPath` API docs](ngx-meta.withmanagerjsonpath.md) for more information and known limitations.
+
 See the API reference of [`provideNgxMetaManager`](ngx-meta.providengxmetamanager.md) for more information.
 
 You can also check a full example at [example standalone app]'s [`provideCustomMetadataManager`](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts)

--- a/projects/ngx-meta/example-apps/templates/module/src/app/meta-late-loaded/provide-custom-metadata-manager.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/meta-late-loaded/provide-custom-metadata-manager.ts
@@ -3,13 +3,20 @@ import {
   provideNgxMetaManager,
   withContentAttribute,
   withManagerDeps,
+  withManagerJsonPath,
   withNameAttribute,
 } from '@davidlj95/ngx-meta/core'
 import CUSTOM_METADATA_JSON from '@/e2e/cypress/fixtures/custom-metadata.json'
 
+interface CustomMetadata {
+  custom: {
+    title: string
+  }
+}
+
 export const provideCustomMetadataManager = () =>
   provideNgxMetaManager<string | undefined>(
-    'custom.title',
+    withManagerJsonPath<CustomMetadata>('custom', 'title'),
     (metaElementsService: NgxMetaElementsService) => (value) => {
       metaElementsService.set(
         withNameAttribute(CUSTOM_METADATA_JSON.custom.keyName),

--- a/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts
+++ b/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts
@@ -3,14 +3,21 @@ import {
   provideNgxMetaManager,
   withContentAttribute,
   withManagerDeps,
+  withManagerJsonPath,
   withNameAttribute,
   withOptions,
 } from '@davidlj95/ngx-meta/core'
 import CUSTOM_METADATA_JSON from '@/e2e/cypress/fixtures/custom-metadata.json'
 
+interface CustomMetadata {
+  custom: {
+    title: string
+  }
+}
+
 export const provideCustomMetadataManager = () =>
   provideNgxMetaManager<string | undefined>(
-    'custom.title',
+    withManagerJsonPath<CustomMetadata>('custom', 'title'),
     (metaElementsService: NgxMetaElementsService) => (value) => {
       metaElementsService.set(
         withNameAttribute(CUSTOM_METADATA_JSON.custom.keyName),

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-module-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-module-manager.ts
@@ -13,13 +13,14 @@ import {
 } from '../../../meta-elements'
 import { MetadataSetterFactory } from '../metadata-setter-factory'
 import { withOptions } from '../../../utils'
+import { StringKeyOf } from '../../../utils/string-key-of'
 
 /**
  * @internal
  */
 export const _provideNgxMetaModuleManager = <
   Type extends object,
-  Key extends StringKey<Type>,
+  Key extends StringKeyOf<Type>,
 >(
   key: Key,
   scope: ReadonlyArray<string>,
@@ -39,8 +40,6 @@ export const _provideNgxMetaModuleManager = <
       options,
     ),
   )
-
-type StringKey<T = object> = Extract<keyof T, string>
 
 /**
  * @internal

--- a/projects/ngx-meta/src/core/src/utils/string-key-of.ts
+++ b/projects/ngx-meta/src/core/src/utils/string-key-of.ts
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export type StringKeyOf<T = object> = Extract<keyof T, string>


### PR DESCRIPTION
# Issue or need

The util to create JSON Paths `withManagerJsonPath`s could be improved so given a type, it ensures the keys passed can be used to access a value inside the type.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a magic Typescript type to ensure the util checks key types to see if they are valid.

Document the new feature around: API docs + custom metadata guide as a tip.

Extract `StringKeyOf` util as it's also used by module manager provider util.

**Known quirk**: WebStorm highlights uses of `withManagerJsonPath` with purple colour. As if it was a variable. Either if using `interface` or `type x & y` to create the overload types for it. If changing to `function` instead of `const`, WebStorm highlights it with blue colour, as functions are. However, 14 bytes are added (`return` + `function` length).  So going with that quirk to save some bytes around.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
