### PR TITLE
ci: restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/cicd-completed.yml
+++ b/.github/workflows/cicd-completed.yml
@@ -11,8 +11,7 @@ on:
       - completed
 
 permissions:
-  # 👇 Needed for PR bundle size comment only
-  pull-requests: write
+  contents: read
 
 env:
   #👇 Keep in sync with the bundle size workflow
@@ -46,6 +45,8 @@ jobs:
     strategy:
       matrix:
         ng-cli-version-alias: ${{ fromJSON(needs.config.outputs.ng-cli-version-aliases) }}
+    permissions:
+      pull-requests: write
     steps:
       - name: Download bundle size analysis results
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   config:
     name: CI/CD configuration


### PR DESCRIPTION
# Issue or need

Many code scanning alerts appeared. Complaining about GITHUB_TOKEN privileges being too wide by default. 

From https://github.com/davidlj95/ngx/security/code-scanning/2 (alert 2) until https://github.com/davidlj95/ngx/security/code-scanning/25 (alert 25)

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Specify GITHUB_TOKEN permissions in main workflows to fix the alerts

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
