### PR TITLE
perf: use pure annotations for tree shaking

### DIFF
--- a/projects/ngx-meta/src/core/src/url-resolution/angular-router-url.ts
+++ b/projects/ngx-meta/src/core/src/url-resolution/angular-router-url.ts
@@ -9,7 +9,7 @@
  *
  * @public
  */
-export const ANGULAR_ROUTER_URL = Symbol(
+export const ANGULAR_ROUTER_URL = /* @__PURE__ */ Symbol(
   ngDevMode
     ? "NgxMeta: Use Angular's router URL as relative URL"
     : 'NgxMetaARU',


### PR DESCRIPTION
# Issue or need

After seeing a pure annotation to [`RouterTitleKey` symbol in Angular's router package](https://github.com/angular/angular/blob/17.3.12/packages/router/src/shared.ts#L24), the use of pure annotations has given me several ideas:
 - [To solve issue](https://github.com/davidlj95/ngx/issues/960#issuecomment-2488859545) #960
 - To use it around for tree shaking. Like:
   - Symbols 
   - `const`s
   - ...

Applying here the pure annotation when possible to improve tree shaking
<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Use pure annotation to tree shake:
 - Symbols: `ANGULAR_ROUTER_URL` symbol if unused. It's the only symbol used around

Reviewed the API report and nothing else seems to bee applicable for optimizations using pure annotations.

Tested that the symbol is not in production bundle when removing its usage in example app + not providing `withBaseUrl`

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
