### PR TITLE
test: run ng-add in example apps

### DIFF
--- a/projects/ngx-meta/example-apps/src/create-example-app.ts
+++ b/projects/ngx-meta/example-apps/src/create-example-app.ts
@@ -15,6 +15,7 @@ import { copyTemplates } from './copy-templates.js'
 import { updateTsConfigToImportJsonFilesAndSetPathMappings } from './update-ts-config-to-import-json-files-and-set-path-mappings.js'
 import { updateAppModuleOrAppConfigFromTemplates } from './update-app-module-or-app-config-from-templates.js'
 import { isStandaloneDefaultForVersion } from './is-standalone-default-for-version.js'
+import { ngAddLibrary } from './ng-add-library.js'
 
 async function createExampleApp({
   angularCliVersion,
@@ -53,9 +54,10 @@ async function createExampleApp({
     })(),
     copyTemplates({ appDir, standalone }),
     updateTsConfigToImportJsonFilesAndSetPathMappings(appDir),
-    updateAppModuleOrAppConfigFromTemplates(appDir, standalone),
   ])
   await install({ projectDir: appDir, what: 'app dependencies' })
+  await ngAddLibrary(appDir)
+  await updateAppModuleOrAppConfigFromTemplates(appDir, standalone)
 }
 
 if (isMain(import.meta.url)) {

--- a/projects/ngx-meta/example-apps/src/ng-add-library.ts
+++ b/projects/ngx-meta/example-apps/src/ng-add-library.ts
@@ -1,0 +1,27 @@
+import { getLibraryDistDir, Log } from './utils.js'
+import { execa } from './execa.js'
+import { readPackageJsonInDir } from './read-package-json-in-dir.js'
+
+export const ngAddLibrary = async (appDir: string) => {
+  Log.step(`Running ng-add to set up library`)
+  const libraryPackageJson = await readPackageJsonInDir(getLibraryDistDir())
+  return execa(
+    'pnpm',
+    [
+      'ng',
+      'add',
+      libraryPackageJson.name,
+      '--skip-confirmation',
+      '--routing',
+      '--metadata-modules',
+      'json-ld',
+      'open-graph',
+      'open-graph-profile',
+      'standard',
+      'twitter-card',
+    ],
+    {
+      cwd: appDir,
+    },
+  )
+}

--- a/projects/ngx-meta/schematics/ng-add/schema.json
+++ b/projects/ngx-meta/schematics/ng-add/schema.json
@@ -21,6 +21,17 @@
     "metadataModules": {
       "type": "array",
       "description": "Built-in metadata modules to use",
+      "items": {
+        "type": "string",
+        "enum": [
+          "json-ld",
+          "open-graph",
+          "open-graph-profile",
+          "standard",
+          "twitter-card"
+        ]
+      },
+      "uniqueItems": true,
       "default": [],
       "//todo": "Enable x-prompts for this and metadata modules to include when both are ready",
       "//x-prompt": {


### PR DESCRIPTION
# Issue or need

> [!IMPORTANT]
> This additional testing raised the issue fixed in #984 🎉  

`ng-add` isn't E2E tested. Initially (in #962) it was due to:
 - Not supporting setting up router & metadata modules.
 - `provideNgxMetaCore` having special needs that can't (at least now) be set with schematics (defaults / base URL). 
   - Base URL could be added as option, but defaults is quite weird to be added.

However, first one has been solved in #975 and #978. Second one can be workarounded.
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Run `ng-add` schematic when creating the example apps for E2E testing in order to E2E test those.

`ng add` is ran after installing because:
 - Due to caching, can't be run before installing the package (see `addLinkedLibrary` method for moar info)
 - Due to an [Angular CLI limitation, `ng-add` schematic CLI options won't be properly used if hasn't been installed yet](https://github.com/angular/angular-cli/blob/18.2.9/packages/angular/cli/src/commands/add/cli.ts#L106-L115). The specific issue lies in the `NodeModulesEngineHost`, which [can't resolve `file:../../../dist` as dependency path](https://github.com/angular/angular-cli/blob/18.2.9/packages/angular_devkit/schematics/tools/node-module-engine-host.ts#L62). So just basic options will be taken into account. Like `routing: true`. But not array ones (they're considered as `--key value` by default). That's also why the library name has to be used to do `ng add`. As otherwise the engine host will fail to resolve and then CLI options won't work as expected.

Finally, the call expressions in `providers` array that refer to a function existing in the template are removed from the generated app to give priority to the template. Then, providers from template are added to the generated app if don't exist as usual.

Now that `ng add` adds core, routing and metadata modules, one may think why not removing those from template files. Reason is template files are used as reference in documentation, so better to leave them there for that purpose. In the future an alternative can be thought to fully test `ng add` without messing with root app config / module.

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
