### PR TITLE
ci: try just fetching the needed depth

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Calculate PR commits + 1
         # https://github.com/actions/checkout/issues/520#issuecomment-1167205721
-        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commitsy }} + 1 ))" >> "${GITHUB_ENV}"
+        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -42,10 +42,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint last commit
-        #if: github.event_name == 'push'
+        if: github.event_name == 'push'
         run: pnpm run commitlint-last
       - name: Lint all PR commits
-        if: github.event_name == 'pull_requesty'
+        if: github.event_name == 'pull_request'
         run: |
           pnpm commitlint \
             --from ${{ github.event.pull_request.base.sha }} \

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Calculate PR commits + 1
         # https://github.com/actions/checkout/issues/520#issuecomment-1167205721
-        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commitsy }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -42,10 +42,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint last commit
-        if: github.event_name == 'push'
+        #if: github.event_name == 'push'
         run: pnpm run commitlint-last
       - name: Lint all PR commits
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_requesty'
         run: |
           pnpm commitlint \
             --from ${{ github.event.pull_request.base.sha }} \

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -33,11 +33,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Calculate PR commits + 1
-        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commitsy }} + 1 ))" >> "${GITHUB_ENV}"
+        # https://github.com/actions/checkout/issues/520#issuecomment-1167205721
+        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # https://github.com/actions/checkout/issues/520#issuecomment-1167205721
           fetch-depth: ${{ env.pr_commits_plus_one }}
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+          # https://github.com/actions/checkout/issues/416#issuecomment-1172822734
+          # https://github.com/actions/runner/issues/409#issuecomment-752775072
+          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint last commit

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Calculate PR commits + 1
-        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commitsy }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -32,12 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Calculate PR commits + 1
+        run: echo "pr_commits_plus_one=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          # https://github.com/actions/checkout/issues/416#issuecomment-1172822734
-          # https://github.com/actions/runner/issues/409#issuecomment-752775072
-          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
+          # https://github.com/actions/checkout/issues/520#issuecomment-1167205721
+          fetch-depth: ${{ env.pr_commits_plus_one }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint last commit

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format-all": "npm run format -- .",
     "prepare": "husky",
     "commitlint-edit-msg": "commitlint --verbose --edit",
-    "commitlint-last": "commitlint --verbose --from HEAD~1",
+    "commitlint-last": "commitlint --last --verbose",
     "cache-clean": "ng cache clean",
     "commit": "pnpx @commitlint/prompt-cli",
     "validate-codecov-yml": "curl -X POST --data-binary @codecov.yml https://codecov.io/validate",


### PR DESCRIPTION
# Issue or need

After reviewing how the linting tooling is setup to update another repository, saw that `fetch-depth` is set to `0` aka fetch everything. This is too much though. We only need the commits from the PR!

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use several tricks to just fetch the appropriate depth:
 - [Calculates number of commits + 1](https://github.com/actions/checkout/issues/520#issuecomment-1167205721) to fetch only pull request commits. If it's not a pull request, the shell expression will be ` + 1` so just one will be fetched. As expected in the `main` case. The +1 is needed as otherwise the range doesn't exist given the pull request base isn't fetched, but it's included in the range. It has to be included, as the start from the range is needed, despite not inspected.
 - Use `commitlint --last` instead of `commitlint --from HEAD~1`. As if just fetching last commit in `main`, the `HEAD~1` doesn't exist. As explained above.

Simulated both cases and everything goes fine

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
