### PR TITLE
docs: add migration doc for metadata manager provider APIs

### DIFF
--- a/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
@@ -4,7 +4,7 @@
 
 APIs to manage `<meta>` elements on the page changed to improve development experience. [`NgxMetaMetaService`](ngx-meta.ngxmetametaservice.md) and related APIs are deprecated in favour of [`NgxMetaElementsService`](ngx-meta.ngxmetaelementsservice.md) and related APIs
 
-See [migration](#migration) for more info about running automatic migrations or migrating manually.
+See [migration](#migration) for more info about how to migrate.
 
 ## Summary
 
@@ -59,7 +59,7 @@ Following set of APIs are deprecated[^1]:
 - [`NgxMetaMetaMetaDefinition`](ngx-meta.ngxmetametadefinition.md)
   - [`makeKeyValMetaDefinition`](ngx-meta.makekeyvalmetadefinition.md)
   - [`makeComposedKeyValMetaDefinition`](ngx-meta.makecomposedkeyvalmetadefinition.md)
-    - [`MakeComopsedKeyValMetaDefinitionOptions`](ngx-meta.makecomposedkeyvalmetadefinitionoptions.md)
+    - [`MakeComposedKeyValMetaDefinitionOptions`](ngx-meta.makecomposedkeyvalmetadefinitionoptions.md)
 - [`NgxMetaMetaContent`](ngx-meta.ngxmetametacontent.md)
 
 And the following set of APIs are introduced:

--- a/projects/ngx-meta/docs/content/migrations/02-manager-provider-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/02-manager-provider-apis.md
@@ -1,0 +1,152 @@
+# Manager provider APIs
+
+## TL;DR
+
+APIs to help creating metadata managers ([`NgxMetaMetadataManager`](ngx-meta.ngxmetametadatamanager.md)) changed to improve development experience. The horribly long-named [`makeMetadataManagerProviderFromSetterFactory`](ngx-meta.makemetadatamanagerproviderfromsetterfactory.md) and related APIs are deprecated in favour of [`provideNgxMetaManager`](ngx-meta.providengxmetamanager.md) and related APIs.
+
+See [migration](#migration) for more info about how to migrate.
+
+## Summary
+
+| Key                            | Value              |
+| :----------------------------- | :----------------- |
+| Category of change             | 👎 **Deprecation** |
+| Automatic migration schematics | No                 |
+| Introduced in version          | `1.0.0-beta.25`    |
+
+## Description
+
+### Issue
+
+[GitHub PR]: https://github.com/davidlj95/ngx/pull/926
+
+[**🎟️ GitHub PR with details**][GitHub PR]
+
+Metadata values on the page are handled by small pieces of code. Specifically, implementations of the [`NgxMetaMetadataManager`](ngx-meta.ngxmetametadatamanager.md) interface.
+
+In order to create implementations of that interface in a lightweight and handier way, the[`makeMetadataManagerProviderFromSetterFactory`](ngx-meta.makemetadatamanagerproviderfromsetterfactory.md) API was introduced. However, it has several issues:
+
+- **Horribly long name**: the most obvious one. 44 chars to be exact. Very Java-like 😅
+
+- **Options are one letter long**: for instance `d` for `deps`, `jP` for JSON Path, ... The intention was to save some bytes around. But at the expense of the development experience.
+
+- **JSON Path is an option**: the JSON path this metadata manager will handle is something that currently must always be specified. Unless new use cases appear. However, it's part of the options object. Which forces to provide an options object for all current use cases.
+
+- **Naming doesn't use the `provide` prefix convention**. Usually functions creating providers are called `provide` by convention. This one doesn't. Which makes it even more difficult to recall if the name wasn't scarily long enough.
+
+### Solution
+
+Provide a new API that solves existing issues by:
+
+- **Shortening its name**
+
+- **Options with helper functions**. This way they can be short. But given using functions to refer to them, the user can use long names when specifying them. Like Angular's [`provideRouter` API with features provided by calling `withX` prefixed functions](https://angular.dev/api/router/provideRouter?tab=usage-notes).
+
+  - Providing an object with long option names was discarded to reduce uncompressed bundle size. Though maybe with compression those long option names are not an issue anyway. However, by adding functions it's also easier to refactor the internal implementation without any API changes.
+
+- **JSON Path as first argument**: as it's used for all current use cases. Plus using a `string` instead of an array as it's more handy to write. A utility is provided to turn arrays into those `strings` ([`withJsonPath`](ngx-meta.withjsonpath.md))
+
+- **Follow `provide` prefix convention**
+
+### Changes
+
+Following set of APIs are deprecated[^1]:
+
+- [`makeMetadataManagerProviderFromSetterFactory`](ngx-meta.makemetadatamanagerproviderfromsetterfactory.md)
+  - [`MakeMetadataManagerProviderFromSetterFactoryOptions`](ngx-meta.makemetadatamanagerproviderfromsetterfactoryoptions.md)
+
+And the following set of APIs are introduced:
+
+- [`provideNgxMetaManager`](ngx-meta.providengxmetamanager.md)
+  - [`withManagerJsonPath`](ngx-meta.withmanagerjsonpath.md)
+  - [`withManagerDeps`](ngx-meta.withmanagerdeps.md)
+  - [`withManagerGlobal`](ngx-meta.withmanagerglobal.md)
+  - [`withManagerObjectMerging`](ngx-meta.withmanagerobjectmerging.md)
+- [`withOptions`](ngx-meta.withoptions.md)
+
+See [GitHub PR] were they were introduced more details. Keep reading for how to migrate from old ones to newer ones.
+
+## Migration
+
+### Automatic
+
+No automatic migration via schematics are available for this change. Manual migration is required
+
+### Manual
+
+Here you have an examples of how the same provider can be created using old and new APIs.
+
+For instance let's create a minimal one to manage the Open Graph image metadata. Or in an example, to manage the metadata values of the following JSON:
+
+```json
+{
+  "image": {
+    "url": "https://example.com/image.jpg"
+  },
+  "openGraph": {
+    "image": {
+      "width": 300
+    }
+  }
+}
+```
+
+It will therefore manage the `image` global and the value inside the `openGraph.image` JSON Path if no global is found.
+
+Object merging will be enabled so that global and specific objects are merged.
+
+<!-- prettier-ignore-start -->
+
+<div class="grid" markdown>
+
+```typescript title="Before"
+type MaybeImageObject = { url: string, width?: string } | undefined
+const provider = makeMetadataManagerProviderFromSetterFactory<MaybeImageObject>(
+  (metaElementsService: NgxMetaElementsService) => (value) => {
+    metaElementsService.set(
+      withNameAttribute('og:image'),
+      withContentAttribute(value?.url)
+    )
+    metaElementsService.set(
+      withNameAttribute('og:image:width'),
+      withContentAttribute(value?.width)
+    )
+  },
+  {
+    jP: ['openGraph', 'image'],
+    d: [NgxMetaElementsService],
+    g: 'image',
+    m: true, 
+  }
+)
+```
+
+```typescript title="After"
+type MaybeImageObject = { url: string, width?: string } | undefined
+const provider = provideNgxMetaManager<MaybeImageObject>(
+  'openGraph.image', // or `withManagerJsonPath(['openGraph', 'image`])
+  (metaElementsService: NgxMetaElementsService) => (value) => {
+    metaElementsService.set(
+      withNameAttribute('og:image'),
+      withContentAttribute(value?.url)
+    )
+    metaElementsService.set(
+      withNameAttribute('og:image:width'),
+      withContentAttribute(value?.width)
+    )
+  },
+  withOptions(
+    withManagerDeps(NgxMetaElementsService),
+    withManagerGlobal('image'),
+    withManagerObjectMerging(),
+  )
+)
+```
+
+</div>
+
+For a detailed explanation of new APIs, visit the [custom metadata guide](manage-your-custom-metadata.md)
+
+<!-- prettier-ignore-end -->
+
+[^1]: For more details, check the [GitHub PR](https://github.com/davidlj95/ngx/pull/956) introducing the deprecations

--- a/projects/ngx-meta/docs/content/migrations/03-const-to-function-manager-providers.md
+++ b/projects/ngx-meta/docs/content/migrations/03-const-to-function-manager-providers.md
@@ -33,7 +33,7 @@ Until `1.0.0-beta.35`, individual metadata manager providers were `const`s that 
 However, the way these tokens are created means they aren't tree-shakeable (see [GitHub issue] for more details about why).
 Therefore, defeating its purpose of reducing the bundle size by just using the ones you need. All providers from a [built-in metadata module] would be included in the bundle size even if just one is used.
 
-### Options
+### Solution
 
 If using [pure annotations](https://terser.org/docs/miscellaneous/#annotations) , `const`-based providers can be tree-shaken. But it's easy to forget to add them hence resulting in non-tree shakeable providers. Some tests could be added to enforce that, but it's more infra to maintain.
 

--- a/projects/ngx-meta/docs/mkdocs.yml
+++ b/projects/ngx-meta/docs/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - changelog.md
   - Migrations:
       - migrations/01-meta-element-apis.md
+      - migrations/02-manager-provider-apis.md
       - migrations/03-const-to-function-manager-providers.md
   - Misc:
       - misc/example-apps.md

--- a/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
+++ b/projects/ngx-meta/src/core/src/managers/provider/v1/make-metadata-manager-provider-from-setter-factory.ts
@@ -14,7 +14,7 @@ import { MetadataSetterFactory } from '../metadata-setter-factory'
  * See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | manage custom metadata guide} for an example.
  *
  * @deprecated Use {@link provideNgxMetaManager} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more information.
+ *             See {@link https://ngx-meta.dev/migrations/02-manager-provider-apis/ } for more information.
  *
  * @remarks
  *
@@ -54,7 +54,7 @@ export const makeMetadataManagerProviderFromSetterFactory = <T>(
  * Options argument object for {@link makeMetadataManagerProviderFromSetterFactory}.
  *
  * @deprecated Use {@link provideNgxMetaManager} APIs instead.
- *             See {@link https://ngx-meta.dev/guides/manage-your-custom-metadata/ | custom metadata guide} for more information.
+ *             See {@link https://ngx-meta.dev/migrations/02-manager-provider-apis/ } for more information.
  *
  * @public
  */


### PR DESCRIPTION
# Issue or need

Continues the spirit of #1013 . Here's the case for metadata manager provider APIs.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Adds a docs page for migration related to metadata manager providers.

Update deprecation notice to point to the published page.

Update other migration guides for consistency

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
