### PR TITLE
feat!: publish first production version v19 :rocket:

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -48,7 +48,6 @@ module.exports = {
     getMaintenanceBranchConfig(),
     {
       name: localBranchAsMain ? getCurrentBranch() : 'main',
-      prerelease: 'beta',
       // ⚠️ Default channel is `undefined` for first release branch, but branch name for the rest.
       // Using `false` to indicate the default distribution channel
       // https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#branches-properties


### PR DESCRIPTION
# Issue or need

Stopped the v19 first production version launch given was unsure if Renovate config was prepared for maintenance branches. 
After reading a bit, seems [`baseBranches` option](https://docs.renovatebot.com/configuration-options/#basebranches) can be used to specify more than one branch to run.
Then there's the [`useBaseBranchConfig` option](https://docs.renovatebot.com/configuration-options/#usebasebranchconfig) which allows merging the configuration from default branch with the one in base branch. So that each base branch can override the default configuration present in the default branch.

Anyway, the main thing is that Renovate config should be as clean as possible. As we're going to be launching many branches from this point. So the cleaner it is, fewer changes will be needed in maintenance branches in case changes are needed. Thanks to #1150, Renovate config is cleaner, so ready to launch

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Update Semantic Release config to switch to production releases. Given temporal tag on main `ngx-meta-v18.0.0` and current commit type `feat!`, v19 will be launched.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
