### PR TITLE
build: add linting for schematics

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,7 +39,8 @@
             "lintFilePatterns": [
               "projects/ngx-meta/src/**/*.ts",
               "projects/ngx-meta/src/**/*.html",
-              "projects/ngx-meta/e2e/**/*.cy.ts"
+              "projects/ngx-meta/e2e/**/*.cy.ts",
+              "projects/ngx-meta/schematics/**/*.ts"
             ]
           }
         }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-cypress": "3.6.0",
+    "eslint-plugin-jest": "28.8.3",
     "husky": "9.1.6",
     "jasmine-core": "5.4.0",
     "jest": "29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       eslint-plugin-cypress:
         specifier: 3.6.0
         version: 3.6.0(eslint@8.57.0)
+      eslint-plugin-jest:
+        specifier: 28.8.3
+        version: 28.8.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@22.7.6))(typescript@5.4.5)
       husky:
         specifier: 9.1.6
         version: 9.1.6
@@ -3285,6 +3288,19 @@ packages:
     resolution: {integrity: sha512-7IAMcBbTVu5LpWeZRn5a9mQ30y4hKp3AfTz+6nSD/x/7YyLMoBI6X7XjDLYI6zFvuy4Q4QVGl563AGEXGW/aSA==}
     peerDependencies:
       eslint: '>=7'
+
+  eslint-plugin-jest@28.8.3:
+    resolution: {integrity: sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==}
+    engines: {node: ^16.10.0 || ^18.12.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -10112,6 +10128,17 @@ snapshots:
     dependencies:
       eslint: 8.57.0
       globals: 13.23.0
+
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@22.7.6))(typescript@5.4.5):
+    dependencies:
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      jest: 29.7.0(@types/node@22.7.6)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-scope@5.1.1:
     dependencies:

--- a/projects/ngx-meta/schematics/.eslintrc.json
+++ b/projects/ngx-meta/schematics/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["**/*.spec.ts"],
+      "extends": ["plugin:jest/recommended"]
+    }
+  ]
+}

--- a/projects/ngx-meta/schematics/ng-add/index.spec.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.spec.ts
@@ -76,7 +76,7 @@ describe('ng-add schematic', () => {
 
 // https://github.com/FortAwesome/angular-fontawesome/blob/0.15.0/projects/schematics/src/ng-add/index.spec.ts#L107
 // https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/testing/test-app.ts
-export const createTestApp = async (
+const createTestApp = async (
   runner: SchematicTestRunner,
   options: Omit<NgNewSchema, 'version'> & Partial<Pick<NgNewSchema, 'version'>>,
 ) => {
@@ -92,7 +92,7 @@ export const createTestApp = async (
 }
 
 // https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/testing/file-content.ts
-export function getFileContent(tree: Tree, filePath: string): string {
+const getFileContent = (tree: Tree, filePath: string): string => {
   const contentBuffer = tree.read(filePath)
 
   if (!contentBuffer) {


### PR DESCRIPTION
# Issue or need

Schematics infra introduced in #962 can be improved. One of those improvements is linting schematics files.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add linting via ESLint to schematics. Including test files via `eslint-plugin-jest`

Some changes are needed indeed to pass the linter. Specifically, removing `exports` from test files.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
