### PR TITLE
fix: do not publish tarball inside package

### DIFF
--- a/postbuild.sh
+++ b/postbuild.sh
@@ -37,4 +37,8 @@ done
 echo "ℹ️ Building schematics"
 cd projects/ngx-meta/schematics
 pnpm run build
-cd "$(dirname "$0")"
+cd -
+
+# Ignore tarballs
+echo "ℹ️ Ignore tarballs on dist dir"
+printf '\n# Ignore tarballs\n*.tgz' >> "$NGX_META_DIST_DIR/.npmignore"


### PR DESCRIPTION
# Issue or need

After inspecting randomly the contents of the published package, noticed that the tarball is inside the package! So package is contained within the package xD

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Do not include tarballs from distribution directory

Considered also putting the tarball in another place. But `dist` dir feels most appropriate

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
