### PR TITLE
refactor: return generic `Provider` type for providers

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -109,7 +109,7 @@ export const _injectMetadataManagers: () => readonly NgxMetaMetadataManager[];
 export const _isDefined: <T>(value: T | null | undefined) => value is T;
 
 // @public
-export const JSON_LD_METADATA_PROVIDER: FactoryProvider;
+export const JSON_LD_METADATA_PROVIDER: Provider;
 
 // @public
 export interface JsonLdMetadata {
@@ -296,16 +296,16 @@ export class NgxMetaTwitterCardModule {
 }
 
 // @public
-export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_DESCRIPTION_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_IMAGE_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_LOCALE_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_LOCALE_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_PROFILE_FIRST_NAME_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_PROFILE_FIRST_NAME_METADATA_PROVIDER: Provider;
 
 // @public
 export const OPEN_GRAPH_PROFILE_GENDER_FEMALE = "female";
@@ -314,19 +314,19 @@ export const OPEN_GRAPH_PROFILE_GENDER_FEMALE = "female";
 export const OPEN_GRAPH_PROFILE_GENDER_MALE = "male";
 
 // @public
-export const OPEN_GRAPH_PROFILE_GENDER_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_PROFILE_GENDER_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_PROFILE_LAST_NAME_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_PROFILE_LAST_NAME_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_PROFILE_USERNAME_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_PROFILE_USERNAME_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_SITE_NAME_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_SITE_NAME_METADATA_PROVIDER: Provider;
 
 // @public
-export const OPEN_GRAPH_TITLE_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_TITLE_METADATA_PROVIDER: Provider;
 
 // @public
 export const OPEN_GRAPH_TYPE_ARTICLE = "article";
@@ -335,7 +335,7 @@ export const OPEN_GRAPH_TYPE_ARTICLE = "article";
 export const OPEN_GRAPH_TYPE_BOOK = "book";
 
 // @public
-export const OPEN_GRAPH_TYPE_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_TYPE_METADATA_PROVIDER: Provider;
 
 // @public
 export const OPEN_GRAPH_TYPE_MUSIC_ALBUM = "music.album";
@@ -368,7 +368,7 @@ export const OPEN_GRAPH_TYPE_VIDEO_TV_SHOW = "video.tv_show";
 export const OPEN_GRAPH_TYPE_WEBSITE = "website";
 
 // @public
-export const OPEN_GRAPH_URL_METADATA_PROVIDER: FactoryProvider;
+export const OPEN_GRAPH_URL_METADATA_PROVIDER: Provider;
 
 // @public
 export interface OpenGraph {
@@ -415,12 +415,12 @@ export type OpenGraphType = typeof OPEN_GRAPH_TYPE_MUSIC_SONG | typeof OPEN_GRAP
 export const provideNgxMetaCore: (...features: CoreFeatures) => EnvironmentProviders;
 
 // @public
-export const provideNgxMetaJsonLd: () => Provider[];
+export const provideNgxMetaJsonLd: () => Provider;
 
 // Warning: (ae-incompatible-release-tags) The symbol "provideNgxMetaManager" is marked as @public, but its signature references "_ProvideNgxMetaManagerOptions" which is marked as @internal
 //
 // @public
-export const provideNgxMetaManager: <T>(jsonPath: string, setterFactory: MetadataSetterFactory<T>, options?: _ProvideNgxMetaManagerOptions) => FactoryProvider;
+export const provideNgxMetaManager: <T>(jsonPath: string, setterFactory: MetadataSetterFactory<T>, options?: _ProvideNgxMetaManagerOptions) => Provider;
 
 // @internal (undocumented)
 export type _ProvideNgxMetaManagerOptions = Partial<{
@@ -431,12 +431,12 @@ export type _ProvideNgxMetaManagerOptions = Partial<{
 }>;
 
 // @public
-export const provideNgxMetaMetadataLoader: () => Provider[];
+export const provideNgxMetaMetadataLoader: () => Provider;
 
 // Warning: (ae-forgotten-export) The symbol "StringKeyOf" needs to be exported by the entry point all-entry-points.d.ts
 //
 // @internal (undocumented)
-export const _provideNgxMetaModuleManager: <Type extends object, Key extends StringKeyOf<Type>>(key: Key, scope: readonly string[], options: _ProvideNgxMetaModuleManagerOptions<Type[Key]>) => FactoryProvider;
+export const _provideNgxMetaModuleManager: <Type extends object, Key extends StringKeyOf<Type>>(key: Key, scope: readonly string[], options: _ProvideNgxMetaModuleManagerOptions<Type[Key]>) => Provider;
 
 // @internal (undocumented)
 export type _ProvideNgxMetaModuleManagerOptions<T> = Partial<{
@@ -446,19 +446,19 @@ export type _ProvideNgxMetaModuleManagerOptions<T> = Partial<{
 }> & _ProvideNgxMetaManagerOptions;
 
 // @public
-export const provideNgxMetaOpenGraph: () => Provider[];
+export const provideNgxMetaOpenGraph: () => Provider;
 
 // @public
-export const provideNgxMetaOpenGraphProfile: () => Provider[];
+export const provideNgxMetaOpenGraphProfile: () => Provider;
 
 // @public
 export const provideNgxMetaRouting: () => EnvironmentProviders;
 
 // @public
-export const provideNgxMetaStandard: () => Provider[];
+export const provideNgxMetaStandard: () => Provider;
 
 // @public
-export const provideNgxMetaTwitterCard: () => Provider[];
+export const provideNgxMetaTwitterCard: () => Provider;
 
 // @internal (undocumented)
 export type _RouteMetadataStrategy = () => MetadataValues | undefined;
@@ -480,31 +480,31 @@ export interface Standard {
 }
 
 // @public
-export const STANDARD_APPLICATION_NAME_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_APPLICATION_NAME_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_AUTHOR_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_AUTHOR_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_CANONICAL_URL_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_CANONICAL_URL_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_DESCRIPTION_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_DESCRIPTION_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_GENERATOR_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_GENERATOR_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_KEYWORDS_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_KEYWORDS_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_LOCALE_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_LOCALE_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_THEME_COLOR_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_THEME_COLOR_METADATA_PROVIDER: Provider;
 
 // @public
-export const STANDARD_TITLE_METADATA_PROVIDER: FactoryProvider;
+export const STANDARD_TITLE_METADATA_PROVIDER: Provider;
 
 // @public
 export interface StandardMetadata {
@@ -524,22 +524,22 @@ export interface StandardThemeColorMetadataObject {
 type StringKeyOf<T = object> = Extract<keyof T, string>;
 
 // @public
-export const TWITTER_CARD_CARD_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_CARD_METADATA_PROVIDER: Provider;
 
 // @public
-export const TWITTER_CARD_CREATOR_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_CREATOR_METADATA_PROVIDER: Provider;
 
 // @public
-export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_DESCRIPTION_METADATA_PROVIDER: Provider;
 
 // @public
-export const TWITTER_CARD_IMAGE_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_IMAGE_METADATA_PROVIDER: Provider;
 
 // @public
-export const TWITTER_CARD_SITE_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_SITE_METADATA_PROVIDER: Provider;
 
 // @public
-export const TWITTER_CARD_TITLE_METADATA_PROVIDER: FactoryProvider;
+export const TWITTER_CARD_TITLE_METADATA_PROVIDER: Provider;
 
 // @public
 export const TWITTER_CARD_TYPE_APP = "app";

--- a/projects/ngx-meta/src/core/src/loader/ngx-meta-metadata-loader.module.ts
+++ b/projects/ngx-meta/src/core/src/loader/ngx-meta-metadata-loader.module.ts
@@ -9,6 +9,6 @@ import { provideNgxMetaMetadataLoader } from './provide-ngx-meta-metadata-loader
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaMetadataLoader(),
+  providers: [provideNgxMetaMetadataLoader()],
 })
 export class NgxMetaMetadataLoaderModule {}

--- a/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
+++ b/projects/ngx-meta/src/core/src/loader/provide-ngx-meta-metadata-loader.ts
@@ -14,7 +14,7 @@ import {
  *
  * @public
  */
-export const provideNgxMetaMetadataLoader = (): Provider[] => [
+export const provideNgxMetaMetadataLoader = (): Provider => [
   provideMetadataRegistry(),
   {
     provide: ENVIRONMENT_INITIALIZER,

--- a/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v2/provide-ngx-meta-manager.ts
@@ -1,4 +1,4 @@
-import { FactoryProvider } from '@angular/core'
+import { FactoryProvider, Provider } from '@angular/core'
 import {
   MetadataResolverOptions,
   NgxMetaMetadataManager,
@@ -64,21 +64,22 @@ export const provideNgxMetaManager = <T>(
   setterFactory: MetadataSetterFactory<T>,
   /* istanbul ignore next - quite simple */
   options: _ProvideNgxMetaManagerOptions = {},
-): FactoryProvider => ({
-  provide: NgxMetaMetadataManager,
-  multi: true,
-  useFactory: (...deps: readonly unknown[]) =>
-    ({
-      id: jsonPath,
-      set: setterFactory(...deps),
-      resolverOptions: {
-        jsonPath: jsonPath.split('.'),
-        global: options.g,
-        objectMerge: options.o,
-      },
-    }) satisfies NgxMetaMetadataManager<T>,
-  deps: options.d,
-})
+): Provider =>
+  ({
+    provide: NgxMetaMetadataManager,
+    multi: true,
+    useFactory: (...deps: readonly unknown[]) =>
+      ({
+        id: jsonPath,
+        set: setterFactory(...deps),
+        resolverOptions: {
+          jsonPath: jsonPath.split('.'),
+          global: options.g,
+          objectMerge: options.o,
+        },
+      }) satisfies NgxMetaMetadataManager<T>,
+    deps: options.d,
+  }) satisfies FactoryProvider
 
 /**
  * @internal

--- a/projects/ngx-meta/src/json-ld/src/providers/ngx-meta-json-ld.module.ts
+++ b/projects/ngx-meta/src/json-ld/src/providers/ngx-meta-json-ld.module.ts
@@ -10,6 +10,6 @@ import { provideNgxMetaJsonLd } from './provide-ngx-meta-json-ld'
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaJsonLd(),
+  providers: [provideNgxMetaJsonLd()],
 })
 export class NgxMetaJsonLdModule {}

--- a/projects/ngx-meta/src/json-ld/src/providers/provide-ngx-meta-json-ld.ts
+++ b/projects/ngx-meta/src/json-ld/src/providers/provide-ngx-meta-json-ld.ts
@@ -12,6 +12,4 @@ import { JSON_LD_METADATA_PROVIDER } from '../managers'
  *
  * @public
  */
-export const provideNgxMetaJsonLd = (): Provider[] => [
-  JSON_LD_METADATA_PROVIDER,
-]
+export const provideNgxMetaJsonLd = (): Provider => [JSON_LD_METADATA_PROVIDER]

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/providers/ngx-meta-open-graph.module.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/providers/ngx-meta-open-graph.module.ts
@@ -10,6 +10,6 @@ import { provideNgxMetaOpenGraph } from './provide-ngx-meta-open-graph'
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaOpenGraph(),
+  providers: [provideNgxMetaOpenGraph()],
 })
 export class NgxMetaOpenGraphModule {}

--- a/projects/ngx-meta/src/open-graph/src/basic-optional/providers/provide-ngx-meta-open-graph.ts
+++ b/projects/ngx-meta/src/open-graph/src/basic-optional/providers/provide-ngx-meta-open-graph.ts
@@ -20,7 +20,7 @@ import {
  *
  * @public
  */
-export const provideNgxMetaOpenGraph = (): Provider[] => [
+export const provideNgxMetaOpenGraph = (): Provider => [
   OPEN_GRAPH_TITLE_METADATA_PROVIDER,
   OPEN_GRAPH_TYPE_METADATA_PROVIDER,
   OPEN_GRAPH_IMAGE_METADATA_PROVIDER,

--- a/projects/ngx-meta/src/open-graph/src/profile/providers/ngx-meta-open-graph-profile.module.ts
+++ b/projects/ngx-meta/src/open-graph/src/profile/providers/ngx-meta-open-graph-profile.module.ts
@@ -10,6 +10,6 @@ import { provideNgxMetaOpenGraphProfile } from './provide-ngx-meta-open-graph-pr
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaOpenGraphProfile(),
+  providers: [provideNgxMetaOpenGraphProfile()],
 })
 export class NgxMetaOpenGraphProfileModule {}

--- a/projects/ngx-meta/src/open-graph/src/profile/providers/provide-ngx-meta-open-graph-profile.ts
+++ b/projects/ngx-meta/src/open-graph/src/profile/providers/provide-ngx-meta-open-graph-profile.ts
@@ -17,7 +17,7 @@ import {
  *
  * @public
  */
-export const provideNgxMetaOpenGraphProfile = (): Provider[] => [
+export const provideNgxMetaOpenGraphProfile = (): Provider => [
   OPEN_GRAPH_PROFILE_FIRST_NAME_METADATA_PROVIDER,
   OPEN_GRAPH_PROFILE_LAST_NAME_METADATA_PROVIDER,
   OPEN_GRAPH_PROFILE_USERNAME_METADATA_PROVIDER,

--- a/projects/ngx-meta/src/standard/src/providers/ngx-meta-standard.module.ts
+++ b/projects/ngx-meta/src/standard/src/providers/ngx-meta-standard.module.ts
@@ -10,6 +10,6 @@ import { provideNgxMetaStandard } from './provide-ngx-meta-standard'
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaStandard(),
+  providers: [provideNgxMetaStandard()],
 })
 export class NgxMetaStandardModule {}

--- a/projects/ngx-meta/src/standard/src/providers/provide-ngx-meta-standard.ts
+++ b/projects/ngx-meta/src/standard/src/providers/provide-ngx-meta-standard.ts
@@ -22,7 +22,7 @@ import {
  *
  * @public
  */
-export const provideNgxMetaStandard = (): Provider[] => [
+export const provideNgxMetaStandard = (): Provider => [
   STANDARD_TITLE_METADATA_PROVIDER,
   STANDARD_DESCRIPTION_METADATA_PROVIDER,
   STANDARD_AUTHOR_METADATA_PROVIDER,

--- a/projects/ngx-meta/src/twitter-card/src/providers/ngx-meta-twitter-card.module.ts
+++ b/projects/ngx-meta/src/twitter-card/src/providers/ngx-meta-twitter-card.module.ts
@@ -10,6 +10,6 @@ import { provideNgxMetaTwitterCard } from './provide-ngx-meta-twitter-card'
  * @public
  */
 @NgModule({
-  providers: provideNgxMetaTwitterCard(),
+  providers: [provideNgxMetaTwitterCard()],
 })
 export class NgxMetaTwitterCardModule {}

--- a/projects/ngx-meta/src/twitter-card/src/providers/provide-ngx-meta-twitter-card.ts
+++ b/projects/ngx-meta/src/twitter-card/src/providers/provide-ngx-meta-twitter-card.ts
@@ -19,7 +19,7 @@ import {
  *
  * @public
  */
-export const provideNgxMetaTwitterCard = (): Provider[] => [
+export const provideNgxMetaTwitterCard = (): Provider => [
   TWITTER_CARD_CARD_METADATA_PROVIDER,
   TWITTER_CARD_SITE_METADATA_PROVIDER,
   TWITTER_CARD_CREATOR_METADATA_PROVIDER,


### PR DESCRIPTION
# Issue or need

Built-in metadata providers are returning providers of type `FactoryProvider`. Module ones return `Provider[]`. All of those are part of public API, as can be seen in API report file.

This is an implementation detail. At some point maybe it's need to change to another thing. But maybe users are relying on that detail.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Change the type of providers to generic `Provider`. This way we can change to another kind of provider if needed.

Technically speaking, it's a breaking change. However don't think any users out there are relying on the provider type. So making it a refactor instead

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
