### PR TITLE
test: do not rely on `ng-add` defaults for tests

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/index.spec.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.spec.ts
@@ -16,10 +16,9 @@ describe('ng-add schematic', () => {
   let runner: SchematicTestRunner
   let appTree: Tree
 
-  const defaultOptions: NgAddSchema = {
+  const defaultOptions = {
     project: 'test',
-    routing: false,
-  }
+  } satisfies Partial<NgAddSchema>
 
   beforeEach(async () => {
     runner = new SchematicTestRunner(
@@ -51,7 +50,7 @@ describe('ng-add schematic', () => {
         let tree: Tree
 
         beforeEach(async () => {
-          tree = await runner.runSchematic<NgAddSchema>(
+          tree = await runner.runSchematic<Partial<NgAddSchema>>(
             SCHEMATIC_NAME,
             defaultOptions,
             appTree,
@@ -61,20 +60,22 @@ describe('ng-add schematic', () => {
         shouldAddRootProvider(CORE_PROVIDER, () => tree, standalone)
         shouldNotAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
       })
+      ;[true, false].forEach((routing) => {
+        describe(`when routing option is ${routing}`, () => {
+          let tree: Tree
 
-      describe('when routing option is true', () => {
-        const routing = true
-        let tree: Tree
+          beforeEach(async () => {
+            tree = await runner.runSchematic<Partial<NgAddSchema>>(
+              SCHEMATIC_NAME,
+              { ...defaultOptions, routing },
+              appTree,
+            )
+          })
 
-        beforeEach(async () => {
-          tree = await runner.runSchematic<NgAddSchema>(
-            SCHEMATIC_NAME,
-            { ...defaultOptions, routing },
-            appTree,
-          )
+          routing
+            ? shouldAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
+            : shouldNotAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
         })
-
-        shouldAddRootProvider(ROUTING_PROVIDER, () => tree, standalone)
       })
     })
   })


### PR DESCRIPTION
# Issue or need

In previous PR, a test said that by default, should not add routing provider. However, the options passed to run the schematic included `routing: false`. Hence wasn't actually testing what happened by default

Also, just a test was added for what happened when routing was enabled. But what if the default changes at some point? Then there would be no test for what happens when routing is disabled.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Do not set a `routing` value as `defaultOptions`. Project is needed as otherwise the schematic can't run. But `routing` isn't. If not providing it, we can ensure what happens when not provided. Defaults from `schema.json` will be used.

Then, adds another test to ensure the behaviour when `routing` option is specified. So defaults case and specifying a value case are separated.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
