### PR TITLE
build: prepare for maintenance branches

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '*[0-9]+.x'
   pull_request:
   workflow_dispatch:
 
@@ -73,7 +74,7 @@ jobs:
       deployments: write
   release:
     name: Release
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push'
     needs: [build, test, lint, style, e2e, coverage]
     uses: ./.github/workflows/reusable-release.yml
     secrets:

--- a/.github/workflows/reusable-bundle-size.yml
+++ b/.github/workflows/reusable-bundle-size.yml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Analyze main bundle size
         run: pnpm run analyze ${{ matrix.ng-cli-version-alias }} --json
-      - name: Fetch bundle size analysis results from 'main' branch
+      - name: Fetch bundle size analysis results from target branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         if: github.event_name == 'pull_request'
         with:
@@ -62,7 +62,7 @@ jobs:
             const checkRunResponse = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'heads/main',
+              ref: '${{ github.base_ref }}',
               check_name: '${{ env.BUNDLE_SIZE_CHECK_RUN_NAME_PREFIX }}${{ matrix.ng-cli-version-alias }}',
               per_page: 1,
             })

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: |
-      github.ref_name == 'main' ||
+      (github.event_name == 'push' && github.ref_name == 'main') ||
       (
         github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'preview docs')

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -9,9 +9,9 @@ on:
 env:
   E2E_DIR: projects/ngx-meta/e2e
   COVERAGE_DIR: coverage/ngx-meta
-  # 👇 Keep in sync with example apps workflow
+  # 👇 Keep in sync with the example apps workflow
   COVERAGE_ARTIFACT_NAME_SUFFIX: -coverage
-  # 👇 Keep in sync with example apps workflow
+  # 👇 Keep in sync with the example apps workflow
   EXAMPLE_APP_ARTIFACT_NAME_SUFFIX: -example-app
   # 👇 Keep in sync with e2e and coverage workflows
   COVERAGE_REPORT_ARTIFACT_NAME_SUFFIX: -coverage-report

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 public-hoist-pattern[]=@eslint/js
+public-hoist-pattern[]=micromatch

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,34 +1,61 @@
 const { execSync } = require('child_process')
+const micromatch = require('micromatch')
 
-const useLocalBranch = Boolean(process.env.LOCAL_SEMANTIC_RELEASE_BRANCH)
+const localBranchAsMain = Boolean(
+  process.env.LOCAL_SEMANTIC_RELEASE_BRANCH_AS_MAIN,
+)
 const getCurrentBranch = () =>
   execSync('git rev-parse --abbrev-ref HEAD', {
     encoding: 'utf-8',
   }).trim()
 const repositoryUrl = process.env.LOCAL_SEMANTIC_RELEASE_REPOSITORY_URL?.trim()
 const isDotRepositoryUrl = repositoryUrl === '.'
+const MAINTENANCE_BRANCH_GLOB = '*[0-9]+.x'
+const getMaintenanceBranchConfig = () => {
+  const baseConfig = {
+    name: MAINTENANCE_BRANCH_GLOB,
+  }
+  const currentBranch = getCurrentBranch()
+  const isMaintenanceBranch = micromatch.isMatch(
+    currentBranch,
+    MAINTENANCE_BRANCH_GLOB,
+  )
+  if (!isMaintenanceBranch) return baseConfig
+  const prefixedMajorVersion = currentBranch.split('.').at(-2)
+  const matches = /[0-9]+$/.exec(prefixedMajorVersion)
+  const majorVersion = matches[0]
+  if (
+    matches.index === 0 &&
+    prefixedMajorVersion.length === majorVersion.length
+  )
+    throw new Error('Non major version maintenance branches are not supported')
+  return {
+    ...baseConfig,
+    range: `${majorVersion}.x`,
+    channel: `v${majorVersion}`,
+  }
+}
 
