### PR TITLE
build: add ESLint to example apps infra

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,8 @@
 {
   "*": ["pnpm run format"],
   "projects/ngx-meta/src/**/*.ts": ["ng-lint-staged lint:code --fix --"],
+  "projects/ngx-meta/example-apps/**/*.ts": [
+    "ng-lint-staged lint:code --fix --"
+  ],
   ".github/**/*.{yml,yaml}": ["pnpm run lint:gh-actions"]
 }

--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,7 @@
             "lintFilePatterns": [
               "projects/ngx-meta/src/**/*.ts",
               "projects/ngx-meta/src/**/*.html",
+              "projects/ngx-meta/example-apps/**/*.ts",
               "projects/ngx-meta/e2e/**/*.cy.ts",
               "projects/ngx-meta/schematics/**/*.ts"
             ]

--- a/projects/ngx-meta/example-apps/.eslintrc.json
+++ b/projects/ngx-meta/example-apps/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "ignorePatterns": ["!**/*", "node_modules/**/*", "apps/**/*", "dist/**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "app",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "app",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/ngx-meta/example-apps/src/parse-args.ts
+++ b/projects/ngx-meta/example-apps/src/parse-args.ts
@@ -28,8 +28,7 @@ export function parseArgs(
       continue
     }
     if (arg.startsWith(BASE_APP_DIR_ARG)) {
-      const [_, argValue] = arg.split('=')
-      baseAppDir = argValue
+      baseAppDir = arg.split('=')[1]
       continue
     }
     if (arg === NO_CLEANUP_ARG) {
@@ -37,8 +36,7 @@ export function parseArgs(
       continue
     }
     if (arg.startsWith(TMP_DIR_ARG)) {
-      const [_, argValue] = arg.split('=')
-      tmpDir = argValue
+      tmpDir = arg.split('=')[1]
       continue
     }
     if (appCliAlias === null) {

--- a/projects/ngx-meta/example-apps/templates/module/src/app/app.component.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core'
 import { ROUTES } from '@/e2e/cypress/fixtures/routes'
-// @ts-expect-error(2307): in templates directory file doesn't exist
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore(2307): in templates directory file doesn't exist
 import packageJson from '../../package.json'
 
 @Component({

--- a/projects/ngx-meta/example-apps/templates/module/src/app/app.component.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewEncapsulation } from '@angular/core'
 import { ROUTES } from '@/e2e/cypress/fixtures/routes'
-// @ts-ignore (in templates directory file doesn't exist)
+// @ts-expect-error(2307): in templates directory file doesn't exist
 import packageJson from '../../package.json'
 
 @Component({

--- a/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.ts
+++ b/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.ts
@@ -2,7 +2,8 @@ import { Component, ViewEncapsulation } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { RouterLink, RouterOutlet } from '@angular/router'
 import { ROUTES } from '@/e2e/cypress/fixtures/routes'
-// @ts-expect-error(2307): in templates directory file doesn't exist
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore(2307): in templates directory file doesn't exist
 import packageJson from '../../package.json'
 
 @Component({

--- a/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.ts
+++ b/projects/ngx-meta/example-apps/templates/standalone/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component, ViewEncapsulation } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { RouterLink, RouterOutlet } from '@angular/router'
 import { ROUTES } from '@/e2e/cypress/fixtures/routes'
-// @ts-ignore (in templates directory file doesn't exist)
+// @ts-expect-error(2307): in templates directory file doesn't exist
 import packageJson from '../../package.json'
 
 @Component({


### PR DESCRIPTION
# Issue or need

After adding linting to schematics files + its Jest unit tests and to Jasmine unit tests, let's add them to example apps infra too

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Setup ESLint for example apps infra. Includes setting up `lint-staged` for those files.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
