### PR TITLE
test: refactor `ng-add` to make it easier to add moar tests

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/testing/get-app-config-or-app-module-content.ts
+++ b/projects/ngx-meta/schematics/ng-add/testing/get-app-config-or-app-module-content.ts
@@ -1,0 +1,10 @@
+import { Tree } from '@angular-devkit/schematics'
+import { getFileContent } from '../../testing/get-file-content'
+
+export const getAppConfigOrAppModuleContent = (
+  tree: Tree,
+  standalone: boolean,
+) =>
+  standalone
+    ? getFileContent(tree, '/src/app/app.config.ts')
+    : getFileContent(tree, '/src/app/app.module.ts')

--- a/projects/ngx-meta/schematics/ng-add/testing/provider-test-case.ts
+++ b/projects/ngx-meta/schematics/ng-add/testing/provider-test-case.ts
@@ -1,0 +1,18 @@
+export class ProviderTestCase {
+  readonly name: string
+  readonly symbol: string
+  readonly code: string
+  readonly entrypoint: string
+
+  constructor(opts: {
+    name: string
+    symbol: string
+    code?: string
+    entrypoint?: string
+  }) {
+    this.name = opts.name
+    this.symbol = opts.symbol
+    this.code = opts.code ?? `${this.symbol}()`
+    this.entrypoint = opts.entrypoint ?? this.name
+  }
+}

--- a/projects/ngx-meta/schematics/ng-add/testing/should-add-root-provider.ts
+++ b/projects/ngx-meta/schematics/ng-add/testing/should-add-root-provider.ts
@@ -1,0 +1,26 @@
+import { ProviderTestCase } from './provider-test-case'
+import { Tree } from '@angular-devkit/schematics'
+import { expect, it } from '@jest/globals'
+import { getAppConfigOrAppModuleContent } from './get-app-config-or-app-module-content'
+import { LIB_NAME } from '../../testing/lib-name'
+import { stripWhitespace } from '../../testing/strip-whitespace'
+import { regexpEscape } from '../../testing/regexp-escape'
+
+export const shouldAddRootProvider = (
+  providerTestCase: ProviderTestCase,
+  treeFactory: () => Tree,
+  standalone: boolean,
+) => {
+  it(`should add ${providerTestCase.name} provider`, () => {
+    const appConfigOrAppModuleContents = getAppConfigOrAppModuleContent(
+      treeFactory(),
+      standalone,
+    )
+    expect(appConfigOrAppModuleContents).toContain(
+      `import { ${providerTestCase.symbol} } from '${LIB_NAME}/${providerTestCase.entrypoint}`,
+    )
+    expect(stripWhitespace(appConfigOrAppModuleContents)).toMatch(
+      new RegExp(`providers:\\[.*${regexpEscape(providerTestCase.code)}.*]`),
+    )
+  })
+}

--- a/projects/ngx-meta/schematics/testing/create-test-app.ts
+++ b/projects/ngx-meta/schematics/testing/create-test-app.ts
@@ -1,0 +1,19 @@
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing'
+import { Schema as NgNewSchema } from '@schematics/angular/ng-new/schema'
+
+// https://github.com/FortAwesome/angular-fontawesome/blob/0.15.0/projects/schematics/src/ng-add/index.spec.ts#L107
+// https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/testing/test-app.ts
+export const createTestApp = async (
+  runner: SchematicTestRunner,
+  options: Omit<NgNewSchema, 'version'> & Partial<Pick<NgNewSchema, 'version'>>,
+) => {
+  return runner.runExternalSchematic<NgNewSchema>(
+    '@schematics/angular',
+    'ng-new',
+    {
+      version: '9.0.0',
+      directory: '.',
+      ...options,
+    },
+  )
+}

--- a/projects/ngx-meta/schematics/testing/get-file-content.ts
+++ b/projects/ngx-meta/schematics/testing/get-file-content.ts
@@ -1,0 +1,12 @@
+import { Tree } from '@angular-devkit/schematics'
+
+// https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/testing/file-content.ts
+export const getFileContent = (tree: Tree, filePath: string): string => {
+  const contentBuffer = tree.read(filePath)
+
+  if (!contentBuffer) {
+    throw new Error(`Cannot read "${filePath}" because it does not exist.`)
+  }
+
+  return contentBuffer.toString()
+}

--- a/projects/ngx-meta/schematics/testing/regexp-escape.ts
+++ b/projects/ngx-meta/schematics/testing/regexp-escape.ts
@@ -1,0 +1,4 @@
+// https://stackoverflow.com/a/9310752/3263250
+// https://github.com/tc39/proposal-regex-escaping
+export const regexpEscape = (string: string) =>
+  string.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')

--- a/projects/ngx-meta/schematics/testing/strip-whitespace.ts
+++ b/projects/ngx-meta/schematics/testing/strip-whitespace.ts
@@ -1,0 +1,2 @@
+// https://github.com/angular/angular-cli/blob/18.2.9/packages/schematics/angular/utility/standalone/rules_spec.ts#L45-L47
+export const stripWhitespace = (value: string) => value.replace(/\s/g, '')


### PR DESCRIPTION
# Issue or need

After starting to add more features to the `ng-add` schematic, noticed that same test code repeats over and over.

Despite being conscious that WET > DRY in tests, the `T`wice of `WET` was definitely not twice. 

Some things can be abstracted to avoid repeating the same tests around and around.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add an abstraction to allow testing whether providers are added or not to the root file (app config / app module): `shouldAddRootProvider`.

Also extracts util functions into `testing` directories

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
