### PR TITLE
docs: add migration document for meta element APIs

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -437,6 +437,16 @@
         </option>
         <option name="myCustomValuesEnabled" value="true" />
       </scope>
+      <scope name="ngx-meta doc contents" level="WARNING" enabled="true">
+        <option name="myValues">
+          <value>
+            <list size="1">
+              <item index="0" class="java.lang.String" itemvalue="markdown" />
+            </list>
+          </value>
+        </option>
+        <option name="myCustomValuesEnabled" value="true" />
+      </scope>
       <option name="myValues">
         <value>
           <list size="0" />

--- a/.idea/scopes/ngx_meta_doc_contents.xml
+++ b/.idea/scopes/ngx_meta_doc_contents.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="ngx-meta doc contents" pattern="file[ngx]:projects/ngx-meta/docs/includes//*.md||file[ngx]:projects/ngx-meta/docs/content//*.md" />
+</component>

--- a/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
@@ -83,6 +83,8 @@ No automatic migration via schematics are available for this change. Manual migr
 
 Here you have some examples of how the same thing can be achieved using old and new APIs:
 
+<!-- prettier-ignore-start -->
+
 #### Set a single `<meta>` element
 
 Let's set a `<meta name="description">` element:
@@ -91,12 +93,18 @@ Let's set a `<meta name="description">` element:
 
 ```typescript title="Before"
 const metaService = inject(NgxMetaMetaService)
-metaService.set(makeKeyValMetaDefinition('description'), 'foo')
+metaService.set(
+  makeKeyValMetaDefinition('description'), 
+  'foo'
+)
 ```
 
 ```typescript title="After"
 const metaService = inject(NgxMetaElementsService)
-metaService.set(withNameAttribute('description'), withContentAttribute('foo'))
+metaService.set(
+  withNameAttribute('description'), 
+  withContentAttribute('foo')
+)
 ```
 
 </div>
@@ -122,7 +130,10 @@ metaService.set(
   undefined, // or null or empty array
 )
 // or also just
-metaService.set(withNameAttribute('description'), withContentAttribute(undefined))
+metaService.set(
+  withNameAttribute('description'), 
+  withContentAttribute(undefined)
+)
 ```
 
 </div>
@@ -135,12 +146,24 @@ Like a `<meta name="theme-color">` with a `media` attribute:
 
 ```typescript title="Before"
 const metaService = inject(NgxMetaMetaService)
-metaService.set(makeKeyValMetaDefinition('theme-color', { extras: { media: '(prefers-color-scheme: dark)' } }), 'darkblue')
+metaService.set(
+  makeKeyValMetaDefinition(
+    'theme-color', 
+    { extras: { media: '(prefers-color-scheme: dark)' } }
+  ), 
+  'darkblue'
+)
 ```
 
 ```typescript title="After"
 const metaService = inject(NgxMetaElementsService)
-metaService.set(withNameAttribute('theme-color'), withContentAttribute('darkblue', { media: '(prefers-color-scheme: dark)' }))
+metaService.set(
+  withNameAttribute('theme-color'), 
+  withContentAttribute(
+    'darkblue',
+    { media: '(prefers-color-scheme: dark)' }
+  )
+)
 ```
 
 </div>
@@ -157,9 +180,20 @@ Like multiple `<meta name="theme-color">`:
 
 ```typescript title="After"
 const metaService = inject(NgxMetaElementsService)
