### PR TITLE
docs: update docs to point to migration docs

### DIFF
--- a/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
+++ b/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md
@@ -107,16 +107,9 @@ You can also check a full example at [example standalone app]'s [`provideCustomM
 
 --8<-- "includes/ngx-meta-elements-service.md"
 
-??? tip "Where is the awfully long `makeMetadataManagerProviderFromSetterFactory` function?"
+??? question "Where is the awfully long `makeMetadataManagerProviderFromSetterFactory` function?"
 
-    Well [it's still there](ngx-meta.makemetadatamanagerproviderfromsetterfactory.md).
-    But the one appearing above has been introduced as it's shorter and more developer friendly.
-    If you need, you can still check [this guide when it was using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
-    Or the [example app file using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts)
-
-    However, beware that those APIs are now deprecated and will be removed in the future. It's recommended to upgrade to the new one described in the guide as soon as you can.
-
-    Also, built-in modules are using the new one. And if you use this, then two functions will end up in your bundle that do the same. So some extra unneeded bytes in there.
+    It has been deprecated. Yes, long name is one of the reasons. See the [migration guide](02-manager-provider-apis.md) for more information about how to migrate and more reasons for its deprecation.
 
 ### Using a class
 

--- a/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/01-meta-element-apis.md
@@ -196,4 +196,17 @@ metaService.set(
 
 <!-- prettier-ignore-end -->
 
+For a detailed explanation of new APIs, visit its [API reference](ngx-meta.ngxmetaelementsservice.set.md)
+
+## Notices
+
+It's recommended to upgrade to new APIs to reduce bundle size. As internally, new APIs are used. So if you consume the deprecated APIs in your project, you're adding two API sets to the bundle that achieve the same purpose.
+
+## Deprecated references
+
+If you still need to see information about deprecated APIs, check out:
+
+- [Custom metadata guide using deprecated APIs](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
+- [Example app file using deprecated APIs](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts)
+
 [^1]: For more details, check out the [deprecation PR](https://github.com/davidlj95/ngx/pull/955)

--- a/projects/ngx-meta/docs/content/migrations/02-manager-provider-apis.md
+++ b/projects/ngx-meta/docs/content/migrations/02-manager-provider-apis.md
@@ -147,6 +147,17 @@ const provider = provideNgxMetaManager<MaybeImageObject>(
 
 For a detailed explanation of new APIs, visit the [custom metadata guide](manage-your-custom-metadata.md)
 
+## Notices
+
+It's recommended to upgrade to new APIs to reduce bundle size. As internally, new APIs are used. So if you consume the deprecated APIs in your project, you're adding two API sets to the bundle that achieve the same purpose.
+
+## Deprecated references
+
+If you still to see information about deprecated APIs, check out:
+
+- [Custom metadata managers guide using deprecated APIs](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
+- [Example app file using deprecated APIs](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.20/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts)
+
 <!-- prettier-ignore-end -->
 
 [^1]: For more details, check the [GitHub PR](https://github.com/davidlj95/ngx/pull/956) introducing the deprecations

--- a/projects/ngx-meta/docs/content/migrations/03-const-to-function-manager-providers.md
+++ b/projects/ngx-meta/docs/content/migrations/03-const-to-function-manager-providers.md
@@ -91,4 +91,14 @@ You can find a full list [in the schematics testing support file](https://github
 
 Finally, the [custom metadata providers selection guide](custom-metadata-providers-selection.md) has been updated with new usages. But you can check [an older version](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.31/projects/ngx-meta/docs/content/guides/custom-metadata-providers-selection.md) if you need to.
 
+## Notices
+
+It's recommended to upgrade to new APIs to reduce bundle size. As internally, new APIs are used. So if you consume the deprecated APIs in your project, you're adding two API sets to the bundle that achieve the same purpose.
+
+## Deprecated references
+
+If you still need to see information about deprecated APIs, check out:
+
+- [Custom metadata providers selection guide using deprecated APIs](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.34/projects/ngx-meta/docs/content/guides/custom-metadata-providers-selection.md)
+
 [^1]: See the [PR introducing changes](https://github.com/davidlj95/ngx/pull/1004) for details about the extra bundle size increase.

--- a/projects/ngx-meta/docs/includes/ngx-meta-elements-service.md
+++ b/projects/ngx-meta/docs/includes/ngx-meta-elements-service.md
@@ -4,10 +4,6 @@ Notice the use of [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservic
 
     That's a convention of the library to work as expected. If you don't provide a value in your metadata values JSON, it is expected that the metadata element will disappear from the page. But as a metadata manager, you actually need to remove it! That's why [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/) is used, to facilitate this process.
 
-??? tip "Were you looking for `NgxMetaMetaService`?"
+??? question "Were you looking for `NgxMetaMetaService`?"
 
-    Before [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/) was introduced, the service managing those was [`NgxMetaMetaService`](/api/ngx-meta.ngxmetametaservice/). However, API design for it and its related util functions was a bit limited. It also didn't allow to manage multiple `#!html <meta>` elements. So they were replaced. And right now they are deprecated, so new ones should be used instead. See [the PR were newer APIs were introduced](https://github.com/davidlj95/ngx/pull/883) for more information.
-
-    You can still checkout the [example app file using it](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/example-apps/templates/standalone/src/app/meta-late-loaded/provide-custom-metadata-manager.ts) and the [custom metadata guide using that service instead](https://github.com/davidlj95/ngx/blob/ngx-meta-v1.0.0-beta.16/projects/ngx-meta/docs/content/guides/manage-your-custom-metadata.md)
-
-    Also, beware that built-in metadata modules use [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/). So if using built-in metadata modules and [`NgxMetaMetaService`](/api/ngx-meta.ngxmetametaservice/) for your custom metadata managers, you'll be adding both meta element managers (the new and the old one) to your bundle. Therefore there'll be some unneeded extra bytes in your bundle size. As there are two pieces of code doing the same thing. Whereas if using [`NgxMetaElementsService`](/api/ngx-meta.ngxmetaelementsservice/), just this one will be included.
+    It has been deprecated. See the [migration guide](/migrations/01-meta-element-apis/) for more information on how to migrate and why it has been deprecated.

--- a/projects/ngx-meta/src/README.md
+++ b/projects/ngx-meta/src/README.md
@@ -75,3 +75,5 @@ Go deeper by:
 - [**Fine-grained choosing metadata elements**](https://ngx-meta.dev/guides/custom-metadata-providers-selection/) you're interested in. Rest of them won't end up in your bundle
 
 Are you by any chance looking for the [**API reference**](https://ngx-meta.dev/api/ngx-meta/)?
+
+If you see some deprecations and want to fix them, take a look at the **migrations** section in the [docs site](https://ngx-meta.dev)


### PR DESCRIPTION
# Issue or need

Custom metadata manager guide contains a bit of explanation about the first two deprecations. However, there are now entire pages dedicated to them.
Providers selection guide can also be referred in the migration guide about `function`-based providers. To checkout deprecated documentation.

Also, migration docs aren't in `README.md` introduction points

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Reference doc pages about migrations. Move information in those comments (outdated references to deprecated APIs and comment about bundle size) to the migration page.

Change admonition types to question. As that's what titles for those are right now.

Add references to providers selection guide to the `function`-based providers migration.

Add migration docs to README.md introduction points

Adds link to API reference to first migration (every guide contains a link at the end to the new docs)


<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
