### PR TITLE
fix: update JSON-LD type to allow arrays explicitly

### DIFF
--- a/projects/ngx-meta/api-extractor/ngx-meta.api.md
+++ b/projects/ngx-meta/api-extractor/ngx-meta.api.md
@@ -113,7 +113,7 @@ export const JSON_LD_METADATA_PROVIDER: Provider;
 
 // @public
 export interface JsonLdMetadata {
-    readonly jsonLd?: object | null;
+    readonly jsonLd?: object | readonly object[] | null;
 }
 
 // @internal

--- a/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
+++ b/projects/ngx-meta/docs/content/built-in-modules/json-ld.md
@@ -6,7 +6,7 @@ Structured data refers to a way of organizing and presenting data on the web to 
 
 JSON-LD is used in the context of structured data on the web by allowing website owners and developers to embed structured data directly into their HTML documents. This structured data is often in the form of [schema.org](https://schema.org) vocabulary, which provides a set of schemas (types, properties, and relationships) to describe various entities on the web, such as articles, events, products, and more.
 
-The module allows you to embed a JSON-LD object inside a `#!html <script>` tag (with proper JSON-LD types set) under the `#!html <head>` of the page. It does no validation or whatsoever about the JSON-LD object set.
+The module allows you to embed one or more JSON-LD objects inside a `#!html <script>` tag (with proper JSON-LD type set) under the `#!html <head>` of the page. It does no validation or whatsoever about the JSON-LD object(s) set.
 
 ## Setup
 
@@ -76,6 +76,8 @@ const metadata = {
   },
 } satisfies JsonLdMetadata
 ```
+
+An array of objects can be used to insert multiple JSON-LD objects inside the same `<script>` element. Which follows [Google's guidelines to insert multiple individual structured data items in one page](https://developers.google.com/search/docs/appearance/structured-data/sd-policies#individual-items)
 
 [`JsonLdMetadata` API Reference](ngx-meta.jsonldmetadata.md)
 

--- a/projects/ngx-meta/docs/pyproject.toml
+++ b/projects/ngx-meta/docs/pyproject.toml
@@ -5,6 +5,7 @@ description = "@davidlj95/ngx-meta NPM/JS library docs"
 authors = ["David LJ <mail@davidlj95.com>"]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "==3.12.6"

--- a/projects/ngx-meta/src/json-ld/src/types/json-ld-metadata.ts
+++ b/projects/ngx-meta/src/json-ld/src/types/json-ld-metadata.ts
@@ -10,11 +10,15 @@ export interface JsonLdMetadata {
   /**
    * JSON-LD object (as a JSON object) to set in the page
    *
+   * An array of JSON-LD objects can be given too. They will all be added inside the same `<script>` element.
+   * As per {@link https://developers.google.com/search/docs/appearance/structured-data/sd-policies#individual-items
+   * | Google's structured data general guidelines}.
+   *
    * @remarks
    *
    * Provider:
    *
    * {@link provideNgxMetaJsonLd}
    */
-  readonly jsonLd?: object | null
+  readonly jsonLd?: object | readonly object[] | null
 }


### PR DESCRIPTION
# Issue or need

In #1116, the use case of inserting multiple JSON-LD objects was discussed. Seems it was actually possible (see #1123). However, the types aren't explicit enough about it. Neither the documentation mentions it.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Add arrays as an accepted type to set multiple JSON-LD objects.

Update JSON-LD related docs to mention that multiple JSON-LD objects can be set.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
