### PR TITLE
feat: deprecate meta elements APIs v1

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -119,10 +119,10 @@ export interface JsonLdMetadata {
 // @internal
 export type _LazyInjectionToken<T> = () => InjectionToken<T>;
 
-// @public
+// @public @deprecated
 export const makeComposedKeyValMetaDefinition: (names: ReadonlyArray<string>, options?: MakeComposedKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 
-// @public
+// @public @deprecated
 export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaDefinitionOptions {
     separator?: string;
 }
@@ -130,10 +130,10 @@ export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaD
 // @internal
 export const _makeInjectionToken: <T>(description: string, factory?: () => T) => InjectionToken<T>;
 
-// @public
-export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
+// @public @deprecated
+export const makeKeyValMetaDefinition: (keyName: string, options: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 
-// @public
+// @public @deprecated
 export interface MakeKeyValMetaDefinitionOptions {
     extras?: MetaDefinition;
     keyAttr?: string;
@@ -231,7 +231,7 @@ export class NgxMetaElementsService {
 export class NgxMetaJsonLdModule {
 }
 
-// @public
+// @public @deprecated
 export type NgxMetaMetaContent = string | undefined | null;
 
 // @public
@@ -245,15 +245,18 @@ export abstract class NgxMetaMetadataManager<Value = unknown> {
     abstract readonly set: MetadataSetter<Value>;
 }
 
-// @public
+// @public @deprecated
 export interface NgxMetaMetaDefinition {
+    // @deprecated
     readonly attrSelector: string;
+    // @deprecated
     readonly withContent: (content: string) => MetaDefinition;
 }
 
-// @public
+// @public @deprecated
 export class NgxMetaMetaService {
     constructor(meta: Meta);
+    // @deprecated
     set(definition: NgxMetaMetaDefinition, content: NgxMetaMetaContent): void;
 }
 

--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -131,7 +131,7 @@ export interface MakeComposedKeyValMetaDefinitionOptions extends MakeKeyValMetaD
 export const _makeInjectionToken: <T>(description: string, factory?: () => T) => InjectionToken<T>;
 
 // @public @deprecated
-export const makeKeyValMetaDefinition: (keyName: string, options: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
+export const makeKeyValMetaDefinition: (keyName: string, options?: MakeKeyValMetaDefinitionOptions) => NgxMetaMetaDefinition;
 
 // @public @deprecated
 export interface MakeKeyValMetaDefinitionOptions {

--- a/projects/ngx-meta/docs/includes/ngx-meta-elements-service.md
+++ b/projects/ngx-meta/docs/includes/ngx-meta-elements-service.md
@@ -6,7 +6,7 @@ Notice the use of [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservic
 
 ??? tip "Were you looking for `NgxMetaMetaService`?"
 
-    Before [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/) was introduced, the service managing those was [`NgxMetaMetaService`](/api/ngx-meta.ngxmetametaservice/). However, API design for it and its related util functions was a bit limited. It also didn't allow to manage multiple `#!html <meta>` elements. So they were replaced. See [the PR were newer APIs were introduced](https://github.com/davidlj95/ngx/pull/883) for more information.
+    Before [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/) was introduced, the service managing those was [`NgxMetaMetaService`](/api/ngx-meta.ngxmetametaservice/). However, API design for it and its related util functions was a bit limited. It also didn't allow to manage multiple `#!html <meta>` elements. So they were replaced. And right now they are deprecated, so new ones should be used instead. See [the PR were newer APIs were introduced](https://github.com/davidlj95/ngx/pull/883) for more information.
 
     You can still checkout the [example app file using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts) and the [custom metadata guide using that service instead](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
 

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/make-composed-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/make-composed-key-val-meta-definition.ts
@@ -1,3 +1,5 @@
+// noinspection JSDeprecatedSymbols
+
 import {
   makeKeyValMetaDefinition,
   MakeKeyValMetaDefinitionOptions,
@@ -25,6 +27,9 @@ import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
  * )
  * ```
  *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *
  * @param names - Names to create they key name
  * @param options - Options object
  * @public
@@ -38,6 +43,9 @@ export const makeComposedKeyValMetaDefinition = (
 
 /**
  * Options argument object for {@link makeComposedKeyValMetaDefinition}
+ *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
  *
  * @public
  */

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
@@ -1,3 +1,5 @@
+// noinspection JSDeprecatedSymbols
+
 import { MetaDefinition } from '@angular/platform-browser'
 import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
 
@@ -19,12 +21,18 @@ import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
  * Value is set by {@link NgxMetaMetaService.set} by providing this model and an
  * actual value
  *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *
  * @param keyName - Name of the key in the key/value meta definition
  * @param options - Specifies HTML attribute names and extras of the definition if any
  *
  * @public
  */
-export const makeKeyValMetaDefinition = (
+export const makeKeyValMetaDefinition: (
+  keyName: string,
+  options: MakeKeyValMetaDefinitionOptions,
+) => NgxMetaMetaDefinition = (
   keyName: string,
   /* istanbul ignore next - quite simple */
   options: MakeKeyValMetaDefinitionOptions = {},
@@ -45,6 +53,9 @@ export const makeKeyValMetaDefinition = (
 
 /**
  * Options argument object for {@link makeKeyValMetaDefinition}
+ *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
  *
  * @public
  */

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
@@ -29,10 +29,7 @@ import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
  *
  * @public
  */
-export const makeKeyValMetaDefinition: (
-  keyName: string,
-  options: MakeKeyValMetaDefinitionOptions,
-) => NgxMetaMetaDefinition = (
+export const makeKeyValMetaDefinition = (
   keyName: string,
   /* istanbul ignore next - quite simple */
   options: MakeKeyValMetaDefinitionOptions = {},

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-content.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-content.ts
@@ -5,6 +5,9 @@
  *
  * See {@link NgxMetaMetaService.set}
  *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *
  * @public
  */
 export type NgxMetaMetaContent = string | undefined | null

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-definition.ts
@@ -9,6 +9,9 @@ import { MetaDefinition } from '@angular/platform-browser'
  *
  *  - {@link makeComposedKeyValMetaDefinition}
  *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *
  * @remarks
  *
  * Inspired by Angular {@link https://angular.dev/api/platform-browser/MetaDefinition | MetaDefinition}.
@@ -22,6 +25,9 @@ export interface NgxMetaMetaDefinition {
    *
    * With the given content as value of the `<meta>` element.
    *
+   * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+   *
    * @example
    * For instance, `(content) => ({name: 'description', content})` to create a
    * `<meta name='description' content='{content}'>` element. Where `content` will come from
@@ -32,6 +38,9 @@ export interface NgxMetaMetaDefinition {
   /**
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors | Attribute selector}
    * to identify the `<meta>` element. In order to remove this specific `<meta>` element when needed.
+   *
+   * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
    *
    * @example
    * For instance, `[name='description']` for the `<meta name='description'>` element.

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.ts
@@ -1,3 +1,5 @@
+// noinspection JSDeprecatedSymbols
+
 import { Injectable } from '@angular/core'
 import { Meta } from '@angular/platform-browser'
 import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
@@ -7,6 +9,9 @@ import { NgxMetaMetaContent } from './ngx-meta-meta-content'
  * Creates, updates or removes `<meta>` elements.
  *
  * Uses Angular {@link https://angular.dev/api/platform-browser/Meta | Meta} APIs under the hood.
+ *
+ * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
  *
  * @public
  */
@@ -20,6 +25,9 @@ export class NgxMetaMetaService {
    * The element is modeled using a {@link NgxMetaMetaDefinition} object.
    *
    * The element is created with the provided content. If no content is given, element is removed.
+   *
+   * @deprecated Use {@link NgxMetaElementsService} APIs instead.
+   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
    *
    * @param definition - `<meta>` element to create, update or remove
    * @param content - Content value to create or update the `<meta>` element.


### PR DESCRIPTION
# Issue or need

After introducing and using new meta elements APIs in #883 and using them in #919, it's time to deprecate older APIs

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Deprecate all meta elements APIs v1 via a deprecation notice.

Update docs with the deprecation.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
