### PR TITLE
ci: codecov coverage status not reported

### DIFF
--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -29,6 +29,10 @@ jobs:
           merge-multiple: true
       - name: Merge coverage reports
         run: pnpm run coverage:report:all
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:


### PR DESCRIPTION
# Issue or need

Latest PRs (starting from #1014 4 days ago) don't have the Codecov status check. In Codecov, the commit of the PR appears without uploads. Despite the coverage upload job doesn't fail

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Investigate...

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
