### PR TITLE
build: add linting to Jasmine test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-cypress": "3.6.0",
+    "eslint-plugin-jasmine": "4.2.2",
     "eslint-plugin-jest": "28.8.3",
     "husky": "9.1.6",
     "jasmine-core": "5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       eslint-plugin-cypress:
         specifier: 3.6.0
         version: 3.6.0(eslint@8.57.0)
+      eslint-plugin-jasmine:
+        specifier: 4.2.2
+        version: 4.2.2
       eslint-plugin-jest:
         specifier: 28.8.3
         version: 28.8.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@22.7.6))(typescript@5.4.5)
@@ -3288,6 +3291,10 @@ packages:
     resolution: {integrity: sha512-7IAMcBbTVu5LpWeZRn5a9mQ30y4hKp3AfTz+6nSD/x/7YyLMoBI6X7XjDLYI6zFvuy4Q4QVGl563AGEXGW/aSA==}
     peerDependencies:
       eslint: '>=7'
+
+  eslint-plugin-jasmine@4.2.2:
+    resolution: {integrity: sha512-nALbewRk63uz28UGNhUTJyd6GofXxVNFpWFNAwr9ySc6kpSRIoO4suwZqIYz3cfJmCacilmjp7+1Ocjr7zRagA==}
+    engines: {node: '>=8', npm: '>=6'}
 
   eslint-plugin-jest@28.8.3:
     resolution: {integrity: sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==}
@@ -10128,6 +10135,8 @@ snapshots:
     dependencies:
       eslint: 8.57.0
       globals: 13.23.0
+
+  eslint-plugin-jasmine@4.2.2: {}
 
   eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@22.7.6))(typescript@5.4.5):
     dependencies:

--- a/projects/ngx-meta/src/.eslintrc.json
+++ b/projects/ngx-meta/src/.eslintrc.json
@@ -26,6 +26,11 @@
     {
       "files": ["*.html"],
       "rules": {}
+    },
+    {
+      "files": ["*.spec.ts"],
+      "extends": ["plugin:jasmine/recommended"],
+      "plugins": ["jasmine"]
     }
   ]
 }

--- a/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
+++ b/projects/ngx-meta/src/__tests__/resolver-object-merging.spec.ts
@@ -50,6 +50,7 @@ describe('Metadata value resolver object merging', () => {
       expect(resolved).toEqual(VALUES_DUMMY_OBJ)
     })
   })
