### PR TITLE
feat: ask whether to add routing in `ng-add` schematic

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/index.spec.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.spec.ts
@@ -4,8 +4,9 @@ import { beforeEach, describe } from '@jest/globals'
 import { join } from 'path'
 import { Schema as NgAddSchema } from './schema'
 import { ProviderTestCase } from './testing/provider-test-case'
-import { shouldAddRootProvider } from './testing/should-add-root-provider'
 import { createTestApp } from '../testing/create-test-app'
+import { shouldAddRootProvider } from './testing/should-add-root-provider'
+import { shouldNotAddRootProvider } from './testing/should-not-add-root-provider'
 
 // https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/ng-add/index.spec.ts
 // https://github.com/angular/components/blob/18.2.8/src/material/schematics/ng-add/index.spec.ts
@@ -17,6 +18,7 @@ describe('ng-add schematic', () => {
 
   const defaultOptions: NgAddSchema = {
     project: 'test',
+    routing: false,
   }
 
   beforeEach(async () => {
@@ -29,6 +31,10 @@ describe('ng-add schematic', () => {
   const CORE_PROVIDER = new ProviderTestCase({
     name: 'core',
     symbol: 'provideNgxMetaCore',
+  })
+  const ROUTING_PROVIDER = new ProviderTestCase({
+    name: 'routing',
+    symbol: 'provideNgxMetaRouting',
   })
 
   ;([true, false] as const).forEach((standalone) => {
@@ -53,6 +59,22 @@ describe('ng-add schematic', () => {
         })
 
         shouldAddRootProvider(CORE_PROVIDER, () => tree, standalone)
+        shouldNotAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
+      })
+
+      describe('when routing option is true', () => {
+        const routing = true
+        let tree: Tree
+
+        beforeEach(async () => {
+          tree = await runner.runSchematic<NgAddSchema>(
+            SCHEMATIC_NAME,
+            { ...defaultOptions, routing },
+            appTree,
+          )
+        })
+
+        shouldAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
       })
     })
   })

--- a/projects/ngx-meta/schematics/ng-add/index.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.ts
@@ -1,12 +1,23 @@
-import { Rule } from '@angular-devkit/schematics'
+import { chain, noop, Rule } from '@angular-devkit/schematics'
 import { addRootProvider } from '@schematics/angular/utility'
 import { Schema } from './schema'
+import { classify } from '@angular-devkit/core/src/utils/strings'
 
 // noinspection JSUnusedGlobalSymbols (actually used in `collection.json`)
 export function ngAdd(options: Schema): Rule {
-  return addRootProvider(
-    options.project,
-    ({ code, external }) =>
-      code`${external('provideNgxMetaCore', '@davidlj95/ngx-meta/core')}()`,
-  )
+  const maybeAddNgxMetaRootProvider = (name?: string): Rule => {
+    if (!name) {
+      return noop()
+    }
+    return addRootProvider(
+      options.project,
+      ({ code, external }) =>
+        code`${external(`provideNgxMeta${classify(name)}`, `@davidlj95/ngx-meta/${name}`)}()`,
+    )
+  }
+
+  return chain([
+    maybeAddNgxMetaRootProvider('core'),
+    maybeAddNgxMetaRootProvider(options.routing ? 'routing' : undefined),
+  ])
 }

--- a/projects/ngx-meta/schematics/ng-add/schema.json
+++ b/projects/ngx-meta/schematics/ng-add/schema.json
@@ -10,6 +10,13 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "routing": {
+      "type": "boolean",
+      "description": "Enables routing module to provide metadata in Angular routes' data",
+      "default": false,
+      "//todo": "Enable x-prompts for this and metadata modules to include when both are ready",
+      "//x-prompt": "Would you like to provide metadata in Angular routes' data?"
     }
   },
   "required": []

--- a/projects/ngx-meta/schematics/ng-add/schema.ts
+++ b/projects/ngx-meta/schematics/ng-add/schema.ts
@@ -1,3 +1,4 @@
 export interface Schema {
   project: string
+  routing: boolean
 }

--- a/projects/ngx-meta/schematics/ng-add/testing/should-not-add-root-provider.ts
+++ b/projects/ngx-meta/schematics/ng-add/testing/should-not-add-root-provider.ts
@@ -1,0 +1,18 @@
+import { ProviderTestCase } from './provider-test-case'
+import { Tree } from '@angular-devkit/schematics'
+import { expect, it } from '@jest/globals'
+import { getAppConfigOrAppModuleContent } from './get-app-config-or-app-module-content'
+
+export const shouldNotAddRootProvider = (
+  providerTestCase: ProviderTestCase,
+  treeFactory: () => Tree,
+  standalone: boolean,
+) => {
+  it(`should not add ${providerTestCase.name} provider`, () => {
+    const appConfigOrAppModuleContents = getAppConfigOrAppModuleContent(
+      treeFactory(),
+      standalone,
+    )
+    expect(appConfigOrAppModuleContents).not.toContain(providerTestCase.symbol)
+  })
+}


### PR DESCRIPTION
# Issue or need

`ng-add` schematic added in #962 just adds the core provider.

It could be nice for users to add routing and many metadata modules too.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add an option to the `ng-add` schematic to enable the routing module.

It can be enabled by `ng add @davidlj95/ngx-meta --routing`. Defaults to not enabled.

It's disabled by default and doesn't ask the user via `x-prompt` in the schema yet. 
This way, we can start asking for both routing & metadata modules all at once. At that moment, docs may be updated to reflect this new feature.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
