### PR TITLE
ci: reduce number of times load-config job runs

### DIFF
--- a/.github/actions/config/action.yml
+++ b/.github/actions/config/action.yml
@@ -1,15 +1,15 @@
 name: Configuration
 description: Loads GitHub Actions CI/CD pipelines (workflows) configuration
 outputs:
-  example-apps-version-aliases:
+  ng-cli-version-aliases:
     description: Angular CLI version aliases (from `angular-cli-versions.json` file) to generate example apps for
-    value: ${{ steps.example-apps-version-aliases.outputs.result }}
+    value: ${{ steps.ng-cli-version-aliases.outputs.result }}
 runs:
   using: composite
   steps:
     - name: Load available example apps Angular CLI version aliases
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
-      id: example-apps-version-aliases
+      id: ng-cli-version-aliases
       with:
         script: |
           const angularCliVersions = require('./projects/ngx-meta/example-apps/angular-cli-versions.json')

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,6 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  load-config:
+    name: Load CI/CD configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      cli-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Load CI/CD configuration
+        id: load-config
+        uses: ./.github/actions/config
   build:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
@@ -25,13 +37,17 @@ jobs:
     name: API Extractor
     uses: ./.github/workflows/reusable-api-extractor.yml
   example-apps:
-    needs: build
+    needs: [build, load-config]
     name: Example apps
     uses: ./.github/workflows/reusable-example-apps.yml
+    with:
+      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
   e2e:
-    needs: example-apps
+    needs: [example-apps, load-config]
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
+    with:
+      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
   coverage:
     needs: [e2e, test]
     name: Coverage
@@ -39,9 +55,11 @@ jobs:
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:
-    needs: example-apps
+    needs: [example-apps, load-config]
     name: Bundle size
     uses: ./.github/workflows/reusable-bundle-size.yml
+    with:
+      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
     permissions:
       checks: write
   docs:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,17 +8,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  load-config:
-    name: Load CI/CD configuration
+  config:
+    name: CI/CD configuration
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      cli-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
+      ng-cli-version-aliases: ${{ steps.config.outputs.ng-cli-version-aliases }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Load CI/CD configuration
-        id: load-config
+      - name: CI/CD configuration
+        id: config
         uses: ./.github/actions/config
   build:
     name: Build
@@ -37,17 +37,17 @@ jobs:
     name: API Extractor
     uses: ./.github/workflows/reusable-api-extractor.yml
   example-apps:
-    needs: [build, load-config]
+    needs: [build, config]
     name: Example apps
     uses: ./.github/workflows/reusable-example-apps.yml
     with:
-      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
+      ng-cli-version-aliases: ${{ needs.config.outputs.ng-cli-version-aliases }}
   e2e:
-    needs: [example-apps, load-config]
+    needs: [example-apps, config]
     name: E2E
     uses: ./.github/workflows/reusable-e2e.yml
     with:
-      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
+      ng-cli-version-aliases: ${{ needs.config.outputs.ng-cli-version-aliases }}
   coverage:
     needs: [e2e, test]
     name: Coverage
@@ -55,11 +55,11 @@ jobs:
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
   bundle-size:
-    needs: [example-apps, load-config]
+    needs: [example-apps, config]
     name: Bundle size
     uses: ./.github/workflows/reusable-bundle-size.yml
     with:
-      cli-version-aliases: ${{ needs.load-config.outputs.cli-version-aliases }}
+      ng-cli-version-aliases: ${{ needs.config.outputs.ng-cli-version-aliases }}
     permissions:
       checks: write
   docs:

--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -21,35 +21,35 @@ env:
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-
 
 jobs:
-  load-config:
+  config:
     name: Load CI/CD configuration
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      example-apps-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
+      ng-cli-version-aliases: ${{ steps.config.outputs.ng-cli-version-aliases }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Load CI/CD configuration
-        id: load-config
+        id: config
         uses: ./.github/actions/config
 
   bundle-size-pr-comment:
-    name: Bundle size - PR comment - Angular ${{ matrix.cli-version-alias }}
-    needs: load-config
+    name: Bundle size - PR comment - Angular ${{ matrix.ng-cli-version-alias }}
+    needs: config
     if: github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(needs.load-config.outputs.example-apps-version-aliases) }}
