### PR TITLE
ci: fix pull request completed workflow

### DIFF
--- a/.github/workflows/cicd-completed.yml
+++ b/.github/workflows/cicd-completed.yml
@@ -1,12 +1,12 @@
 # Split into another workflow to make it work with PRs from forked repos
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-# Tried using just bundle size reusable workflow file/name, but doesn't work
-name: Pull request completed
+# Tried using just bundle size reusable workflow, but doesn't work yet
+name: CI/CD completed
 
 on:
   workflow_run:
-    #👇 Keep in sync with the pull request workflow
-    workflows: [Pull request]
+    #👇 Keep in sync with the CI/CD workflow
+    workflows: [CI/CD]
     types:
       - completed
 
@@ -23,6 +23,8 @@ env:
 jobs:
   config:
     name: Load CI/CD configuration
+    if: github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
# Issue or need

After #1141, the pull request workflow does not exist anymore. Hence the pull request completed workflow that depends on that workflow completion doesn't run anymore.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Run it after CI/CD main workflow completes. Add an extra `if` to load configuration to avoid even running that step if CI/CD workflow completed is not due to a pull request.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
