### PR TITLE
refactor: introduce utils for r/w package.json files

### DIFF
--- a/projects/ngx-meta/example-apps/src/add-ci-run-scripts.ts
+++ b/projects/ngx-meta/example-apps/src/add-ci-run-scripts.ts
@@ -1,7 +1,6 @@
-import { jsonToString, Log } from './utils.js'
-import { join } from 'path'
-import { PACKAGE_JSON } from './constants.js'
-import { readFile, writeFile } from 'fs/promises'
+import { Log } from './utils.js'
+import { readPackageJsonInDir } from './read-package-json-in-dir.js'
+import { writePackageJsonInDir } from './write-package-json-in-dir.js'
 
 const BUILD_SSR_RUN_SCRIPT = 'build:ssr'
 //👇 Since v17, this script name includes :{projectName} at the end
@@ -19,12 +18,7 @@ export async function addCiRunScripts(opts: {
 }) {
   // Builds with SSR + source maps
   Log.step('Adding build and serve common run scripts for CI/CD')
-  const appPkgJsonFile = join(opts.appDir, PACKAGE_JSON)
-  const appPkgJson = JSON.parse(
-    await readFile(join(opts.appDir, PACKAGE_JSON), 'utf8'),
-  ) as {
-    scripts: Record<string, string>
-  }
+  const appPkgJson = await readPackageJsonInDir(opts.appDir)
 
   // Build script
   if (BUILD_SSR_RUN_SCRIPT in appPkgJson.scripts) {
@@ -43,5 +37,5 @@ export async function addCiRunScripts(opts: {
   }
   appPkgJson.scripts[CI_SERVE_RUN_SCRIPT] =
     `export ${SSR_PORT_ENV_VAR}=${SSR_SERVE_PORT} && pnpm run ${serveSsrRunScript}`
-  await writeFile(appPkgJsonFile, jsonToString(appPkgJson))
+  await writePackageJsonInDir(opts.appDir, appPkgJson)
 }

--- a/projects/ngx-meta/example-apps/src/constants.ts
+++ b/projects/ngx-meta/example-apps/src/constants.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
 
-export const PACKAGE_JSON = 'package.json'
 export const NPMRC_FILENAME = '.npmrc'
 export const ANGULAR_CLI_BINARY_PATH = join('node_modules', '.bin', 'ng')
 export const PROVIDERS_PROPERTY = 'providers'

--- a/projects/ngx-meta/example-apps/src/create-package-json-with-angular-cli.ts
+++ b/projects/ngx-meta/example-apps/src/create-package-json-with-angular-cli.ts
@@ -1,11 +1,8 @@
-import { join } from 'path'
-import { writeFile } from 'fs/promises'
-import { jsonToString } from './utils.js'
-import { PACKAGE_JSON } from './constants.js'
 import {
   ANGULAR_CLI_VERSIONS_PKG_JSON,
   AngularCliVersionAlias,
 } from './angular-cli-versions.js'
+import { writePackageJsonInDir } from './write-package-json-in-dir.js'
 
 const DEV_DEPENDENCIES_KEY =
   'devDependencies' satisfies keyof typeof ANGULAR_CLI_VERSIONS_PKG_JSON
@@ -14,7 +11,6 @@ export async function createPackageJsonWithAngularCli(
   cliVersionAlias: AngularCliVersionAlias,
   tmpDir: string,
 ) {
-  const pkgJsonFile = join(tmpDir, PACKAGE_JSON)
   const pkgJsonWithOnlyAngularCliDevDep = {
     ...ANGULAR_CLI_VERSIONS_PKG_JSON,
     [DEV_DEPENDENCIES_KEY]: {
@@ -22,5 +18,5 @@ export async function createPackageJsonWithAngularCli(
         ANGULAR_CLI_VERSIONS_PKG_JSON.devDependencies[cliVersionAlias],
     },
   }
-  await writeFile(pkgJsonFile, jsonToString(pkgJsonWithOnlyAngularCliDevDep))
+  await writePackageJsonInDir(tmpDir, pkgJsonWithOnlyAngularCliDevDep)
 }

--- a/projects/ngx-meta/example-apps/src/package-json.ts
+++ b/projects/ngx-meta/example-apps/src/package-json.ts
@@ -1,0 +1,6 @@
+export interface PackageJson {
+  name: string
+  scripts: Record<string, string>
+  dependencies: Record<string, string>
+}
+export const PACKAGE_JSON = 'package.json'

--- a/projects/ngx-meta/example-apps/src/read-package-json-in-dir.ts
+++ b/projects/ngx-meta/example-apps/src/read-package-json-in-dir.ts
@@ -1,0 +1,6 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { PACKAGE_JSON, PackageJson } from './package-json.js'
+
+export const readPackageJsonInDir = async (dir: string): Promise<PackageJson> =>
+  JSON.parse(await readFile(join(dir, PACKAGE_JSON), 'utf8'))

--- a/projects/ngx-meta/example-apps/src/write-package-json-in-dir.ts
+++ b/projects/ngx-meta/example-apps/src/write-package-json-in-dir.ts
@@ -1,0 +1,10 @@
+import { writeFile } from 'fs/promises'
+import { join } from 'path'
+import { jsonToString } from './utils.js'
+import { PACKAGE_JSON } from './package-json.js'
+
+export const writePackageJsonInDir = async (
+  dir: string,
+  packageJson: object,
+): Promise<void> =>
+  writeFile(join(dir, PACKAGE_JSON), jsonToString(packageJson))


### PR DESCRIPTION
# Issue or need

After starting to alter code in example apps infra in order to run `ng-add` schematic for example apps, noticed that code to read/write `package.json` files is repeated around

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Introduce `read/writePackageJsonInDir` to abstract that code around

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