+        ng-cli-version-alias: ${{ fromJSON(needs.config.outputs.ng-cli-version-aliases) }}
     steps:
       - name: Download bundle size analysis results
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
-          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}
-          #👇 Need to specify it, otherwise, `run-id` argument won't be taken into account
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}
+          #👇 Need to specify it. Otherwise, the ` run-id ` argument won't be taken into account
           # https://github.com/actions/download-artifact/tree/v4.1.4#:~:text=current%20workflow%20run.-,github%2Dtoken%3A,-%23%20The%20repository
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -84,7 +84,7 @@ jobs:
         with:
           issue-number: ${{ steps.pr.outputs.result }}
           comment-author: github-actions[bot]
-          body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.cli-version-alias }}
+          body-includes: ${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.ng-cli-version-alias }}
       - name: Update bundle size PR comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         if: steps.pr.outputs.result != ''

--- a/.github/workflows/pull-request-completed.yml
+++ b/.github/workflows/pull-request-completed.yml
@@ -5,7 +5,7 @@ name: Pull request completed
 
 on:
   workflow_run:
-    #👇 Keep in sync with pull request workflow
+    #👇 Keep in sync with the pull request workflow
     workflows: [Pull request]
     types:
       - completed
@@ -15,9 +15,9 @@ permissions:
   pull-requests: write
 
 env:
-  #👇 Keep in sync with bundle size workflow
+  #👇 Keep in sync with the bundle size workflow
   BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX: -bundle-size
-  #👇 Keep in sync with bundle size workflow
+  #👇 Keep in sync with the bundle size workflow
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-
 
 jobs:

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -2,7 +2,7 @@ name: Bundle size
 on:
   workflow_call:
     inputs:
-      cli-version-aliases:
+      ng-cli-version-aliases:
         type: string
         required: true
 
@@ -22,15 +22,15 @@ env:
 
 jobs:
   analysis:
-    name: Analysis - Angular ${{ matrix.cli-version-alias }}
+    name: Analysis - Angular ${{ matrix.ng-cli-version-alias }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
+        ng-cli-version-alias: ${{ fromJSON(inputs.ng-cli-version-aliases) }}
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}
-      OUTPUT_DIR: out/${{ matrix.cli-version-alias }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.ng-cli-version-alias }}
+      OUTPUT_DIR: out/${{ matrix.ng-cli-version-alias }}
     defaults:
       run:
         working-directory: ${{ env.BUNDLE_SIZE_DIR }}
@@ -40,7 +40,7 @@ jobs:
       - name: Download example app distribution files
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
-          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}
+          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}
           path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -53,7 +53,7 @@ jobs:
       - name: Install bundle size analysis dependencies
         run: pnpm install --frozen-lockfile
       - name: Analyze main bundle size
-        run: pnpm run analyze ${{ matrix.cli-version-alias }} --json
+        run: pnpm run analyze ${{ matrix.ng-cli-version-alias }} --json
       - name: Fetch bundle size analysis results from 'main' branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         if: github.event_name == 'pull_request'
@@ -63,7 +63,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'heads/main',
-              check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.cli-version-alias }}',
+              check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.ng-cli-version-alias }}',
               per_page: 1,
             })
             const checkRuns = checkRunResponse.data.check_runs
@@ -81,34 +81,34 @@ jobs:
       - name: Generate bundle size PR comment
         if: github.event_name == 'pull_request'
         run: >
-          pnpm run report ${{ matrix.cli-version-alias }}
+          pnpm run report ${{ matrix.ng-cli-version-alias }}
           --git-ref '${{ github.event.pull_request.head.sha }}'
-          --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.cli-version-alias }}'
+          --hidden-info '${{ env.BUNDLE_SIZE_COMMENT_ID_PREFIX }}${{ matrix.ng-cli-version-alias }}'
           --base-file '${{ env.OUTPUT_DIR }}/source-map-explorer-main.json'
           --output-file '${{ env.OUTPUT_DIR }}/bundle-size-pr-comment.md'
       - name: Generate bundle size report