-metaService.set(withNameAttribute('theme-color'), [withContentAttribute('darkblue', { media: '(prefers-color-scheme: dark)' }), withContentAttribute('lightblue')])
+metaService.set(
+  withNameAttribute('theme-color'), 
+  [
+    withContentAttribute(
+      'darkblue', 
+      { media: '(prefers-color-scheme: dark)' }
+    ),
+    withContentAttribute('lightblue')
+  ]
+)
 ```
 
 </div>
+
+<!-- prettier-ignore-end -->
 
 [^1]: For more details, check out the [deprecation PR](https://github.com/davidlj95/ngx/pull/955)

--- a/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
@@ -1,0 +1,165 @@
+# `<meta>` element APIs
+
+## TL;DR
+
+APIs to manage `<meta>` elements on the page changed to improve development experience. [`NgxMetaMetaService`](ngx-meta.ngxmetametaservice.md) and related APIs are deprecated in favour of [`NgxMetaElementsService`](ngx-meta.ngxmetaelementsservice.md) and related APIs
+
+See [migration](#migration) for more info about running automatic migrations or migrating manually.
+
+## Summary
+
+| Key                            | Value              |
+| :----------------------------- | :----------------- |
+| Category of change             | 👎 **Deprecation** |
+| Automatic migration schematics | No                 |
+| Introduced in version          | `1.0.0-beta.24`    |
+
+## Description
+
+### Issue
+
+[GitHub PR]: https://github.com/davidlj95/ngx/pull/883
+
+[**🎟️ GitHub PR with details**][GitHub PR]
+
+[theme color standard meta]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
+
+APIs to manage `<meta>` elements on the page had several issues:
+
+- **Unneeded abstraction**: [`NgxMetaMetaService`](ngx-meta.ngxmetametaservice.md) requires as first argument an [`NgxMetaMetaDefinition`](ngx-meta.ngxmetametadefinition.md) and then the content to place in there. Idea behind that definition type was to model and manage a kind of `<meta>` elements. Like `<meta name="description">` for instance. But this can be done without introducing an additional type / abstraction. Which adds unnecessary cognitive load to do something simple as managing `<meta>` elements.
+- **Limited abstraction**: [`NgxMetaMetaDescription`](ngx-meta.ngxmetametadefinition.md) has two properties:
+  - [`attrSelector`](ngx-meta.ngxmetametadefinition.attrselector.md): identifies the kind of `<meta>` elements. Like `name="description"`. So they can be created, updated or removed depending on the metadata to set on the page. Nothing wrong with it.
+  - [`withContent`](ngx-meta.ngxmetametadefinition.withcontent.md): a function that given some content as `string`, generates an Angular's [`MetaDefinition`](https://angular.dev/api/platform-browser/MetaDefinition). This was done so that Open Graph metadata name is placed in a `property` attribute. Though most names are placed in a `name` attribute. Or to customize the attribute holding the content if needed. However, sometimes more attributes are needed for a `<meta>` element. A `string` is then not enough to specify them all. Like [theme color standard meta].
+- **Coupled API design**: [`NgxMetaMetaService`](ngx-meta.ngxmetametaservice.md) second argument is the content to set to the `<meta>` element. That content is a `string` because of [`NgxMetaMetaDefinition.withContent`](ngx-meta.ngxmetametadefinition.withcontent.md). It couples even more to the abstraction above. And also it inherits the limitation of being a `string`.
+- **Can't set multiple `<meta>` elements**. If calling the API to set a given `<meta>`, it will replace existing element. Can't add more than one. This is an issue for metadata that may need multiple `<meta>` elements. Like [theme color standard meta] or [Open Graph arrays](https://ogp.me/#array)
+
+- **Too long names**: I know, subjective. But [`NgxMetaMetaDefinition`](ngx-meta.ngxmetametadefinition.md) feels too long. Same for [`makeKeyValMetaDefinition`](ngx-meta.makekeyvalmetadefinition.md) and [`makeComposedKeyValMetaDefinition`](ngx-meta.makecomposedkeyvalmetadefinition.md)
+
+### Solution
+
+As APIs are coupled, introducing a compatibility layer on top of existing ones would:
+
+- **Add more complexity** to existing ones to manage both old and new usages.
+- **Increase bundle size** because of this extra compatibility layer
+
+So newer APIs were designed to solve the existing issues. The goals of these new APIs are then:
+
+- **No unneeded abstractions**: everything should be able to be specified without introducing extra abstractions. Using primitive types. Helper functions can be introduced as syntactic sugar.
+
+- **Support `<meta>` elements with more attributes**: not just `name` and `content` ones. For instance [theme color standard meta] can specify the `media` attribute.
+- **Support setting multiple `<meta>` elements**
+
+- **Shorter names**
+
+### Changes
+
+Following set of APIs are deprecated[^1]:
+
+- [`NgxMetaMetaService`](ngx-meta.ngxmetametaservice.md)
+- [`NgxMetaMetaMetaDefinition`](ngx-meta.ngxmetametadefinition.md)
+  - [`makeKeyValMetaDefinition`](ngx-meta.makekeyvalmetadefinition.md)
+  - [`makeComposedKeyValMetaDefinition`](ngx-meta.makecomposedkeyvalmetadefinition.md)
+    - [`MakeComopsedKeyValMetaDefinitionOptions`](ngx-meta.makecomposedkeyvalmetadefinitionoptions.md)
+- [`NgxMetaMetaContent`](ngx-meta.ngxmetametacontent.md)
+
+And the following set of APIs are introduced:
+
+- [`NgxMetaElementsService`](ngx-meta.ngxmetaelementsservice.md)
+- [`NgxMetaElementNameAttribute`](ngx-meta.ngxmetaelementnameattribute.md)
+  - [`withNameAttribute`](ngx-meta.withnameattribute.md)
+  - [`withPropertyAttribute`](ngx-meta.withpropertyattribute.md)
+- [`NgxMetaElementAttributes`](ngx-meta.ngxmetaelementattributes.md)
+  - [`withContentAttribute`](ngx-meta.withcontentattribute.md)
+
+See [GitHub PR] were they were introduced more details. Keep reading for how to migrate from old ones to newer ones.
+
+## Migration
+
+### Automatic
+
+No automatic migration via schematics are available for this change. Manual migration is required
+
+### Manual
+
+Here you have some examples of how the same thing can be achieved using old and new APIs:
+
+#### Set a single `<meta>` element
+
+Let's set a `<meta name="description">` element:
+
+<div class="grid" markdown>
+
+```typescript title="Before"
+const metaService = inject(NgxMetaMetaService)
+metaService.set(makeKeyValMetaDefinition('description'), 'foo')
+```
+
+```typescript title="After"
+const metaService = inject(NgxMetaElementsService)
+metaService.set(withNameAttribute('description'), withContentAttribute('foo'))
+```
+
+</div>
+
+#### Remove all `<meta>` elements of a kind
+
+Let's remove all `<meta name="description">` elements:
+
+<div class="grid" markdown>
+
+```typescript title="Before"
+const metaService = inject(NgxMetaMetaService)
+metaService.set(
+  makeKeyValMetaDefinition('description'),
+  undefined, // or null
+)
+```
+
+```typescript title="After"
+const metaService = inject(NgxMetaElementsService)
+metaService.set(
+  withNameAttribute('description'),
+  undefined, // or null or empty array
+)
+// or also just
+metaService.set(withNameAttribute('description'), withContentAttribute(undefined))
+```
+
+</div>
+
+#### Set `<meta>` element with more attributes
+
+Like a `<meta name="theme-color">` with a `media` attribute:
+
+<div class="grid" markdown>
+
+```typescript title="Before"
+const metaService = inject(NgxMetaMetaService)
+metaService.set(makeKeyValMetaDefinition('theme-color', { extras: { media: '(prefers-color-scheme: dark)' } }), 'darkblue')
+```
+
+```typescript title="After"
+const metaService = inject(NgxMetaElementsService)
+metaService.set(withNameAttribute('theme-color'), withContentAttribute('darkblue', { media: '(prefers-color-scheme: dark)' }))
+```
+
+</div>
+
+#### Set many `<meta>` elements
+
+Like multiple `<meta name="theme-color">`:
+
+<div class="grid" markdown>
+
+```typescript title="Before"
+// ❌ Not possible with library-provided APIs
+```
+
+```typescript title="After"
+const metaService = inject(NgxMetaElementsService)
+metaService.set(withNameAttribute('theme-color'), [withContentAttribute('darkblue', { media: '(prefers-color-scheme: dark)' }), withContentAttribute('lightblue')])
+```
+
+</div>
+
+[^1]: For more details, check out the [deprecation PR](https://github.com/davidlj95/ngx/pull/955)

--- a/projects/ngx-meta/docs/mkdocs.yml
+++ b/projects/ngx-meta/docs/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - API Reference: api/ngx-meta.md
   - changelog.md
   - Migrations:
+      - migrations/01-meta-element-apis.md
       - migrations/03-const-to-function-manager-providers.md
   - Misc:
       - misc/example-apps.md

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/make-composed-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/make-composed-key-val-meta-definition.ts
@@ -28,7 +28,7 @@ import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
  * ```
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @param names - Names to create they key name
  * @param options - Options object
