### PR TITLE
feat: deprecate manager provider APIs v1

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -140,10 +140,10 @@ export interface MakeKeyValMetaDefinitionOptions {
     valAttr?: string;
 }
 
-// @public
+// @public @deprecated
 export const makeMetadataManagerProviderFromSetterFactory: <T>(setterFactory: MetadataSetterFactory<T>, opts: MakeMetadataManagerProviderFromSetterFactoryOptions) => FactoryProvider;
 
-// @public
+// @public @deprecated
 export interface MakeMetadataManagerProviderFromSetterFactoryOptions {
     d?: FactoryProvider['deps'];
     g?: MetadataResolverOptions['global'];

--- a/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
+++ b/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
@@ -114,9 +114,9 @@ You can also check a full example at [example standalone app]'s [`provideCustomM
     If you need, you can still check [this guide when it was using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
     Or the [example app file using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts)
 
-    Anyway, it's recommended you upgrade to the new one described in the guide as soon as you can.
-    Otherwise, built-in modules are using the new one. And if you use this, then two functions will end up in
-    your bundle size that do the same. So some extra unwanted bytes in there.
+    However, beware that those APIs are now deprecated and will be removed in the future. It's recommended to upgrade to the new one described in the guide as soon as you can.
+
+    Also, built-in modules are using the new one. And if you use this, then two functions will end up in your bundle that do the same. So some extra unneeded bytes in there.
 
 ### Using a class
 

--- a/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
@@ -1,3 +1,5 @@
+// noinspection JSDeprecatedSymbols
+
 import {
   MetadataResolverOptions,
   NgxMetaMetadataManager,
@@ -10,6 +12,9 @@ import { MetadataSetterFactory } from '../metadata-setter-factory'
  * providing an {@link NgxMetaMetadataManager}.
  *
  * See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | manage custom metadata guide} for an example.
+ *
+ * @deprecated Use {@link provideNgxMetaManager} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more information.
  *
  * @remarks
  *
@@ -47,6 +52,9 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
 
 /**
  * Options argument object for {@link makeMetadataManagerProviderFromSetterFactory}.
+ *
+ * @deprecated Use {@link provideNgxMetaManager} APIs instead.
+ *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more information.
  *
  * @public
  */


### PR DESCRIPTION
# Issue or need

After introducing new APIs for providing metadata managers in #926 and using them around in #927, old APIs are ready to be deprecated.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Deprecate old APIs to provide metadata managers to favour new ones.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
