### PR TITLE
build: support only actively supported versions

### DIFF
--- a/projects/ngx-meta/docs/content/get-started.md
+++ b/projects/ngx-meta/docs/content/get-started.md
@@ -8,6 +8,10 @@ Glad you're here 🥰 Let's set it up in 3 steps ⚡️
 ng add @davidlj95/ngx-meta
 ```
 
+??? note "If using Angular v15 or v16"
+
+    Run `ng add @davidlj95/ngx-meta@1.0.0-beta.38`. As latest v19 production version is not compatible with v15, v16. But latest beta version is. Soon will launch production versions to support older Angular versions. There are no other differences between last beta version and v19 version, so for now they can be used interchangeably.
+
 The command will install the library and add ask you if you want to set up the routing module to set metadata values in Angular routes' `data`.
 
 Then, to set some metadata to get started, choose at least the [standard module].

--- a/projects/ngx-meta/docs/content/guides/manual-setup.md
+++ b/projects/ngx-meta/docs/content/guides/manual-setup.md
@@ -10,6 +10,10 @@ Using your package manager's install command. For instance, with `npm`:
 npm install @davidlj95/ngx-meta
 ```
 
+??? note "If using Angular v15 or v16"
+
+    Run `npm install @davidlj95/ngx-meta@1.0.0-beta.38`. As latest v19 production version is not compatible with v15, v16. But latest beta version is. Soon will launch production versions to support older Angular versions. There are no other differences between last beta version and v19 version, so for now they can be used interchangeably.
+
 ## 2. Add library's providers
 
 Now, let's add some providers to set the library up.

--- a/projects/ngx-meta/docs/content/why/features.md
+++ b/projects/ngx-meta/docs/content/why/features.md
@@ -17,11 +17,13 @@ Actually, a series of E2E tests are in place to ensure support for SSR and hydra
 
 ### 🤝 Compatibility with [Angular actively supported versions]
 
-Right now being Angular v17, v18 and v19. Update from an Angular version to another when you're ready: this library won't be an issue! Latest version will be compatible with all [Angular actively supported versions]. [There are some E2E tests to ensure that indeed][E2E tests]
+Right now this means the last three major versions. Update from an Angular version to another when you're ready: this library won't be an issue! The latest version will be compatible with [Angular actively supported versions] at that time. [There are some E2E tests to ensure that indeed][E2E tests]
 
 !!! info "Older versions may be supported"
 
     Latest version of the library may support older Angular versions other than the currently [actively supported ones][Angular actively supported versions]. But it's not guaranteed to do so. Checkout the library's [`package.json` `peerDependencies` field for exact versions compatibility claims](https://github.com/davidlj95/ngx/blob/main/projects/ngx-meta/src/package.json). It may even work for older versions than the ones specified in there, but those haven't been tested.
+
+    While production versions for older versions are being launched, you can still use version `ngx-meta@1.0.0-beta.38` that supports v15 until v19
 
 [E2E tests]: https://github.com/davidlj95/ngx/blob/main/.github/workflows/reusable-e2e.yml
 

--- a/projects/ngx-meta/example-apps/angular-cli-versions.json
+++ b/projects/ngx-meta/example-apps/angular-cli-versions.json
@@ -7,10 +7,8 @@
   "//1": "👇 Updated by dependency bot, but restricted to major versions",
   "//2": "   See Renovate configuration for more information",
   "devDependencies": {
-    "v15": "npm:@angular/cli@15.2.11",
-    "v16": "npm:@angular/cli@16.2.15",
-    "v17": "npm:@angular/cli@17.3.9",
-    "v18": "npm:@angular/cli@18.2.3",
-    "v19": "npm:@angular/cli@19.0.0"
+    "v17": "npm:@angular/cli@17.0.10",
+    "v18": "npm:@angular/cli@18.0.7",
+    "v19": "npm:@angular/cli@19.2.9"
   }
 }

--- a/projects/ngx-meta/src/package.json
+++ b/projects/ngx-meta/src/package.json
@@ -37,9 +37,9 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19 || ^18 || ^17 || ^16 || ^15",
-    "@angular/core": "^19 || ^18 || ^17 || ^16 || ^15",
-    "@angular/router": "^19 || ^18 || ^17 || ^16 || ^15"
+    "@angular/common": "^19 || ^18 || ^17",
+    "@angular/core": "^19 || ^18 || ^17",
+    "@angular/router": "^19 || ^18 || ^17"
   },
   "peerDependenciesMeta": {
     "@angular/router": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -69,29 +69,15 @@
       matchFileNames: [
         'projects/ngx-meta/example-apps/angular-cli-versions.json',
       ],
-      matchDepNames: ['v15'],
-      allowedVersions: '^15',
-    },
-    {
-      matchFileNames: [
-        'projects/ngx-meta/example-apps/angular-cli-versions.json',
-      ],
-      matchDepNames: ['v16'],
-      allowedVersions: '^16',
-    },
-    {
-      matchFileNames: [
-        'projects/ngx-meta/example-apps/angular-cli-versions.json',
-      ],
       matchDepNames: ['v17'],
-      allowedVersions: '^17',
+      allowedVersions: '17.0.x',
     },
     {
       matchFileNames: [
         'projects/ngx-meta/example-apps/angular-cli-versions.json',
       ],
       matchDepNames: ['v18'],
-      allowedVersions: '^18',
+      allowedVersions: '18.0.x',
     },
     {
       matchFileNames: [


### PR DESCRIPTION
# Issue or need

The #1144 PR was about to merge and launch the first production ready, but... stopped it at last minute! After watching the E2E tests for the several Angular major versions, remembered that in `package.json`, support for v15 and v16 was claimed. However, the intention is to launch a major version to support each of those. Hence they would be removed. This would be a breaking change.

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Remove versions that won't be supported in v19: v15 and v16. Remove its associated E2E tests. Add a comment in docs about how to support older versions whilst production ones are launched.

Additionally, changing v17 and v18 CLI versions. So that they use `0.x` minor instead of latest minor. Issue with using latest minor is that if some feature is added in, let's say `17.1.x`, and we never test in `17.0.x` we may be using a feature in `1.x` that doesn't exist in `0.x` hence being compatible with `17.1.x` but not `17.0.x`. Using the `0` minor ensure we're compatible with the major version as we use the minor version with less features.

Finally v15 and v16 required checks are removed from GitHub `main` branch rules

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