@@ -45,7 +45,7 @@ export const makeComposedKeyValMetaDefinition = (
  * Options argument object for {@link makeComposedKeyValMetaDefinition}
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @public
  */

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/make-key-val-meta-definition.ts
@@ -22,7 +22,7 @@ import { NgxMetaMetaDefinition } from './ngx-meta-meta-definition'
  * actual value
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @param keyName - Name of the key in the key/value meta definition
  * @param options - Specifies HTML attribute names and extras of the definition if any
@@ -52,7 +52,7 @@ export const makeKeyValMetaDefinition = (
  * Options argument object for {@link makeKeyValMetaDefinition}
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @public
  */

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-content.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-content.ts
@@ -6,7 +6,7 @@
  * See {@link NgxMetaMetaService.set}
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @public
  */

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-definition.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta-definition.ts
@@ -10,7 +10,7 @@ import { MetaDefinition } from '@angular/platform-browser'
  *  - {@link makeComposedKeyValMetaDefinition}
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @remarks
  *
@@ -26,7 +26,7 @@ export interface NgxMetaMetaDefinition {
    * With the given content as value of the `<meta>` element.
    *
    * @deprecated Use {@link NgxMetaElementsService} APIs instead.
-   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+   *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
    *
    * @example
    * For instance, `(content) => ({name: 'description', content})` to create a
@@ -40,7 +40,7 @@ export interface NgxMetaMetaDefinition {
    * to identify the `<meta>` element. In order to remove this specific `<meta>` element when needed.
    *
    * @deprecated Use {@link NgxMetaElementsService} APIs instead.
-   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+   *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
    *
    * @example
    * For instance, `[name='description']` for the `<meta name='description'>` element.

--- a/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.ts
+++ b/projects/ngx-meta/src/core/src/meta-elements/v1/ngx-meta-meta.service.ts
@@ -11,7 +11,7 @@ import { NgxMetaMetaContent } from './ngx-meta-meta-content'
  * Uses Angular {@link https://angular.dev/api/platform-browser/Meta | Meta} APIs under the hood.
  *
  * @deprecated Use {@link NgxMetaElementsService} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+ *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
  *
  * @public
  */
@@ -27,7 +27,7 @@ export class NgxMetaMetaService {
    * The element is created with the provided content. If no content is given, element is removed.
    *
    * @deprecated Use {@link NgxMetaElementsService} APIs instead.
-   *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more info
+   *             See {@link https://ngx-meta.dev/migrations/01-meta-element-apis | migration guide} for more info
    *
    * @param definition - `<meta>` element to create, update or remove
    * @param content - Content value to create or update the `<meta>` element.


### PR DESCRIPTION
# Issue or need

In #1013, a migration guide was added to aid usersmigrate from deprecated `const` manager providers to new `function` manager providers 

Same could be done for other deprecations so users are informed about how to migrate. Here adding migration docs for the first deprecation: meta elements API

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add migration docs for meta element APIs. Update deprecation notices to link to the new doc.

Also configures WebStorm to allow for `markdown` HTML attribute in doc contents

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
