### PR TITLE
chore: allow cypress postinstall script

### DIFF
--- a/projects/ngx-meta/e2e/package.json
+++ b/projects/ngx-meta/e2e/package.json
@@ -17,5 +17,10 @@
     "tslib": "2.7.0",
     "typescript": "5.5.3"
   },
-  "packageManager": "pnpm@10.4.1"
+  "packageManager": "pnpm@10.4.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "cypress"
+    ]
+  }
 }


### PR DESCRIPTION
# Issue or need

Recently, CI/CD jobs related to E2E testing with Cypress started to fail. See https://github.com/davidlj95/ngx/actions/runs/13480235256/job/37664531817?pr=1113 for instance. 

The reason is that `cypress` binary is missing. 

It is very probably due to the major changes introduced when updating to [`pnpm` v10](https://github.com/pnpm/pnpm/releases/tag/v10.0.0). Specifically, that now `pnpm` doesn't run `postinstall` scripts of installed deps. Unless they are approved.

See [the related Cypress issue about it](https://github.com/cypress-io/cypress-documentation/issues/6069)

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes
Allow the `postinstall` script to install Cypress (via `pnpm approve-builds` cmd) and keep E2E tests working.

Not downgrading `pnpm` as the fix is quite straight forward and nothing else is failing.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
