### PR TITLE
docs: split between utility types and metadata values types

### DIFF
--- a/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
@@ -54,12 +54,27 @@ The module allows you to embed a JSON-LD object inside a `#!html <script>` tag (
     export class AppModule {}
     ```
 
-## Type
+## Utility type
 
-Following Typescript type provides you with all implemented metadata you can set:
+Following Typescript type will help you provide metadata values:
 
 ```typescript
 import { JsonLdMetadata } from '@davidlj95/ngx-meta/json-ld'
+
+const metadata = {
+  jsonLd: {
+    '@context': 'https://schema.org/',
+    '@type': 'Recipe',
+    name: 'Party Coffee Cake',
+    author: {
+      '@type': 'Person',
+      name: 'Mary Stone',
+    },
+    datePublished: '2018-03-10',
+    description: 'This coffee cake is awesome and perfect for parties.',
+    prepTime: 'PT20M',
+  },
+} satisfies JsonLdMetadata
 ```
 
 [`JsonLdMetadata` API Reference](ngx-meta.jsonldmetadata.md)

--- a/projects/ngx-meta/docs/content/built-in-modules/open-graph.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/open-graph.md
@@ -8,7 +8,7 @@ This module will help you set those tags to provide metadata to social networks 
 
 ## Setup
 
-Depending on what metadata you need to set, add one of more of the Open Graph modules / providers.
+Depending on what metadata you need to set, add one of more of the Open Graph providers.
 
 ### Main
 
@@ -60,6 +60,14 @@ Specifically, manages [basic](https://ogp.me/#metadata) and [optional](https://o
     export class AppModule {}
     ```
 
+#### Metadata
+
+To check all the metadata that can be set with this provider, check out
+
+[`OpenGraph` API Reference](ngx-meta.opengraph.md)
+
+> Except if the property indicates otherwise, like `profile`.
+
 ### Profile
 
 Manages [profile](https://ogp.me/#type_profile) non-vertical metadata. Manages metadata under [`OpenGraph.profile`](ngx-meta.opengraph.profile.md)
@@ -108,12 +116,27 @@ Manages [profile](https://ogp.me/#type_profile) non-vertical metadata. Manages m
     export class AppModule {}
     ```
 
-## Type
+#### Metadata
 
-Following Typescript type provides you with all implemented metadata you can set:
+To check all the metadata that can be set with this provider, check out
+
+[`OpenGraphProfile` API Reference](ngx-meta.opengraphprofile.md)
+
+## Utility type
+
+Following Typescript type will help you provide metadata values:
 
 ```typescript
-import { OpenGraphMetadata } from '@davidlj95/ngx-meta/open-graph'
+import { OpenGraphMetadata, OPEN_GRAPH_TYPE_WEBSITE } from '@davidlj95/ngx-meta/open-graph'
+
+const metadata = {
+  openGraph: {
+    type: OPEN_GRAPH_TYPE_WEBSITE,
+    profile: {
+      username: 'angular',
+    },
+  },
+} satisfies OpenGraphMetadata
 ```
 
 [`OpenGraphMetadata` API Reference](ngx-meta.opengraphmetadata.md)

--- a/projects/ngx-meta/docs/content/built-in-modules/standard.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/standard.md
@@ -4,7 +4,7 @@ This module allows managing HTML `#!html <meta>` tags whose [`name` attribute is
 
 ## Setup
 
-Depending on what metadata you need to set, add one of more of the following modules / providers.
+Depending on what metadata you need to set, add one of more of the following providers.
 
 ### Main
 
@@ -52,12 +52,24 @@ Depending on what metadata you need to set, add one of more of the following mod
     export class AppModule {}
     ```
 
-## Type
+#### Metadata
 
-Following Typescript type provides you with all implemented metadata you can set:
+To check all the metadata that can be set with this module, check out
+
+[`Standard` API Reference](ngx-meta.standard.md)
+
+## Utility type
+
+Following Typescript type will help you provide metadata values:
 
 ```typescript
 import { StandardMetadata } from '@davidlj95/ngx-meta/standard'
+
+const metadata = {
+  standard: {
+    keywords: ['cool', 'site'],
+  },
+} satisfies StandardMetadata
 ```
 
 [`StandardMetadata` API Reference](ngx-meta.standardmetadata.md)

--- a/projects/ngx-meta/docs/content/built-in-modules/twitter-cards.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/twitter-cards.md
@@ -8,7 +8,7 @@ Some [Twitter Cards tags fallback to Open Graph equivalent properties if they ca
 
 ## Setup
 
-Depending on what metadata you need to set, add one of more of the Twitter Card modules / providers.
+Depending on what metadata you need to set, add one of more of the Twitter Card providers.
 
 ### Main
 
@@ -58,12 +58,24 @@ To set the Twitter Card type or the basic _summary_ or _summary large_ cards, yo
     export class AppModule {}
     ```
 
-## Type
+#### Metadata
 
-Following Typescript type provides you with all implemented metadata you can set:
+To check all the metadata that can be set with this provider, check out
+
+[`TwitterCard` API Reference](ngx-meta.twittercard.md)
+
+## Utility type
+
+Following Typescript type will help you provide metadata values:
 
 ```typescript
 import { TwitterCardMetadata } from '@davidlj95/ngx-meta/twitter-card'
+
+const metadata = {
+  twitterCard: {
+    site: { username: '@angular' },
+  },
+} satisfies TwitterCardMetadata
 ```
 
 [`TwitterCardMetadata` API Reference](ngx-meta.twittercardmetadata.md)


### PR DESCRIPTION
# Issue or need

In built-in modules docs, the only type reference is to the type helping to set metadata values JSON. However, there's another interesting type to see all the metadata a provider can set. Which is the same without the `Metadata` suffix. Reaching this one requires clicking in the `Metadata` one and then clicking into the type. Which can be confusing as insdide the `XMetadata` type there is the `x` property and the `X` type. So easy to click the not useful one.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add reference to both types. Specify which one is the utility one and which one allows to see all metadata values that can be set for a provider.

Replace `module / providers` with just `providers` as providers API is recommended.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