-        run: pnpm run report ${{ matrix.cli-version-alias }} --git-ref '${{ github.sha }}'
+        run: pnpm run report ${{ matrix.ng-cli-version-alias }} --git-ref '${{ github.sha }}'
       - name: Upload bundle size analysis results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}
           path: ${{ env.BUNDLE_SIZE_DIR }}/${{ env.OUTPUT_DIR }}
           retention-days: 5
 
   store:
     needs: analysis
     if: github.event_name == 'push'
-    name: Store - Angular ${{ matrix.cli-version-alias }}
+    name: Store - Angular ${{ matrix.ng-cli-version-alias }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
+        ng-cli-version-alias: ${{ fromJSON(inputs.ng-cli-version-aliases) }}
     steps:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
-          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}
+          name: ngx-meta${{ env.BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}
       - name: Create check run
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -118,7 +118,7 @@ jobs:
             return github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.cli-version-alias }}',
+              name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.ng-cli-version-alias }}',
               head_sha: context.sha,
               // In case you're testing this in a PR, you'll want the head SHA
               // otherwise, `context.sha` refers to the GitHub PR merge branch
@@ -126,9 +126,9 @@ jobs:
               // head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               output: {
-                title: 'Bundle size - Angular ${{ matrix.cli-version-alias }}',
+                title: 'Bundle size - Angular ${{ matrix.ng-cli-version-alias }}',
                 summary: 'Sizes of the library modules when packed inside a ' +
-                         'main bundle of an Angular ${{ matrix.cli-version-alias }} ' +
+                         'main bundle of an Angular ${{ matrix.ng-cli-version-alias }} ' +
                          'app. In bytes. Thanks to `source-map-explorer` :)',
                 text: smeJsonString,
               }

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -1,43 +1,33 @@
 name: Bundle size
 on:
   workflow_call:
+    inputs:
+      cli-version-aliases:
+        type: string
+        required: true
 
 #permissions:
 #  👇 Needed for main bundle size check store only
 #  checks: write
 
 env:
-  # 👇 Keep in sync with pull request completed workflow
+  # 👇 Keep in sync with the pull request completed workflow
   BUNDLE_SIZE_COMMENT_ID_PREFIX: bundle-size-comment-
   BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX: ngx-meta-bundle-size-
   BUNDLE_SIZE_DIR: projects/ngx-meta/bundle-size
-  # 👇 Keep in sync with example apps workflow
+  # 👇 Keep in sync with the example apps workflow
   EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
-  # 👇 Keep in sync with pull request completed and docs workflow
+  # 👇 Keep in sync with the pull request completed and the docs' workflow
   BUNDLE_SIZE_ARTIFACT_NAME_SUFFIX: -bundle-size
 
 jobs:
-  load-config:
-    name: Load CI/CD configuration
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      example-apps-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Load CI/CD configuration
-        id: load-config
-        uses: ./.github/actions/config
-
   analysis:
     name: Analysis - Angular ${{ matrix.cli-version-alias }}
-    needs: load-config
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(needs.load-config.outputs.example-apps-version-aliases) }}
+        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
     env:
       EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}
       OUTPUT_DIR: out/${{ matrix.cli-version-alias }}
@@ -106,14 +96,14 @@ jobs:
           retention-days: 5
 
   store:
-    needs: [load-config, analysis]
+    needs: analysis
     if: github.event_name == 'push'
     name: Store - Angular ${{ matrix.cli-version-alias }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(needs.load-config.outputs.example-apps-version-aliases) }}
+        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
     steps:
       - name: Download main bundle analysis results
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -1,6 +1,10 @@
 name: E2E
 on:
   workflow_call:
+    inputs:
+      cli-version-aliases:
+        type: string
+        required: true
 
 env:
   E2E_DIR: projects/ngx-meta/e2e
@@ -13,27 +17,13 @@ env:
   COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX: -coverage-report
 
 jobs:
-  load-config:
-    name: Load CI/CD configuration
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      example-apps-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Load CI/CD configuration
-        id: load-config
-        uses: ./.github/actions/config
-
   e2e:
     name: E2E tests - Angular ${{ matrix.cli-version-alias }}
