### PR TITLE
build: use provider APIs for module-based example apps

### DIFF
--- a/projects/ngx-meta/example-apps/templates/module/src/app/app.module.template.ts
+++ b/projects/ngx-meta/example-apps/templates/module/src/app/app.module.template.ts
@@ -9,19 +9,19 @@ import { AllMetaSetByServiceComponent } from './all-meta-set-by-service/all-meta
 import { AllMetaSetByRouteComponent } from './all-meta-set-by-route/all-meta-set-by-route.component'
 import { MetaSetByRouteAndServiceComponent } from './meta-set-by-route-and-service/meta-set-by-route-and-service.component'
 import {
-  NgxMetaCoreModule,
+  provideNgxMetaCore,
   withNgxMetaBaseUrl,
   withNgxMetaDefaults,
 } from '@davidlj95/ngx-meta/core'
 import DEFAULTS_JSON from '@/e2e/cypress/fixtures/defaults.json'
-import { NgxMetaRoutingModule } from '@davidlj95/ngx-meta/routing'
-import { NgxMetaStandardModule } from '@davidlj95/ngx-meta/standard'
+import { provideNgxMetaRouting } from '@davidlj95/ngx-meta/routing'
+import { provideNgxMetaStandard } from '@davidlj95/ngx-meta/standard'
 import {
-  NgxMetaOpenGraphModule,
-  NgxMetaOpenGraphProfileModule,
+  provideNgxMetaOpenGraph,
+  provideNgxMetaOpenGraphProfile,
 } from '@davidlj95/ngx-meta/open-graph'
-import { NgxMetaTwitterCardModule } from '@davidlj95/ngx-meta/twitter-card'
-import { NgxMetaJsonLdModule } from '@davidlj95/ngx-meta/json-ld'
+import { provideNgxMetaTwitterCard } from '@davidlj95/ngx-meta/twitter-card'
+import { provideNgxMetaJsonLd } from '@davidlj95/ngx-meta/json-ld'
 import { OneMetaSetByServiceComponent } from './one-meta-set-by-service/one-meta-set-by-service.component'
 import { UrlResolutionMetaComponent } from './url-resolution-meta/url-resolution-meta.component'
 import { BASE_URL } from '@/e2e/cypress/fixtures/base-url'
@@ -35,24 +35,19 @@ import { BASE_URL } from '@/e2e/cypress/fixtures/base-url'
     OneMetaSetByServiceComponent,
     UrlResolutionMetaComponent,
   ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    NgForOf,
-    RouterOutlet,
-    JsonPipe,
-    NgxMetaCoreModule.forRoot(
+  imports: [BrowserModule, AppRoutingModule, NgForOf, RouterOutlet, JsonPipe],
+  providers: [
+    provideNgxMetaCore(
       withNgxMetaDefaults(DEFAULTS_JSON),
       withNgxMetaBaseUrl(BASE_URL),
     ),
-    NgxMetaRoutingModule.forRoot(),
-    NgxMetaStandardModule,
-    NgxMetaOpenGraphModule,
-    NgxMetaOpenGraphProfileModule,
-    NgxMetaTwitterCardModule,
-    NgxMetaJsonLdModule,
+    provideNgxMetaRouting(),
+    provideNgxMetaStandard(),
+    provideNgxMetaOpenGraph(),
+    provideNgxMetaOpenGraphProfile(),
+    provideNgxMetaTwitterCard(),
+    provideNgxMetaJsonLd(),
   ],
-  providers: [],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/projects/ngx-meta/src/routing/src/providers/ngx-meta-routing.module.ts
+++ b/projects/ngx-meta/src/routing/src/providers/ngx-meta-routing.module.ts
@@ -17,6 +17,7 @@ export class NgxMetaRoutingModule {
    * {@inheritDoc NgxMetaRoutingModule}
    */
   static forRoot(): ModuleWithProviders<NgxMetaRoutingModule> {
+    /* istanbul ignore next - simple enough */
     return {
       ngModule: NgxMetaRoutingModule,
       providers: [provideNgxMetaRouting()],


### PR DESCRIPTION
# Issue or need

In #964 and #858, standalone APIs are recommended over module-based APIs. However example apps are using module-based APIs still.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use standalone APIs in module-based example apps so they're available for reference too.



<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