+// noinspection JSUnusedGlobalSymbols
 /**
  * @type {import('semantic-release').GlobalConfig}
  */
 module.exports = {
   repositoryUrl,
   branches: [
-    //👇 Fake branch so that we can release beta versions in `main`
-    //   until we can release 1.0.0
-    'semantic-release',
+    //👇 Major version maintenance branches
+    getMaintenanceBranchConfig(),
     {
-      name: useLocalBranch ? getCurrentBranch() : 'main',
-      prerelease: 'beta',
+      name: localBranchAsMain ? getCurrentBranch() : 'main',
       // ⚠️ Default channel is `undefined` for first release branch, but branch name for the rest.
-      // Using `false` to indicate default distribution channel
+      // Using `false` to indicate the default distribution channel
       // https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#branches-properties
       channel: false,
     },
   ],
   plugins: [
     '@semantic-release/commit-analyzer',
-    // When running locally with repository URL set to `.`, it fails
+    // When running locally with the repository URL set to `.`, it fails
     // As tries to read parts from `.` which is not a URL:
     // https://github.com/semantic-release/release-notes-generator/blob/v13.0.0/index.js#L37-L39
     !isDotRepositoryUrl
@@ -43,7 +70,7 @@ module.exports = {
         npmPublish: true,
       },
     ],
-    // When using `.` as repository, interest is in publishing
+    // When using `.` as a repository, interest is in publishing
     // Hence there's no need for GitHub release, issue comments...
     !isDotRepositoryUrl
       ? [
@@ -126,17 +153,13 @@ module.exports = {
       subject: '*maintenance*',
       release: 'patch',
     },
-    // Trigger a beta release
-    {
-      body: '*BETA RELEASE*',
-      release: 'patch',
-    },
   ],
   writerOpts: {
     //👇 Add library name in release notes
     // https://github.com/conventional-changelog/conventional-changelog/tree/conventional-changelog-writer-v7.0.1/packages/conventional-changelog-writer#finalizecontext
-    finalizeContext: (context) => {
-      return { ...context, version: `\`ngx-meta\` v${context.version}` }
-    },
+    finalizeContext: (context) => ({
+      ...context,
+      version: `\`ngx-meta\` v${context.version}`,
+    }),
   },
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -25,6 +25,7 @@
         "@angular-eslint/builder",
         // 👇 Unlisted: Manually hoisted by pnpm, but not specified in package.json
         "@eslint/js",
+        "micromatch",
         // 👇 Unused: added by Angular CLI by default
         "@angular/compiler",
         "@angular/platform-browser-dynamic",

--- a/semantic-release-local.sh
+++ b/semantic-release-local.sh
@@ -4,9 +4,10 @@
 
 # Warn if not using local branch just in case
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
-if [ -z "$LOCAL_SEMANTIC_RELEASE_BRANCH" ] && [ "$current_branch" != "main" ]; then
-  echo "💡 Publishing from local branch hasn't been configured. It's probable no release will be done"
-  echo "   export LOCAL_SEMANTIC_RELEASE_BRANCH=true # to use local branch as if it was main one"
+if [ -z "$LOCAL_SEMANTIC_RELEASE_BRANCH_AS_MAIN" ] && [ "$current_branch" != "main" ]; then
+  echo "💡 Publishing from local branch as if it was main one hasn't been configured."
+  echo "   It's probable no release will be done"
+  echo "   export LOCAL_SEMANTIC_RELEASE_BRANCH_AS_MAIN=true # to use local branch as if it was main one"
 fi
 
 # Ensure repository URL set


### PR DESCRIPTION
# Issue or need

Will soon launch the first production major version (see #1144). Before that, let's prepare to maintain multiple major versions. This implies CI/CD and release workflows updates. CI/CD workflow should run on maintenance branches.
On push and on pull requests targeting those. So we can actively work on those. Semantic Release should also run on those branches and release the proper versions.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

CI/CD workflow to run on push to major version maintenance branches. Ensure workflows take into account base ref for a PR can be different from `main`.
Semantic Release to run on maintenance branches. Implies a bit of coding to extract the range from the branch, given it is prefixed.

## Maintained versions
A maintenance branch could be issued per each major version or per each minor one. Initially considered a maintenance branch per minor version. So one for `19.0.x`, another for `19.1.x`,... However, given minor versions shouldn't introduce breaking changes, and to reduce maintenance burden, only major version maintenance branches will be set up for now. 

## Launching older major versions
To launch a new major version in a maintenance branch, steps are a bit quirky due to how Semantic Release ensures everything's ok. For instance, if wanting to launch v18:
 - Choose a commit where greater versions do not exist. i.e. previous commit of `19.0.0` tag
 - Push a temporal tag tagging that commit as the previous major version. i.e.: `git tag ngx-meta-v17.0.0 <commit>; git push origin ngx-meta-v17.0.0`
 - Create a maintenance branch for the major version parting from that commit. i.e.: `git checkout -b ngx-meta-18.x ngx-meta-v17.0.0`
 - Push a new `feat!` commit to it (can be done via PR). 
 - Remove temporal tag. i.e.: `git tag -d ngx-meta-v17.0.0; git push --delete origin ngx-meta-v17.0.0`

## Monorepo issues

One thing to consider in maintenance branches is that it's a monorepo. Right now only `ngx-meta` lives here but everything has been set up to make room for other projects to be here. For instance, version tags are prefixed with `ngx-meta` because of this reason. CHANGELOG is inside `ngx-meta` to contain only changes for this project. So the question here is: should maintenance branches be different by project? Like prefixing them with project name too?

Some repositories do separate version tags and maintenance branches per each project in the monorepo like:
 - [Microsoft's Rush Stack](https://github.com/microsoft/rushstack/)
 
Others don't. Like:
 - [Angular](https://github.com/angular/angular/)
 - [Nx](https://github.com/nrwl/nx/)
 - [Typescript ESLint](https://github.com/typescript-eslint/typescript-eslint/)

Guess strategy depends on whether projects are dependent/related or not. In the case they're dependent or related, like Angular (`core`, `common`, `compiler`, ...), makes sense to release all of them at same time. So at that version, every project in there has been tested to work with related projects in same version. However, in this case we're unsure about next projects in here. Indeed, they'll probably be unrelated given `ngx-meta` doesn't seem will need anything extra. Plus it's published under a scope. So related projects would be with the `@davidlj95` scope, which is weird (don't like it there rn, tbh). Or a different scope, weird too. Could be moved to a new scope, but at this point this is future telling.

I'm suspicious about not having more examples of monorepositories with independent projects living in there. After asking ChatGPT, Expo and Vercel's Turbo were pointed out as examples. However Expo has no branches or tags and Turbo repo has no maintenance branches and tags aren't prefixed. Like if all of projects in there were published at same time (hence not so independent). Also mentioned Google's monorepo, but of course it isn't public. Then it mentions [Babel](https://github.com/babel/babel/releases), Lerna, React Native Elements. In there, version tags and maintenance branches aren't prefixed. They release a new version and projects may be updated or not.

Seems that [aligning with Angular versioning](https://github.com/davidlj95/ngx/issues/993#issuecomment-2816921939) is a good strategy for any new project to host in this monorepository in the future. So maybe having maintenance branches without the project name would be ok. Indeed having tag names without project name would be too. In the case a new project version needs to be published but nothing has been updated for `ngx-meta`, then publishing that version for `ngx-meta` could be avoided, and just the new project version would be published. Hence tags and branches would apply to all projects in the repository. Some decide to still publish the project despite no changes have been made to it. As to say: if you you use all packages in same version, they are guaranteed to work. An example of this is [Typescript ESLint](https://github.com/typescript-eslint/typescript-eslint/blob/v8.30.1/packages/types/CHANGELOG.md). Or Angular, where for instance `@angular/forms` [last version at the moment of writing this is `19.2.7`](https://www.npmjs.com/package/@angular/forms/v/19.2.7). However, [that release doesn't contain any change to that package](https://github.com/angular/angular/releases/tag/19.2.7). It is published anyway so that if you install all related packages in the same version, they're guaranteed to work.

This strategy of one versioning scheme for all packages living here reduces the amount of maintenance branches and versions:
 - 1 versioning scheme for all projects: 1 branch per major Angular version, 0-1 per Angular minor version, 0-1 tag per new package version. Given more than one package could share the same tag when publishing changes.
 - n versioning schemes, 1 for each project: n branch per major Angular version, 0-n per Angular minor version, 1 tag per new package version

So in terms of maintenance, seems this way we'll have less tags and maintenance branches, hence less infra and burden. It doesn't sound 100% correct though, as they'll be unrelated packages. So makes sense that every project follows its own release schedule and versioning. For instance if thinking about shipping a new feature in a project. This would increment minor version. If the change does not apply to a project, we could skip publishing. But then,  if a new feature is added to that project, the jump would be of 2 minor versions. Because last one wasn't published because was unrelated to that package. ie:

```
ngx-meta@19.0.0 | ngx-another@19.0.0
// new feature in ngx-meta
ngx-meta@19.1.0 | ngx-another@19.1.0 (no need to publish, as no changes in there)
// new feature in ngx-another
ngx-meta@19.2.0 (no need to publish, no changes in there) | ngx-another@19.2.0
```

Another thing to take into account is if we want to launch a beta version when shipping a new package. In this case, the package will need it's own format for tags. Like it happened with `ngx-meta` where tags had the format `ngx-meta-v1.0.0-beta.1`. As otherwise no more than one package could be launched in beta. Or some trick should be done like shipping in `v2.0.0`. That is way too quirky. In that case we'd have to configure Semantic Release. For `ngx-meta`, follow the production versioning scheme. For the new package, follow the `beta` versioning scheme. For the case of the `beta` versioning, seems some monorepo plugin could help. Like [`semantic-release-monorepo`](https://github.com/pmowrer/semantic-release-monorepo).

After considering all of this, seems that the most sensible approach is independent releases. Given they'll very probably be independent projects. So prefixing with name each maintenance branch / version tag makes sense. This can be changed at any point anyway. Or if the new project relates to ngx-meta, then it'll make sense to have a joint releasing process. Anyway, we'll see what happens when the new package arrives. For now, separating it to make room for new packages in case it's needed. 

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
