### PR TITLE
ci: always build docs, deploy only if needed

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -25,12 +25,6 @@ jobs:
         working-directory: ${{ env.DOCS_DIR }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: |
-      (github.event_name == 'push' && github.ref_name == 'main') ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'preview docs')
-      )
     permissions:
       deployments: write
     steps:
@@ -85,6 +79,12 @@ jobs:
       - name: Build
         run: make build
       - name: Publish
+        if: |
+          (github.event_name == 'push' && github.ref_name == 'main') ||
+          (
+            github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'preview docs')
+          )
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # 1
         with:
           accountId: ${{ secrets.cloudflare-account-id }}


### PR DESCRIPTION
# Issue or need

In #1174, the update broke the build on `main`. Despite the PR being able to be merged. This is because docs pipeline doesn't run in a PR if doesn't have the `preview docs` label. However, this way we merged a PR that broke `main`

<!-- Describe here WHAT issue or need you're solving -->
<!-- Fixes # -->

# Proposed changes

Always run build docs on CI/CD. But just deploy when needed: has label or is on `main`. This way we avoid merging a PR that breaks the docs pipeline. Adding docs job as required check so that a PR cannot get merged if breaks the CI/CD.

<!-- Describe here HOW you're solving it -->

# Quick reminders

- 🤝 **I will follow [Code of Conduct](https://github.com/davidlj95/ngx/blob/main/CODE_OF_CONDUCT.md)**
- ✅ **No existing pull request** already does almost same changes
- 👁️ **[Contributing docs](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md)** are something I've taken a look at
- 📝 **[Commit messages convention](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#commit-messages)** has been followed
- 💬 **[TSDoc comments](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#tsdoc-comments)** have been added or updated indicating API visibility if API surface has changed.
- 🧪 **[Tests](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#test)** have been added if needed. For instance, if adding new features or fixing a bug. Or removed if removing features.
- ⚙️ **[API Report](https://github.com/davidlj95/ngx/blob/main/CONTRIBUTING.md#api-report)** has been updated if API surface is altered.