+
   describe('when object merging resolver option is enabled', () => {
     const resolverOptions: MetadataResolverOptions = {
       ...baseResolverOptions,

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -18,6 +18,7 @@ describe('Head element upsert or remove', () => {
     headElementHarness = new HeadElementHarness(TestBed.inject(DOCUMENT))
     dummyElement = headElementHarness.createDummyElement('dummy 1')
   })
+
   afterEach(() => {
     headElementHarness.removeAllDummyElements()
   })
@@ -34,8 +35,10 @@ describe('Head element upsert or remove', () => {
         sut(headElementHarness.dummySelector, dummyElement)
 
         const elements = headElementHarness.getAllDummyElements()
+
         expect(elements).toHaveSize(1)
         const element = elements[0]
+
         expect(element).toEqual(dummyElement)
       })
     })
@@ -54,6 +57,7 @@ describe('Head element upsert or remove', () => {
   describe('when element exists already', () => {
     beforeEach(() => {
       headElementHarness.appendElement(dummyElement)
+
       expect(headElementHarness.getAllDummyElements())
         .withContext('element exists already')
         .toHaveSize(1)
@@ -66,8 +70,10 @@ describe('Head element upsert or remove', () => {
         sut(headElementHarness.dummySelector, anotherDummyElement)
 
         const elements = headElementHarness.getAllDummyElements()
+
         expect(elements).toHaveSize(1)
         const element = elements[0]
+
         expect(element).toEqual(anotherDummyElement)
       })
     })

--- a/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
+++ b/projects/ngx-meta/src/core/src/head-elements/head-element-upsert-or-remove.spec.ts
@@ -24,12 +24,6 @@ describe('Head element upsert or remove', () => {
   })
 
   describe('when element does not exist already', () => {
-    beforeEach(() => {
-      expect(headElementHarness.getAllDummyElements())
-        .withContext('element does not exist already')
-        .toHaveSize(0)
-    })
-
     describe('when element is defined', () => {
       it('should append it to head', () => {
         sut(headElementHarness.dummySelector, dummyElement)
@@ -57,12 +51,9 @@ describe('Head element upsert or remove', () => {
   describe('when element exists already', () => {
     beforeEach(() => {
       headElementHarness.appendElement(dummyElement)
-
-      expect(headElementHarness.getAllDummyElements())
-        .withContext('element exists already')
-        .toHaveSize(1)
     })
 
+    // eslint-disable-next-line jasmine/no-suite-dupes
     describe('when element is defined', () => {
       it('should update it', () => {
         const anotherDummyElement =
@@ -78,6 +69,7 @@ describe('Head element upsert or remove', () => {
       })
     })
 
+    // eslint-disable-next-line jasmine/no-suite-dupes
     describe('when element is not defined', () => {
       likeWhenNullOrUndefined((testCase) => {
         it('should remove it', () => {

--- a/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
+++ b/projects/ngx-meta/src/core/src/managers/metadata-registry.spec.ts
@@ -11,6 +11,7 @@ describe('Metadata registry', () => {
     const sut = makeSut({ managers: [dummyManager] })
 
     const managers = [...sut.getAll()]
+
     expect(managers).toHaveSize(1)
     expect(managers).toEqual([dummyManager])
   })
@@ -21,6 +22,7 @@ describe('Metadata registry', () => {
     sut.register(dummyManager)
 
     const managers = [...sut.getAll()]
+
     expect(managers).toHaveSize(1)
     expect(managers).toEqual([dummyManager])
   })
@@ -35,6 +37,7 @@ describe('Metadata registry', () => {
     sut.register(sameDummyManager)
 
     const managers = [...sut.getAll()]
+
     expect(managers).toHaveSize(1)
     expect(managers).toEqual([dummyManager])
   })
@@ -50,6 +53,7 @@ describe('Metadata registry', () => {
     sut.register(globalDummyManager)
 
     const managers = [...sut.findByGlobalOrJsonPath(global)]
+
     expect(managers).toHaveSize(1)
     expect(managers).toEqual([globalDummyManager])
   })
@@ -65,6 +69,7 @@ describe('Metadata registry', () => {
     sut.register(jsonPathManager)
 
     const managers = [...sut.findByGlobalOrJsonPath(jsonPath.join('.'))]
+
     expect(managers).toHaveSize(1)
     expect(managers).toEqual([jsonPathManager])
   })

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.spec.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.spec.ts
@@ -61,7 +61,7 @@ describe('provide manager', () => {
   describe('when global is given', () => {
     const global = 'global'
 
-    it('should set it in the manager', () => {
+    it('should set the manager global', () => {
       const provider = makeSut({ global })
 
       const manager = provideAndInject(provider)
@@ -73,7 +73,7 @@ describe('provide manager', () => {
   describe('when object merging is enabled', () => {
     const objectMerge = true
 
-    it('should set it in the manager', () => {
+    it('should enable object merging in the manager', () => {
       const provider = makeSut({ objectMerge })
 
       const manager = provideAndInject(provider)

--- a/projects/ngx-meta/src/core/src/messaging/maybe-too-long-dev-message.spec.ts
+++ b/projects/ngx-meta/src/core/src/messaging/maybe-too-long-dev-message.spec.ts
@@ -8,25 +8,28 @@ describe('Maybe too long developer message', () => {
     spyOn(console, 'warn')
   })
 
-  describe('when message is not defined', () => {
-    const message = undefined
-
+  const shouldNotEmitAnyMessage = (
+    message: string | undefined,
+    maxLength: number,
+  ) => {
     it('should not emit any message', () => {
-      sut(message, 300, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
+      sut(message, maxLength, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
 
       expect(console.warn).not.toHaveBeenCalled()
     })
+  }
+
+  describe('when message is not defined', () => {
+    const message = undefined
+
+    shouldNotEmitAnyMessage(message, 300)
   })
 
   describe('when message is not too long', () => {
     const message = 'short'
     const maxLength = 300
 
-    it('should not emit any message', () => {
-      sut(message, maxLength, DUMMY_FORMAT_DEV_MESSAGE_OPTIONS)
-
-      expect(console.warn).not.toHaveBeenCalled()
-    })
+    shouldNotEmitAnyMessage(message, maxLength)
   })
 
   describe('when message is too long', () => {

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.spec.ts
@@ -5,6 +5,7 @@ import { MockProvider } from 'ng-mocks'
 import { Meta } from '@angular/platform-browser'
 import { enableAutoSpy } from '@/ngx-meta/test/enable-auto-spy'
 import { makeKeyValMetaDefinition } from './make-key-val-meta-definition'
+import { likeWhenNullOrUndefined } from '@/ngx-meta/test/like-when-null-or-undefined'
 
 describe('Meta service', () => {
   enableAutoSpy()
@@ -17,46 +18,32 @@ describe('Meta service', () => {
     meta = TestBed.inject(Meta)
   })
 
-  describe('set', () => {
-    const metaDefinition = makeKeyValMetaDefinition('dummy', {
-      keyAttr: 'propertyName',
-      valAttr: 'propertyContent',
-    })
+  const metaDefinition = makeKeyValMetaDefinition('dummy', {
+    keyAttr: 'propertyName',
+    valAttr: 'propertyContent',
+  })
 
-    describe('when content is not provided (undefined)', () => {
-      const content = undefined
-
+  describe('when content is not provided', () => {
+    likeWhenNullOrUndefined((testCase) => {
       it('should remove meta element', () => {
-        sut.set(metaDefinition, content)
+        sut.set(metaDefinition, testCase)
 
         expect(meta.removeTag).toHaveBeenCalledOnceWith(
           metaDefinition.attrSelector,
         )
       })
     })
+  })
 
-    describe('when content is null', () => {
-      const content = null
+  describe('when content is provided', () => {
+    const content = 'Lorem ipsum lorem'
 
-      it('should remove meta element', () => {
-        sut.set(metaDefinition, content)
+    it('should update the meta tag', () => {
+      sut.set(metaDefinition, content)
 
-        expect(meta.removeTag).toHaveBeenCalledOnceWith(
-          metaDefinition.attrSelector,
-        )
-      })
-    })
-
-    describe('when content is provided', () => {
-      const content = 'Lorem ipsum lorem'
-
-      it('should update the meta tag', () => {
-        sut.set(metaDefinition, content)
-
-        expect(meta.updateTag).toHaveBeenCalledOnceWith(
-          metaDefinition.withContent(content),
-        )
-      })
+      expect(meta.updateTag).toHaveBeenCalledOnceWith(
+        metaDefinition.withContent(content),
+      )
     })
   })
 })

--- a/projects/ngx-meta/src/core/src/meta-elements/v2/ngx-meta-elements.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v2/ngx-meta-elements.service.spec.ts
@@ -60,8 +60,10 @@ describe('Meta element service', () => {
           sut.set(dummyMetaNameAttribute, dummyMetaContentAttribute)
 
           const elements = getDummyMetaElements()
+
           expect(elements.length).toBe(1)
           const element = elements[0]
+
           expect(htmlAttributesToJson(element.attributes)).toEqual(
             dummyMetaAttributes,
           )
@@ -77,6 +79,7 @@ describe('Meta element service', () => {
           ])
 
           const elements = getDummyMetaElements()
+
           expect(
             elements.map((e) => e.attributes).map(htmlAttributesToJson),
           ).toEqual([dummyMetaAttributes, anotherDummyMetaAttributes])
@@ -104,6 +107,7 @@ describe('Meta element service', () => {
           content: 'existing-content-2',
         },
       ] as MetaDefinition[])
+
       expect(getDummyMetaElements())
         .withContext('test setup: two elements should exist')
         .toHaveSize(2)
@@ -132,8 +136,10 @@ describe('Meta element service', () => {
           sut.set(dummyMetaNameAttribute, dummyMetaContentAttribute)
 
           const elements = getDummyMetaElements()
+
           expect(elements.length).toBe(1)
           const element = elements[0]
+
           expect(htmlAttributesToJson(element.attributes)).toEqual(
             dummyMetaAttributes,
           )

--- a/projects/ngx-meta/src/core/src/meta-elements/v2/ngx-meta-elements.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v2/ngx-meta-elements.service.spec.ts
@@ -3,6 +3,8 @@ import { NgxMetaElementsService } from './ngx-meta-elements.service'
 import { withNameAttribute } from './with-name-attribute'
 import { withContentAttribute } from './with-content-attribute'
 import { Meta, MetaDefinition } from '@angular/platform-browser'
+import { NgxMetaElementNameAttribute } from './ngx-meta-element-name-attribute'
+import { NgxMetaElementAttributes } from './ngx-meta-element-attributes'
 
 describe('Meta element service', () => {
   const dummyMetaNameAttribute = withNameAttribute('dummy')
@@ -33,31 +35,78 @@ describe('Meta element service', () => {
     getDummyMetaElements().forEach((element) => element.remove())
   })
 
-  describe('when no elements exist', () => {
+  const whenNoContentsAreProvided = (
+    tests: (testCase: readonly [] | undefined) => void,
+  ) => {
     describe('when no contents are provided', () => {
       const TEST_CASES = [
         [[], 'empty array'],
         [undefined, 'undefined'],
       ] as const
-
       TEST_CASES.forEach(([testCase, testCaseName]) => {
         describe(`like when ${testCaseName}`, () => {
-          it('should not create any element', () => {
-            const sut = makeSut()
-
-            sut.set(dummyMetaNameAttribute, testCase)
-
-            expect(getDummyMetaElements()).toHaveSize(0)
-          })
+          tests(testCase)
         })
       })
     })
+  }
 
-    describe('when contents are provided', () => {
-      describe('when a single content is provided', () => {
+  const whenSingleContentIsProvided = (
+    tests: (
+      nameAttribute: NgxMetaElementNameAttribute,
+      contentAttributes: NgxMetaElementAttributes,
+      expectedAttributes: NgxMetaElementAttributes,
+    ) => void,
+  ) => {
+    describe('when a single content is provided', () => {
+      tests(
+        dummyMetaNameAttribute,
+        dummyMetaContentAttribute,
+        dummyMetaAttributes,
+      )
+    })
+  }
+
+  const whenMultipleContentsAreProvided = (
+    tests: (
+      nameAttribute: NgxMetaElementNameAttribute,
+      contentAttributes: ReadonlyArray<NgxMetaElementAttributes>,
+      expectedAttributes: ReadonlyArray<NgxMetaElementAttributes>,
+    ) => void,
+  ) => {
+    describe('when multiple contents are provided', () => {
+      tests(
+        dummyMetaNameAttribute,
+        [
+          dummyMetaContentAttribute,
+          anotherDummyMetaContentAttribute,
+          yetAnotherDummyMetaContentAttribute,
+        ],
+        [
+          dummyMetaAttributes,
+          anotherDummyMetaAttributes,
+          yetAnotherDummyMetaAttributes,
+        ],
+      )
+    })
+  }
+
+  describe('when no elements exist', () => {
+    whenNoContentsAreProvided((testCase) => {
+      it('should not create any element', () => {
+        const sut = makeSut()
+
+        sut.set(dummyMetaNameAttribute, testCase)
+
+        expect(getDummyMetaElements()).toHaveSize(0)
+      })
+    })
+
+    whenSingleContentIsProvided(
+      (nameAttribute, contentAttributes, expectedAttributes) => {
         it('should create the element', () => {
           const sut = makeSut()
-          sut.set(dummyMetaNameAttribute, dummyMetaContentAttribute)
+          sut.set(nameAttribute, contentAttributes)
 
           const elements = getDummyMetaElements()
 
@@ -65,27 +114,26 @@ describe('Meta element service', () => {
           const element = elements[0]
 
           expect(htmlAttributesToJson(element.attributes)).toEqual(
-            dummyMetaAttributes,
+            expectedAttributes,
           )
         })
-      })
+      },
+    )
 
-      describe('when multiple contents are provided', () => {
+    whenMultipleContentsAreProvided(
+      (nameAttribute, contentAttributes, expectedAttributes) => {
         it('should create an element for each one', () => {
           const sut = makeSut()
-          sut.set(dummyMetaNameAttribute, [
-            dummyMetaContentAttribute,
-            anotherDummyMetaContentAttribute,
-          ])
+          sut.set(nameAttribute, contentAttributes)
 
           const elements = getDummyMetaElements()
 
           expect(
             elements.map((e) => e.attributes).map(htmlAttributesToJson),
-          ).toEqual([dummyMetaAttributes, anotherDummyMetaAttributes])
+          ).toEqual(expectedAttributes)
         })
-      })
-    })
+      },
+    )
   })
 
   describe('when elements exist', () => {
@@ -107,33 +155,20 @@ describe('Meta element service', () => {
           content: 'existing-content-2',
         },
       ] as MetaDefinition[])
-
-      expect(getDummyMetaElements())
-        .withContext('test setup: two elements should exist')
-        .toHaveSize(2)
     })
 
-    describe('when no contents are provided', () => {
-      const TEST_CASES = [
-        [[], 'empty array'],
-        [undefined, 'undefined'],
-      ] as const
+    whenNoContentsAreProvided((testCase) => {
+      it('should remove them all', () => {
+        sut.set(dummyMetaNameAttribute, testCase)
 
-      TEST_CASES.forEach(([testCase, testCaseName]) => {
-        describe(`like when ${testCaseName}`, () => {
-          it('should remove them all', () => {
-            sut.set(dummyMetaNameAttribute, testCase)
-
-            expect(getDummyMetaElements()).toHaveSize(0)
-          })
-        })
+        expect(getDummyMetaElements()).toHaveSize(0)
       })
     })
 
-    describe('when contents are provided', () => {
-      describe('when a single content is provided', () => {
+    whenSingleContentIsProvided(
+      (nameAttribute, contentAttributes, expectedAttributes) => {
         it('should remove existing elements and create the new one', () => {
-          sut.set(dummyMetaNameAttribute, dummyMetaContentAttribute)
+          sut.set(nameAttribute, contentAttributes)
 
           const elements = getDummyMetaElements()
 
@@ -141,31 +176,25 @@ describe('Meta element service', () => {
           const element = elements[0]
 
           expect(htmlAttributesToJson(element.attributes)).toEqual(
-            dummyMetaAttributes,
+            expectedAttributes,
           )
         })
-      })
+      },
+    )
 
-      describe('when multiple contents are provided', () => {
+    whenMultipleContentsAreProvided(
+      (nameAttribute, contentAttributes, expectedAttributes) => {
         it('should remove existing elements and create new ones', () => {
-          sut.set(dummyMetaNameAttribute, [
-            dummyMetaContentAttribute,
-            anotherDummyMetaContentAttribute,
-            yetAnotherDummyMetaContentAttribute,
-          ])
+          sut.set(nameAttribute, contentAttributes)
 
           expect(
             getDummyMetaElements()
               .map((e) => e.attributes)
               .map(htmlAttributesToJson),
-          ).toEqual([
-            dummyMetaAttributes,
-            anotherDummyMetaAttributes,
-            yetAnotherDummyMetaAttributes,
-          ])
+          ).toEqual(expectedAttributes)
         })
-      })
-    })
+      },
+    )
   })
 })
 

--- a/projects/ngx-meta/src/core/src/meta-elements/v2/with-content-attribute.spec.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v2/with-content-attribute.spec.ts
@@ -8,16 +8,12 @@ describe('with content attribute', () => {
 
   describe('when no content is provided', () => {
     likeWhenNullOrUndefined((testCase) => {
-      describe('when not providing extras', () => {
-        it('should return undefined', () => {
-          expect(sut(testCase)).toBeUndefined()
-        })
+      it('should return undefined when not providing extras', () => {
+        expect(sut(testCase)).toBeUndefined()
       })
 
-      describe('when providing extras', () => {
-        it('should return undefined', () => {
-          expect(sut(testCase, extras)).toBeUndefined()
-        })
+      it('should return undefined when providing extras', () => {
+        expect(sut(testCase, extras)).toBeUndefined()
       })
     })
   })

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
@@ -39,6 +39,7 @@ describe('Metadata JSON resolver', () => {
           expect(sut(values, resolverOptionsWithGlobal)).toBeUndefined()
         })
       })
+
       describe('and global value exists', () => {
         const valuesWithGlobal = { [global]: value, ...values }
 
@@ -59,6 +60,7 @@ describe('Metadata JSON resolver', () => {
         expect(sut(values, { jsonPath: ['dummy'] })).toBeUndefined()
       })
     })
+
     describe('like when key does not exist', () => {
       const values = {}
       const resolverOptions = { jsonPath: [key, subKey] }

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-json-resolver.spec.ts
@@ -18,14 +18,31 @@ describe('Metadata JSON resolver', () => {
   const global = 'global'
   const value = 'value'
 
+  const shouldReturnUndefined = (
+    values: MetadataValues | undefined,
+    resolverOptions: MetadataResolverOptions,
+  ) => {
+    it('should return undefined', () => {
+      expect(sut(values, resolverOptions)).toBeUndefined()
+    })
+  }
+
+  const shouldReturnSpecificValue = (
+    values: MetadataValues | undefined,
+    resolverOptions: MetadataResolverOptions,
+    value: unknown,
+  ) => {
+    it('should return specific value', () => {
+      expect(sut(values, resolverOptions)).toEqual(value)
+    })
+  }
+
   function testGlobalMayBeRetrieved(
     values: MetadataValues,
     resolverOptions: MetadataResolverOptions,
   ) {
     describe('when global is not defined', () => {
-      it('should return undefined', () => {
-        expect(sut(values, resolverOptions)).toBeUndefined()
-      })
+      shouldReturnUndefined(values, resolverOptions)
     })
 
     describe('when global is defined', () => {
@@ -35,9 +52,7 @@ describe('Metadata JSON resolver', () => {
       }
 
       describe('but global value does not exist', () => {
-        it('should return undefined', () => {
-          expect(sut(values, resolverOptionsWithGlobal)).toBeUndefined()
-        })
+        shouldReturnUndefined(values, resolverOptionsWithGlobal)
       })
 
       describe('and global value exists', () => {
@@ -56,9 +71,7 @@ describe('Metadata JSON resolver', () => {
     describe('like when values are undefined', () => {
       const values = undefined
 
-      it('should return undefined', () => {
-        expect(sut(values, { jsonPath: ['dummy'] })).toBeUndefined()
-      })
+      shouldReturnUndefined(values, { jsonPath: ['dummy'] })
     })
 
     describe('like when key does not exist', () => {
@@ -120,9 +133,7 @@ describe('Metadata JSON resolver', () => {
         }
         const resolverOptions = { jsonPath: [key, subKey], global }
 
-        it('should return specific value', () => {
-          expect(sut(values, resolverOptions)).toEqual(value)
-        })
+        shouldReturnSpecificValue(values, resolverOptions, value)
       })
 
       describe('when object merging is enabled', () => {
@@ -140,9 +151,7 @@ describe('Metadata JSON resolver', () => {
             },
           }
 
-          it('should return specific value', () => {
-            expect(sut(values, resolverOptions)).toEqual(value)
-          })
+          shouldReturnSpecificValue(values, resolverOptions, value)
         })
 
         describe('when values are objects', () => {

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
@@ -178,6 +178,7 @@ describe('Metadata resolver', () => {
   describe('when neither value, route value or default value exists', () => {
     it('should return nothing', () => {
       const sut = makeSut()
+
       expect(sut(DUMMY_VALUES, baseResolverOptions)).toBeUndefined()
     })
   })

--- a/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
+++ b/projects/ngx-meta/src/core/src/resolvers/metadata-resolver.spec.ts
@@ -39,6 +39,16 @@ describe('Metadata resolver', () => {
     ) as jasmine.Spy<_RouteMetadataStrategy>
   }
 
+  const shouldReturnValueFromValuesObject = (
+    values: MetadataValues,
+    resolverOptions: MetadataResolverOptions,
+    value: unknown,
+  ) => {
+    it('should return value from values object', () => {
+      expect(sut(values, resolverOptions)).toEqual(value)
+    })
+  }
+
   describe('when value exists in provided values', () => {
     beforeEach(() => {
       sut = makeSut()
@@ -118,9 +128,11 @@ describe('Metadata resolver', () => {
         )
       })
 
-      it('should return value from values object', () => {
-        expect(sut(DUMMY_VALUES, baseResolverOptions)).toEqual(VALUE)
-      })
+      shouldReturnValueFromValuesObject(
+        DUMMY_VALUES,
+        baseResolverOptions,
+        VALUE,
+      )
     })
 
     describe('when object merging is enabled', () => {
@@ -144,9 +156,7 @@ describe('Metadata resolver', () => {
           )
         })
 
-        it('should return value from values object', () => {
-          expect(sut(DUMMY_VALUES, resolverOptions)).toEqual(VALUE)
-        })
+        shouldReturnValueFromValuesObject(DUMMY_VALUES, resolverOptions, VALUE)
       })
 
       describe('when values are objects', () => {
@@ -189,10 +199,12 @@ function makeSut(opts: { defaults?: MetadataValues } = {}): MetadataResolver {
     providers: [
       MockProvider(
         metadataJsonResolver(),
+        // eslint-disable-next-line jasmine/no-unsafe-spy
         jasmine.createSpy('Metadata JSON resolver'),
       ),
       MockProvider(
         _routeMetadataStrategy(),
+        // eslint-disable-next-line jasmine/no-unsafe-spy
         jasmine.createSpy('Route metadata strategy'),
       ),
       opts.defaults ? [MockProvider(defaults(), opts.defaults)] : [],

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -80,8 +80,10 @@ function makeSut() {
     providers: [
       MockProvider(
         metadataRegistryToken(),
+        // eslint-disable-next-line jasmine/no-unsafe-spy
         jasmine.createSpyObj<MetadataRegistry>(['getAll']),
       ),
+      // eslint-disable-next-line jasmine/no-unsafe-spy
       MockProvider(metadataResolver(), jasmine.createSpy('Metadata resolver')),
     ],
   })

--- a/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
+++ b/projects/ngx-meta/src/core/src/service/ngx-meta.service.spec.ts
@@ -54,11 +54,13 @@ describe('Main service', () => {
         dummyValues,
         firstMetadata.resolverOptions,
       )
+
       expect(firstMetadata.set).toHaveBeenCalledWith(dummyFirstMetadataValue)
       expect(resolver).toHaveBeenCalledWith(
         dummyValues,
         secondMetadata.resolverOptions,
       )
+
       expect(secondMetadata.set).toHaveBeenCalledWith(dummySecondMetadataValue)
     })
   })

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-image-metadata-provider.spec.ts
@@ -49,22 +49,27 @@ describe('Open Graph image metadata manager', () => {
         ['property', 'og:image'],
         { content: image.url },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['property', 'og:image:alt'],
         { content: image.alt },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['property', 'og:image:secure_url'],
         { content: image.secureUrl },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['property', 'og:image:type'],
         { content: image.type },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['property', 'og:image:width'],
         { content: image.width.toString() },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['property', 'og:image:height'],
         { content: image.height.toString() },

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
@@ -47,6 +47,7 @@ function makeSut(opts: {
       MockProvider(NgxMetaElementsService),
       {
         provide: _urlResolver(),
+        // eslint-disable-next-line jasmine/no-unsafe-spy
         useValue: opts.urlResolver ?? jasmine.createSpy(),
       },
       OPEN_GRAPH_URL_METADATA_PROVIDER,

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/managers/open-graph-url-metadata-provider.spec.ts
@@ -34,6 +34,7 @@ describe('Open Graph URL metadata manager', () => {
       ['property', 'og:url'],
       { content: dummyResolvedUrl },
     )
+
     expect(urlResolver).toHaveBeenCalledWith(dummyUrl)
   })
 })

--- a/projects/ngx-meta/src/routing/src/listener/router-listener.spec.ts
+++ b/projects/ngx-meta/src/routing/src/listener/router-listener.spec.ts
@@ -120,6 +120,7 @@ function makeSut(
       MockProvider(Router, { events: events$ }),
       MockProvider(
         NgxMetaService,
+        // eslint-disable-next-line jasmine/no-unsafe-spy
         jasmine.createSpyObj<NgxMetaService>(['set']),
       ),
     ],

--- a/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-canonical-url-metadata-provider.spec.ts
@@ -106,12 +106,14 @@ const makeSut = (
         provide: _headElementUpsertOrRemove(),
         useValue:
           opts.headElementUpsertOrRemove ??
+          // eslint-disable-next-line jasmine/no-unsafe-spy
           jasmine.createSpy('Head element upsert or remove'),
       },
       {
         provide: _urlResolver(),
         useValue:
           opts.urlResolver ??
+          // eslint-disable-next-line jasmine/no-unsafe-spy
           jasmine
             .createSpy<_UrlResolver>('URL Resolver')
             .and.callFake((url) => url?.toString()),

--- a/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/standard/src/managers/standard-locale-metadata-provider.spec.ts
@@ -27,6 +27,7 @@ describe('Standard locale metadata', () => {
     likeWhenNullOrUndefined((testCase) => {
       it('should remove HTML element lang attribute', () => {
         htmlLangAttributeHarness.set('es')
+
         expect(htmlLangAttributeHarness.get()).toBeTruthy()
 
         sut.set(testCase)
@@ -43,6 +44,7 @@ describe('Standard locale metadata', () => {
       sut.set(locale)
 
       const htmlTagLangAttribute = htmlLangAttributeHarness.get()
+
       expect(htmlTagLangAttribute).not.toBeNull()
       expect(htmlTagLangAttribute?.value).toEqual(locale)
     })

--- a/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.spec.ts
+++ b/projects/ngx-meta/src/twitter-card/src/managers/twitter-card-image-metadata-provider.spec.ts
@@ -44,6 +44,7 @@ describe('Twitter Card image metadata manager', () => {
         ['name', 'twitter:image'],
         { content: image.url },
       )
+
       expect(metaElementsService.set).toHaveBeenCalledWith(
         ['name', 'twitter:image:alt'],
         { content: image.alt },


### PR DESCRIPTION
# Issue or need

After adding a linter for schematics in #967, thought it could be nice to add one for Jasmine tests too.

And here it goes

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Adds `eslint-plugin-jasmine` for Jasmine unit tests.

Fixes some of the issues automatically. Some others required a bit of refactoring / ignoring around.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