-    needs: load-config
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(needs.load-config.outputs.example-apps-version-aliases) }}
+        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
     env:
       EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}
     defaults:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -2,7 +2,7 @@ name: E2E
 on:
   workflow_call:
     inputs:
-      cli-version-aliases:
+      ng-cli-version-aliases:
         type: string
         required: true
 
@@ -18,14 +18,14 @@ env:
 
 jobs:
   e2e:
-    name: E2E tests - Angular ${{ matrix.cli-version-alias }}
+    name: E2E tests - Angular ${{ matrix.ng-cli-version-alias }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
+        ng-cli-version-alias: ${{ fromJSON(inputs.ng-cli-version-aliases) }}
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.ng-cli-version-alias }}
     defaults:
       run:
         working-directory: ${{ env.E2E_DIR }}
@@ -35,7 +35,7 @@ jobs:
       - name: Download example app with coverage instrumentation
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
-          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}
+          name: ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}
           path: ${{ env.EXAMPLE_APP_DIR }}
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -63,7 +63,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@108b8684ae52e735ff7891524cbffbcd4be5b19f # v6.7.16
         env:
-          COVERAGE_JSON_REPORT_NAME: e2e-${{ matrix.cli-version-alias }}.json
+          COVERAGE_JSON_REPORT_NAME: e2e-${{ matrix.ng-cli-version-alias }}.json
         with:
           working-directory: ${{ env.E2E_DIR }}
           browser: chrome
@@ -75,6 +75,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure() || success()
         with:
