### PR TITLE
build: add script to rehearse a release publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "commit": "pnpx @commitlint/prompt-cli",
     "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate",
     "instrument-for-coverage": "./instrument-for-coverage.sh",
-    "update": "ng update @angular/cli @angular/core @angular-eslint/schematics"
+    "update": "ng update @angular/cli @angular/core @angular-eslint/schematics",
+    "semantic-release:local": "./semantic-release-local.sh"
   },
   "private": true,
   "packageManager": "pnpm@9.12.2",

--- a/semantic-release-local.sh
+++ b/semantic-release-local.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env sh
+# Runs Semantic Release with a local private registry
+# See contributing docs for more information
+
+# Warn if not using local branch just in case
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ -z "$LOCAL_SEMANTIC_RELEASE_BRANCH" ] && [ "$current_branch" != "main" ]; then
+  echo "💡 Publishing from local branch hasn't been configured. It's probable no release will be done"
+  echo "   export LOCAL_SEMANTIC_RELEASE_BRANCH=true # to use local branch as if it was main one"
+fi
+
+# Ensure repository URL set
+if [ -z "$LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL" ]; then
+  echo "❌  Repository URL hasn't been configured. Set one to avoid publishing to real one"
+  echo "   export LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL=. # for the tricky one to work locally"
+  echo "   export LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL=https://github.com/user/ngx.git # to use a copy/fork"
+  exit 1
+else
+  echo "👍 Repository URL set to \"$LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL\""
+fi
+
+set -eu
+
+# Change cwd to this script's directory
+cd "$(dirname "$0")"
+
+DIST_PACKAGE_JSON='projects/ngx-meta/dist/package.json'
+
+# Ensure package.json exists
+if ! [ -r "$DIST_PACKAGE_JSON" ]; then
+  echo "❌  Package JSON file '$DIST_PACKAGE_JSON' does not exist or is not readable"
+  echo "   Build the library first"
+  exit 1
+else
+  echo "👍 Package JSON file exists"
+fi
+
+# Ensure not logged in to `npm` registry
+NPM_REGISTRY='https://registry.npmjs.org/'
+if npm whoami --registry "$NPM_REGISTRY" &>/dev/null; then
+  echo "⚠️ You are authorized to use the real NPM registry"
+  echo "   For safety, you should comment the .npmrc file where credentials are set"
+  echo "   Otherwise if something goes wrong, something could be published there"
+  read -p "   Do you want to continue anyway (yes/no)?  " yn
+  case $yn in
+  [Yy]*) continue ;;
+  [Nn]*) exit 1 ;;
+  *) echo "Please answer yes or no." ;;
+  esac
+else
+  echo "👍 Not logged in to real NPM registry. Nice caution"
+fi
+
+# Tweak the package.json file
+# - Registry: local registry
+# - Provenance: disabled as Verdaccio doesn't support `provenance`:
+#   https://github.com/orgs/verdaccio/discussions/3903)
+package_json="$(cat "$DIST_PACKAGE_JSON")"
+cleanup() {
+  echo "ℹ️ Restoring original package JSON file"
+  echo "$package_json" >"$DIST_PACKAGE_JSON"
+  echo "✅  Done"
+  if [ "$LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL" == "." ]; then
+    echo "ℹ️ If run was successful, remember to clear created objects"
+    echo "   Like git tags if any: 'git tag -d <tag>'"
+  fi
+}
+trap cleanup EXIT INT HUP
+
+LOCAL_REGISTRY_URL='http://localhost:4873'
+tweaked_package_json="$(
+  jq ".publishConfig.provenance=false | .publishConfig.registry=\"${LOCAL_REGISTRY_URL}\"" \
+    $DIST_PACKAGE_JSON
+)"
+echo "ℹ️ Tweaking package JSON file"
+echo "   Setting local registry and disabling provenance"
+echo "$tweaked_package_json" >"$DIST_PACKAGE_JSON"
+
+# Verify tweak
+provenance="$(jq -r ".publishConfig.provenance" "$DIST_PACKAGE_JSON")"
+if [ "$provenance" != "false" ]; then
+  echo "❌ Provenance wasn't updated. Can't proceed."
+  exit 1
+fi
+registry="$(jq -r ".publishConfig.registry" "$DIST_PACKAGE_JSON")"
+if [ "$registry" != "$LOCAL_REGISTRY_URL" ]; then
+  echo "❌ Registry wasn't updated. Can't proceed."
+  exit 1
+fi
+
+# Run it
+echo "ℹ️ Running semantic release"
+pnpm semantic-release --no-ci


### PR DESCRIPTION
# Issue or need

After trying publishing to a local registry in order to test #1005 locally, found out that the process to publish to a local private registry can be improved.

It implies:
 - Altering Semantic Release configurations in `.releaserc.js`:
   - No GitHub plugin if using `.` as repository
   - No release notes plugin if using `.` as repository
 - Registry set to local one, not real one
 - Disable provenance

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add a script to automate and ensure all conditions to avoid pitfalls.

Update contributing docs to refer to the script & update steps. 

Move docs notes into the script / config. Out of contributing docs, to make them lighter.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
