### PR TITLE
test: ensure multiple JSON-LD objects can be set

### DIFF
--- a/projects/ngx-meta/e2e/cypress/fixtures/all-metadata.json
+++ b/projects/ngx-meta/e2e/cypress/fixtures/all-metadata.json
@@ -43,16 +43,24 @@
       "username": "example"
     }
   },
-  "jsonLd": {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "author": {
-      "@type": "Person",
-      "name": "Mr. Foo Bar",
+  "jsonLd": [
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "author": {
+        "@type": "Person",
+        "name": "Mr. Foo Bar",
+        "url": "https://example.com/foo"
+      },
+      "name": "Foo bar",
+      "headline": "Foo bar at your service",
       "url": "https://example.com/foo"
     },
-    "name": "Foo bar",
-    "headline": "Foo bar at your service",
-    "url": "https://example.com/foo"
-  }
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Banana Bread Recipe",
+      "description": "The best banana bread recipe you'll ever find! Learn how to use up all those extra bananas."
+    }
+  ]
 }


### PR DESCRIPTION
# Issue or need

In #1116, @peteregerhazi asked if multiple JSON-LD objects could be set in the page. As far as I recalled, it wasn't possible. However, when creating the E2E test to implement the change to support it, seems that it is actually supported.

The behaviour when using multiple JSON-LDs in an array is that a `<script>` element with JSON-LD type is created, and the array of objects is specified in it. This seems to be [what Google recommends to specify multiple structured data items](https://developers.google.com/search/docs/appearance/structured-data/sd-policies#individual-items). So seems it's good enough.

If due to some use case, multiple `<script>` elements are needed, another solution would be needed though.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add an E2E test to ensure multiple JSON-LD objects can be set

If this is enough, will document it as this wasn't documented.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
