### PR TITLE
chore: remove unneeded entries in CI's Makefile

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -4,31 +4,13 @@
 build:
 	cd .. && pnpm run build
 
-tsc:
-	cd .. && pnpm run ngx-meta:tsc
-
 install:
 	# Despite it's enabled by default on CI. This allows to mock CI locally
 	# https://pnpm.io/cli/install#--frozen-lockfile
 	pnpm install --frozen-lockfile
-
-lint-gh-actions:
-	ationlint
 
 unit-test-libs:
 	pnpm run test:unit:libs:coverage \
 		--browsers=ChromeHeadless \
 		--no-progress \
 		--reporters progress
-
-unit-test-schematics:
-	cd .. && pnpm run test:unit:schematics:coverage
-
-release:
-	cd .. && pnpm semantic-release
-
-api-extractor:
-	cd .. && pnpm run ngx-meta:api-extractor
-
-api-documenter:
-	cd .. && pnpm run ngx-meta:api-documenter

--- a/.github/workflows/reusable-api-extractor.yml
+++ b/.github/workflows/reusable-api-extractor.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run API Extractor in production mode
-        run: cd .ci && make api-extractor
+        run: pnpm run ngx-meta:api-extractor
       - name: Run API Documenter
-        run: cd .ci && make api-documenter
+        run: pnpm run ngx-meta:api-documenter
       - name: Upload API Documenter generated Markdown docs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,7 +26,7 @@ jobs:
           path: .angular/cache
           key: angular-cache
       - name: Build libraries
-        run: cd .ci && make build
+        run: pnpm run build
       - name: Upload distribution files
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run tsc
-        run: cd .ci && make tsc
+        run: pnpm run ngx-meta:tsc
       - name: Upload compiled JS files
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm-token }}
-        run: cd .ci && make release
+        run: pnpm semantic-release
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run unit tests
-        run: cd .ci && make unit-test-schematics
+        run: pnpm run test:unit:schematics:coverage
       - name: Upload coverage report
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: failure() || success()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,9 @@ If adding a whole metadata module, add it to the built-in modules section too.
 
 ### CI/CD jobs
 
-To easily reproduce locally CI/CD jobs, most commands run by CI/CD are stored in [`.ci/Makefile` file](.ci/Makefile).
+To easily reproduce locally CI/CD jobs, commands run by CI/CD which are different from commands ran locally are stored in [`.ci/Makefile` file](.ci/Makefile).
 
-For instance, you can run `make build` (or just `make` in this case) to ensure the command used to build is the same one the CI/CD job will use.
+For instance, you can run `make install` to run the same command used in CI/CD for installing.
 
 ### Release and versioning
 


### PR DESCRIPTION
# Issue or need

Some entries in CI/CD's `.ci/Makefile` are just redirecting to run scripts. The purpose of that file is to add commands that are only different when running in CI/CD

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove CI's `Makefile` targets that just run regular run scripts

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
