### PR TITLE
feat: add `ng-add` option to provide metadata modules

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/index.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.ts
@@ -1,23 +1,31 @@
 import { chain, noop, Rule } from '@angular-devkit/schematics'
 import { addRootProvider } from '@schematics/angular/utility'
-import { Schema } from './schema'
+import { MetadataModules, Schema } from './schema'
 import { classify } from '@angular-devkit/core/src/utils/strings'
 
+const ENTRYPOINTS = new Set<MetadataModules>([
+  'json-ld',
+  'open-graph',
+  'standard',
+  'twitter-card',
+])
 // noinspection JSUnusedGlobalSymbols (actually used in `collection.json`)
 export function ngAdd(options: Schema): Rule {
-  const maybeAddNgxMetaRootProvider = (name?: string): Rule => {
-    if (!name) {
-      return noop()
-    }
+  const addNgxMetaRootProvider = (name: string): Rule => {
+    const entrypoint =
+      [...ENTRYPOINTS].find((entrypoint) => name.startsWith(entrypoint)) ?? name
     return addRootProvider(
       options.project,
       ({ code, external }) =>
-        code`${external(`provideNgxMeta${classify(name)}`, `@davidlj95/ngx-meta/${name}`)}()`,
+        code`${external(`provideNgxMeta${classify(name)}`, `@davidlj95/ngx-meta/${entrypoint}`)}()`,
     )
   }
 
   return chain([
-    maybeAddNgxMetaRootProvider('core'),
-    maybeAddNgxMetaRootProvider(options.routing ? 'routing' : undefined),
+    addNgxMetaRootProvider('core'),
+    options.routing ? addNgxMetaRootProvider('routing') : noop(),
+    ...options.metadataModules.map((metadataModule) =>
+      addNgxMetaRootProvider(metadataModule),
+    ),
   ])
 }

--- a/projects/ngx-meta/schematics/ng-add/schema.json
+++ b/projects/ngx-meta/schematics/ng-add/schema.json
@@ -17,6 +17,38 @@
       "default": false,
       "//todo": "Enable x-prompts for this and metadata modules to include when both are ready",
       "//x-prompt": "Would you like to provide metadata in Angular routes' data?"
+    },
+    "metadataModules": {
+      "type": "array",
+      "description": "Built-in metadata modules to use",
+      "default": [],
+      "//todo": "Enable x-prompts for this and metadata modules to include when both are ready",
+      "//x-prompt": {
+        "type": "list",
+        "message": "What metadata would you like to set?",
+        "items": [
+          {
+            "label": "JSON-LD              [ https://ngx-meta.dev/built-in-modules/json-ld/            ]",
+            "value": "json-ld"
+          },
+          {
+            "label": "Open Graph           [ https://ngx-meta.dev/built-in-modules/open-graph/         ]",
+            "value": "open-graph"
+          },
+          {
+            "label": "Open Graph's profile [ https://ngx-meta.dev/built-in-modules/open-graph/#profile ]",
+            "value": "open-graph-profile"
+          },
+          {
+            "label": "Standard             [ https://ngx-meta.dev/built-in-modules/standard/           ]",
+            "value": "standard"
+          },
+          {
+            "label": "Twitter Card         [ https://ngx-meta.dev/built-in-modules/twitter-cards/      ]",
+            "value": "twitter-card"
+          }
+        ]
+      }
     }
   },
   "required": []

--- a/projects/ngx-meta/schematics/ng-add/schema.ts
+++ b/projects/ngx-meta/schematics/ng-add/schema.ts
@@ -1,4 +1,12 @@
 export interface Schema {
   project: string
   routing: boolean
+  metadataModules: ReadonlyArray<MetadataModules>
 }
+
+export type MetadataModules =
+  | 'json-ld'
+  | 'open-graph'
+  | 'open-graph-profile'
+  | 'standard'
+  | 'twitter-card'

--- a/projects/ngx-meta/schematics/ng-add/testing/should-add-root-provider.ts
+++ b/projects/ngx-meta/schematics/ng-add/testing/should-add-root-provider.ts
@@ -17,7 +17,7 @@ export const shouldAddRootProvider = (
       standalone,
     )
     expect(appConfigOrAppModuleContents).toContain(
-      `import { ${providerTestCase.symbol} } from '${LIB_NAME}/${providerTestCase.entrypoint}`,
+      `import { ${providerTestCase.symbol} } from '${LIB_NAME}/${providerTestCase.entrypoint}'`,
     )
     expect(stripWhitespace(appConfigOrAppModuleContents)).toMatch(
       new RegExp(`providers:\\[.*${regexpEscape(providerTestCase.code)}.*]`),


### PR DESCRIPTION
# Issue or need

Continues improvements on `ng-add` as declared in #962. Actually, the last one, yay!

When installing with `ng add`, could be nice to ask the user if they want to add some metadata modules.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add an option to `ng-add` schematic to add one or more built-in metadata modules.

Defaults to `[]` and doesn't add the prompt yet. In order to do so when docs are updated accordingly. 

However the feature can be activated by using CLI flags:

```shell
ng add @davidlj95/ngx-meta --metadata-modules standard open-graph
```

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
