### PR TITLE
build: improve lint-staged setup

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -12,9 +12,6 @@ install:
 	# https://pnpm.io/cli/install#--frozen-lockfile
 	pnpm install --frozen-lockfile
 
-lint-code:
-	pnpm run lint:code --max-warnings 0
-
 lint-gh-actions:
 	ationlint
 

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run linter
-        run: cd .ci && make lint-code
+        run: pnpm run lint:code
 
   github-actions:
     name: GitHub Actions

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,8 +1,8 @@
 {
-  "*": ["pnpm run format"],
-  "projects/ngx-meta/src/**/*.ts": ["ng-lint-staged lint:code --fix --"],
-  "projects/ngx-meta/example-apps/**/*.ts": [
-    "ng-lint-staged lint:code --fix --"
+  "!(*.ts)": ["pnpm run format"],
+  "projects/ngx-meta/{src,e2e,example-apps,schematics}/**/*.ts": [
+    "ng-lint-staged lint:code --fix --",
+    "pnpm run format"
   ],
   ".github/**/*.{yml,yaml}": ["pnpm run lint:gh-actions"]
 }

--- a/angular.json
+++ b/angular.json
@@ -39,10 +39,11 @@
             "lintFilePatterns": [
               "projects/ngx-meta/src/**/*.ts",
               "projects/ngx-meta/src/**/*.html",
+              "projects/ngx-meta/e2e/**/*.ts",
               "projects/ngx-meta/example-apps/**/*.ts",
-              "projects/ngx-meta/e2e/**/*.cy.ts",
               "projects/ngx-meta/schematics/**/*.ts"
-            ]
+            ],
+            "maxWarnings": 0
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "prepare": "husky",
     "commitlint-edit-msg": "commitlint --verbose --edit",
     "commitlint-last": "commitlint --verbose --from HEAD~1",
-    "ng-lint-staged": "ng-lint-staged lint --max-warnings 0 --fix --",
     "cache-clean": "ng cache clean",
     "commit": "pnpx @commitlint/prompt-cli",
     "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate",


### PR DESCRIPTION
# Issue or need

After adding linters in recent PRs, noticed that `lint-staged` setup can be improved:
 - **Some files that can be linted are missing**. Like schematics or Cypress E2E (test) files.
 - **One match to rule them all**. In `.lintstagedrc.json`. To avoid repeating the linting command around.
 - **Formatter and linter may run for same files at same time**. Due to the rule of applying format to every file. But linter may be altering that file too.


<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Improve setup by:
 - Adding missing files that can be linted: E2E & schematics
 - Join all files patterns in `.lintstagedrc.json` with a glob pattern
 - Do not run format on `ts` files until linter has run

Also, linter has been configured to fail if there's any warning. As that's what will happen on CI/CD. So better to do the same locally to avoid surprises. And to make `lint-staged` fail too if there are warnings indeed. Removes unneeded CI/CD custom `--max-warnings 0` argument now that is applied when linting by default.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
