### PR TITLE
feat: improve `ng-add` logging

### DIFF
--- a/projects/ngx-meta/schematics/ng-add/add-root-provider/make-add-root-provider-fn.ts
+++ b/projects/ngx-meta/schematics/ng-add/add-root-provider/make-add-root-provider-fn.ts
@@ -1,21 +1,14 @@
 import { makeV16AddRootProvider } from './make-v16-add-root-provider'
 import { AddRootProvider } from './index'
 import { type addRootProvider } from '@schematics/angular/utility'
-import { noop } from '@angular-devkit/schematics'
 
-export const makeAddRootProviderFn = async (): Promise<AddRootProvider> => {
+export const makeAddRootProviderFn = async (): Promise<
+  AddRootProvider | undefined
+> => {
   const ngAddRootProvider = (await import('@schematics/angular/utility'))
     .addRootProvider as typeof addRootProvider | undefined
-  /* istanbul ignore next https://github.com/istanbuljs/istanbuljs/issues/719 */
   if (!ngAddRootProvider) {
-    // Standalone schematic utils are only available for v16.1 and above.
-    // https://github.com/angular/angular-cli/commit/b14b959901d5a670da0df45e082b8fd4c3392d14
-    const message =
-      'ngx-meta: `ng add` schematics only work for Angular v16.1 and above, sorry :(\n' +
-      "          Please, setup the library manually. Don't worry, it's just a few lines around :)\n" +
-      '          You can find a guide at: https://ngx-meta.dev/get-started/'
-    console.log(message)
-    return noop
+    return
   }
   return makeV16AddRootProvider(ngAddRootProvider)
 }

--- a/projects/ngx-meta/schematics/ng-add/index.spec.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.spec.ts
@@ -15,6 +15,7 @@ import { createTestApp } from '../testing/create-test-app'
 import { shouldAddRootProvider } from './testing/should-add-root-provider'
 import { shouldNotAddRootProvider } from './testing/should-not-add-root-provider'
 import * as AngularSchematicsUtilities from '@schematics/angular/utility'
+import { logging } from '@angular-devkit/core'
 
 // https://github.com/angular/components/blob/18.2.8/src/cdk/schematics/ng-add/index.spec.ts
 // https://github.com/angular/components/blob/18.2.8/src/material/schematics/ng-add/index.spec.ts
@@ -29,10 +30,14 @@ describe('ng-add schematic', () => {
   } satisfies Partial<NgAddSchema>
 
   beforeEach(async () => {
+    jest.spyOn(logging.Logger.prototype, 'info').mockReturnValue()
     runner = new SchematicTestRunner(
       'schematics',
       join(__dirname, '..', 'collection.json'),
     )
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   const CORE_PROVIDER = new ProviderTestCase({
@@ -144,10 +149,10 @@ describe('ng-add schematic', () => {
 
   // Below Angular v16.1
   describe("when addRootProvider isn't available", () => {
-    let consoleLog: jest.Spied<Console['log']>
+    let logSpy: jest.Spied<(typeof logging.Logger.prototype)['warn']>
 
     beforeEach(async () => {
-      consoleLog = jest.spyOn(console, 'log').mockReturnValue()
+      logSpy = jest.spyOn(logging.Logger.prototype, 'warn').mockReturnValue()
       jest.mock<Partial<typeof AngularSchematicsUtilities>>(
         '@schematics/angular/utility',
         () =>
@@ -162,12 +167,9 @@ describe('ng-add schematic', () => {
         appTree,
       )
     })
-    afterEach(() => {
-      jest.restoreAllMocks()
-    })
 
     it('should log a message', () => {
-      expect(consoleLog).toHaveBeenCalledWith(
+      expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining('Please, setup the library manually'),
       )
     })

--- a/projects/ngx-meta/schematics/ng-add/index.ts
+++ b/projects/ngx-meta/schematics/ng-add/index.ts
@@ -1,11 +1,25 @@
-import { chain, noop, Rule } from '@angular-devkit/schematics'
+import { chain, noop, Rule, SchematicContext } from '@angular-devkit/schematics'
 import { Schema } from './schema'
 import { makeAddRootProviderFn } from './add-root-provider'
 
 // noinspection JSUnusedGlobalSymbols (actually used in `collection.json`)
 export function ngAdd(options: Schema): Rule {
-  return async () => {
+  return async (_tree, context) => {
     const addRootProvider = await makeAddRootProviderFn()
+    if (!addRootProvider) {
+      // Standalone schematic utils are only available for v16.1 and above.
+      // https://github.com/angular/angular-cli/commit/b14b959901d5a670da0df45e082b8fd4c3392d14
+      context.logger.warn(
+        [
+          'ngx-meta `ng add` schematics only work for Angular v16.1 and above, sorry :(',
+          "Please, setup the library manually. Don't worry, it's just a few lines around :)",
+          'You can find a guide at: https://ngx-meta.dev/get-started/',
+        ].join('\n'),
+      )
+      logLibraryInfo(context.logger)
+      return
+    }
+
     const addRootProviderToProject = (name: string) =>
       addRootProvider({ name, project: options.project })
 
@@ -15,6 +29,21 @@ export function ngAdd(options: Schema): Rule {
       ...options.metadataModules.map((metadataModule) =>
         addRootProviderToProject(metadataModule),
       ),
+      () => {
+        context.logger.info('ngx-meta library was successfully set up 🚀')
+        logLibraryInfo(context.logger)
+      },
     ])
   }
 }
+
+const logLibraryInfo = (logger: SchematicContext['logger']) =>
+  logger.info(
+    [
+      'For more information, you can check out:',
+      ' - Documentation: https://ngx-meta.dev',
+      ' - Repository:    https://github.com/davidlj95/ngx',
+      ' - NPM:           https://www.npmjs.com/package/@davidlj95/ngx-meta',
+      'If you enjoyed using the library, please star its GitHub repository! ⭐️❤️',
+    ].join('\n'),
+  )


### PR DESCRIPTION
# Issue or need

Using `console` directly to output a message in `ng-add` schematic was a bit weird. But shipped it anyway to move forward.

After some investigation, seems there's a logger provided in schematics context that can be used for that purpose

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use the Angular's logger for `ng-add` schematic. Update test to spy this one.

Also, change the level to `warn` in case no schematics are ran. So it grabs the user attention.

Finally, adds some useful links at the end of installation (either if successful or not) to improve users' DX.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
