### PR TITLE
build(lint): convert ESLint config to ESM

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,31 +1,31 @@
 // @ts-check
 // noinspection NpmUsedModulesInstalled
-const eslint = require('@eslint/js')
-const tseslint = require('typescript-eslint')
-const angular = require('angular-eslint')
+import eslint from '@eslint/js'
+import tsEslint from 'typescript-eslint'
+import angular from 'angular-eslint'
 
-const eslintCompat = require('@eslint/compat')
-const path = require('path')
-const gitignorePath = path.resolve(__dirname, '.gitignore')
+import { includeIgnoreFile } from '@eslint/compat'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
 
-const eslintConfigPrettier = require('eslint-config-prettier')
+import eslintConfigPrettier from 'eslint-config-prettier'
+import eslintPluginCypress from 'eslint-plugin-cypress/flat'
+import eslintPluginJasmine from 'eslint-plugin-jasmine'
+import eslintPluginJest from 'eslint-plugin-jest'
+import eslintPluginJsonFiles from 'eslint-plugin-json-files'
 
-const eslintPluginCypress = require('eslint-plugin-cypress/flat')
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const gitignorePath = resolve(__dirname, '.gitignore')
 
-const eslintPluginJsonFiles = require('eslint-plugin-json-files')
-
-const eslintPluginJasmine = require('eslint-plugin-jasmine')
-
-const eslintPluginJest = require('eslint-plugin-jest')
-
-module.exports = tseslint.config(
-  eslintCompat.includeIgnoreFile(gitignorePath),
+export default tsEslint.config(
+  includeIgnoreFile(gitignorePath),
   {
     files: ['**/*.ts'],
     extends: [
       eslint.configs.recommended,
-      ...tseslint.configs.recommended,
-      ...tseslint.configs.stylistic,
+      ...tsEslint.configs.recommended,
+      ...tsEslint.configs.stylistic,
     ],
   },
   {


### PR DESCRIPTION
# Issue or need

Most of ESLint config examples use ESM syntax (mainly `import` and `export`). However, Angular ESLint added a CommonJS config file.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use ESM syntax by using `.mjs` extension for the config file. As `type: module` can't be added to `package.json` for now.

Other minor changes:
 - Sort imports

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
