### PR TITLE
fix: import dynamically `addRootProvider` for `ng-add` schematic

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/add-root-provider/add-root-provider.ts
+++ b/projects/ngx-meta/schematics/ng-add/add-root-provider/add-root-provider.ts
@@ -1,0 +1,3 @@
+import { Rule } from '@angular-devkit/schematics'
+
+export type AddRootProvider = (opts: { name: string; project: string }) => Rule

--- a/projects/ngx-meta/schematics/ng-add/add-root-provider/index.ts
+++ b/projects/ngx-meta/schematics/ng-add/add-root-provider/index.ts
@@ -1,0 +1,2 @@
+export { AddRootProvider } from './add-root-provider'
+export { makeAddRootProviderFn } from './make-add-root-provider-fn'

--- a/projects/ngx-meta/schematics/ng-add/add-root-provider/make-add-root-provider-fn.ts
+++ b/projects/ngx-meta/schematics/ng-add/add-root-provider/make-add-root-provider-fn.ts
@@ -1,0 +1,21 @@
+import { makeV16AddRootProvider } from './make-v16-add-root-provider'
+import { AddRootProvider } from './index'
+import { type addRootProvider } from '@schematics/angular/utility'
+import { noop } from '@angular-devkit/schematics'
+
+export const makeAddRootProviderFn = async (): Promise<AddRootProvider> => {
+  const ngAddRootProvider = (await import('@schematics/angular/utility'))
+    .addRootProvider as typeof addRootProvider | undefined
+  /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
+  if (!ngAddRootProvider) {
+    // Standalone schematic utils are only available for v16.1 and above.
+    // https://github.com/angular/angular-cli/commit/b14b959901d5a670da0df45e082b8fd4c3392d14
+    const message =
+      'ngx-meta: `ng add` schematics only work for Angular v16.1 and above, sorry :(\n' +
+      "          Please, setup the library manually. Don't worry, it's just a few lines around :)\n" +
+      '          You can find a guide at: https://ngx-meta.dev/get-started/'
+    console.log(message)
+    return noop
+  }
+  return makeV16AddRootProvider(ngAddRootProvider)
+}

--- a/projects/ngx-meta/schematics/ng-add/add-root-provider/make-v16-add-root-provider.ts
+++ b/projects/ngx-meta/schematics/ng-add/add-root-provider/make-v16-add-root-provider.ts
@@ -1,0 +1,25 @@
+import { Rule } from '@angular-devkit/schematics'
+import { classify } from '@angular-devkit/core/src/utils/strings'
+import { type addRootProvider } from '@schematics/angular/utility'
+import { MetadataModules } from '../schema'
+
+const METADATA_ENTRYPOINTS = new Set<MetadataModules>([
+  'json-ld',
+  'open-graph',
+  'standard',
+  'twitter-card',
+])
+
+export const makeV16AddRootProvider =
+  (ngAddRootProvider: typeof addRootProvider) =>
+  ({ project, name }: { project: string; name: string }): Rule => {
+    const entrypoint =
+      [...METADATA_ENTRYPOINTS].find((entrypoint) =>
+        name.startsWith(entrypoint),
+      ) ?? name
+    return ngAddRootProvider(
+      project,
+      ({ code, external }) =>
+        code`${external(`provideNgxMeta${classify(name)}`, `@davidlj95/ngx-meta/${entrypoint}`)}()`,
+    )
+  }


### PR DESCRIPTION
# Issue or need

After trying to E2E test the `ng-add` schematic, found an error (guess that's a success of testing :P)

The error is that `addRootProvider` schematic utility used for `ng-add` schematic doesn't exist in Angular v15.

Which makes sense as [it was introduced in Angular v16.1](https://github.com/angular/angular-cli/commit/b14b959901d5a670da0df45e082b8fd4c3392d14)

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Try to import `addRootProvider` in case it exists. Otherwise, do nothing. At least for now.

PR was tried on top of #982 to ensure it works (apart from local testing)

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