-          name: ngx-meta-e2e-${{ matrix.cli-version-alias }}${{ env.COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX }}
+          name: ngx-meta-e2e-${{ matrix.ng-cli-version-alias }}${{ env.COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX }}
           path: ${{ env.COVERAGE_DIR }}/*.json
           retention-days: 5

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -2,13 +2,13 @@ name: Example apps
 on:
   workflow_call:
     inputs:
-      cli-version-aliases:
+      ng-cli-version-aliases:
         type: string
         required: true
 
 env:
   EXAMPLE_APPS_DIR: projects/ngx-meta/example-apps
-  # 👇 Keep in sync with build workflow
+  # 👇 Keep in sync with the build workflow
   DIST_ARTIFACT_NAME_SUFFIX: -dist
   # 👇 Keep in sync with build and E2E tests workflow
   COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
@@ -17,15 +17,15 @@ env:
 
 jobs:
   example-app:
-    name: Example app - Angular ${{ matrix.cli-version-alias }} - Coverage ${{ matrix.coverage }}
+    name: Example app - Angular ${{ matrix.ng-cli-version-alias }} - Coverage ${{ matrix.coverage }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
+        ng-cli-version-alias: ${{ fromJSON(inputs.ng-cli-version-aliases) }}
         coverage: [enabled, disabled]
     env:
-      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}
+      EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.ng-cli-version-alias }}
     defaults:
       run:
         working-directory: ${{ env.EXAMPLE_APPS_DIR }}
@@ -40,7 +40,7 @@ jobs:
           fi
           echo "dist_artifact_name=$dist_artifact_name" | tee -a "$GITHUB_ENV"
 
-          example_app_artifact_name="ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.cli-version-alias }}"
+          example_app_artifact_name="ngx-meta${{ env.EXAMPLE_APP_ARTIFACT_NAME_SUFFIX }}-${{ matrix.ng-cli-version-alias }}"
           if [ "${{ matrix.coverage }}" = "enabled" ]; then
             example_app_artifact_name="$example_app_artifact_name${{ env.COVERAGE_ARTIFACT_NAME_SUFFIX }}"
           fi
@@ -61,12 +61,12 @@ jobs:
           node-version-file: .node-version # TODO: may vary depending on Angular version
         # 👇 For caching, see below
         # - PNPM store: https://github.com/pnpm/action-setup/tree/v3.0.0?tab=readme-ov-file#use-cache-to-reduce-installation-time
-        # - Angular CLI version: from versions file
+        # - Angular CLI version: from the versions' file
       - name: Get caching key info
         run: |
           pnpm_store_path="$(pnpm store path --silent)"
           angular_cli_version="$(jq -r \
-            '.devDependencies.${{ matrix.cli-version-alias }}' \
+            '.devDependencies.${{ matrix.ng-cli-version-alias }}' \
             'angular-cli-versions.json' |
             sed 's|npm:@angular/cli@||g'
           )"
@@ -95,15 +95,15 @@ jobs:
             ${{ env.EXAMPLE_APP_DIR }}/pnpm-lock.yaml
           # Key is designed to be invalidated if:
           # - Example apps infra dependencies change
-          # - Angular CLI version is updated
+          # - Angular CLI's version is updated
           # - Week of year (UTC) changes
           # Last one is because we can't know before generating the Angular app
           # which patch version of Angular will be installed.
-          # Angular CLI creates an app with same minor version:
+          # Angular CLI creates an app with the same minor version:
           # https://github.com/angular/angular-cli/blob/17.3.4/packages/schematics/angular/utility/latest-versions.ts#L20-L21
           # So patch is up to dependency resolution step
-          # By invalidating cache each week, if a patch release appears it
-          # will be taken into account in max 1 week time
+          # By invalidating cache each week, if a patch release appears, it
+          # will be taken into account in max 1-week time
           # Patch releases shouldn't break anything anyway
           key: ${{ env.cache-name }}-${{ env.example_apps_lockfile_hash }}-${{ env.angular_cli_version }}-${{ env.week_of_year }}
       - name: Install example apps infra dependencies
@@ -112,7 +112,7 @@ jobs:
         run: pnpm run build
       - name: Create example app
         run: >
-          pnpm run create-example-app ${{ matrix.cli-version-alias }}
+          pnpm run create-example-app ${{ matrix.ng-cli-version-alias }}
           --tmp-dir=${{ runner.temp }}
       - name: Build example app
         run: pnpm run ci:build # includes SSR and source maps
@@ -127,8 +127,8 @@ jobs:
         #    See https://github.com/actions/upload-artifact/issues/418
         #    So we need to perform an installation with hoisted node linker
         #    https://pnpm.io/npmrc#node-linker
-        #    After that, neither of previous commands work :(
-        #    Neither does `pnpm deploy --prod`. So easiest is remove and reinstall
+        #    After that, previous commands do not work :(
+        #    Neither does `pnpm deploy --prod`. So easiest is to remove and reinstall
       - name: Remove development dependencies
         run: |
           rm -rf node_modules/

--- a/.github/workflows/reusable-example-apps.yml
+++ b/.github/workflows/reusable-example-apps.yml
@@ -1,6 +1,10 @@
 name: Example apps
 on:
   workflow_call:
+    inputs:
+      cli-version-aliases:
+        type: string
+        required: true
 
 env:
   EXAMPLE_APPS_DIR: projects/ngx-meta/example-apps
@@ -12,27 +16,13 @@ env:
   EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
 
 jobs:
-  load-config:
-    name: Load CI/CD configuration
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      example-apps-version-aliases: ${{ steps.load-config.outputs.example-apps-version-aliases }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Load CI/CD configuration
-        id: load-config
-        uses: ./.github/actions/config
-
   example-app:
-    needs: load-config
     name: Example app - Angular ${{ matrix.cli-version-alias }} - Coverage ${{ matrix.coverage }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        cli-version-alias: ${{ fromJSON(needs.load-config.outputs.example-apps-version-aliases) }}
+        cli-version-alias: ${{ fromJSON(inputs.cli-version-aliases) }}
         coverage: [enabled, disabled]
     env:
       EXAMPLE_APP_DIR: projects/ngx-meta/example-apps/apps/${{ matrix.cli-version-alias }}


### PR DESCRIPTION
# Issue or need

Closes #1142 

In CI/CD there's a step to load CI/CD configuration. Specifically to load the Angular CLI version aliases to create example apps from those and E2E test against them. They now run in each reusable workflow, so each reusable workflow is independent. However this means running them more than needed and spending resources (compute time) on that.  This can be improved.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Call the load configuration action once in main CI/CD workflow. Then pass it to reusable workflows using arguments.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
